### PR TITLE
bump version to 0.11.0 since we move to a separate repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/bigquery",
   "description": "Google BigQuery Client Library for Node.js",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
@@ -46,7 +46,6 @@
   ],
   "scripts": {
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "publish-module": "node ../../scripts/publish.js bigquery",
     "benchmark": "time node benchmark/bench.js benchmark/queries.json",
     "docs": "repo-tools exec -- jsdoc -c .jsdoc.js",
     "lint": "repo-tools lint --cmd eslint -- src/ samples/ system-test/ test/",

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js system-test/*.test.js && nyc report"
   },
   "dependencies": {
-    "@google-cloud/bigquery": "0.9.6",
+    "@google-cloud/bigquery": "0.11.0",
     "@google-cloud/storage": "1.2.1",
     "yargs": "8.0.2"
   },


### PR DESCRIPTION
Bumping minor version since the package has moved from GoogleCloudPlatform to googleapis/nodejs-bigquery.