### PR TITLE
Fix Job.poll_

### DIFF
--- a/src/job.js
+++ b/src/job.js
@@ -378,7 +378,7 @@ Job.prototype.getQueryResultsStream = common.paginator.streamify(
 Job.prototype.poll_ = function(callback) {
   this.getMetadata(function(err, metadata, apiResponse) {
     if (!err && apiResponse.status && apiResponse.status.errors) {
-      err = common.util.ApiError(apiResponse.status);
+      err = new common.util.ApiError(apiResponse.status);
     }
 
     if (err) {


### PR DESCRIPTION
ApiError was never being instantiated and thus the 'err' variable was always undefined. This caused issues because it would never errback.

This affected Job.on('error', ...) which in turn affected Job.promise, Table.copy, Table.copyFrom, Table.export, and Table.import.

Fixes #14 
