### PR TITLE
System Tests: Correct table notation.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -645,7 +645,7 @@ BigQuery.prototype.createDataset = function(id, options, callback) {
  * const BigQuery = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  *
- * cpmst query = 'SELECT url FROM [publicdata:samples.github_nested] LIMIT 100';
+ * const query = 'SELECT url FROM `publicdata:samples.github_nested` LIMIT 100';
  *
  * bigquery.createQueryStream(query)
  *   .on('error', console.error)
@@ -699,7 +699,7 @@ BigQuery.prototype.createQueryStream = common.paginator.streamify('query');
  * const options = {
  *   configuration: {
  *     query: {
- *       query: 'SELECT url FROM [publicdata:samples.github_nested] LIMIT 100'
+ *       query: 'SELECT url FROM `publicdata:samples.github_nested` LIMIT 100'
  *     }
  *   }
  * };
@@ -1076,7 +1076,7 @@ BigQuery.prototype.job = function(id) {
  * const BigQuery = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  *
- * const query = 'SELECT url FROM [publicdata:samples.github_nested] LIMIT 100';
+ * const query = 'SELECT url FROM `publicdata:samples.github_nested` LIMIT 100';
  *
  * bigquery.query(query, function(err, rows) {
  *   if (!err) {
@@ -1192,7 +1192,7 @@ BigQuery.prototype.query = function(query, options, callback) {
  * const BigQuery = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  *
- * const query = 'SELECT url FROM [publicdata:samples.github_nested] LIMIT 100';
+ * const query = 'SELECT url FROM `publicdata:samples.github_nested` LIMIT 100';
  *
  * //-
  * // You may pass only a query string, having a new table created to store the

--- a/system-test/bigquery.js
+++ b/system-test/bigquery.js
@@ -362,7 +362,7 @@ describe('BigQuery', function() {
   });
 
   it('should cancel a job', function(done) {
-    var query = 'SELECT url FROM [publicdata:samples.github_nested] LIMIT 10';
+    var query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 10';
 
     bigquery.startQuery(query, function(err, job) {
       assert.ifError(err);


### PR DESCRIPTION
This issue popped up today:

```
ApiError: Syntax error: Unexpected "[" at [1:17]. If this is a table identifier, escape the name with `, e.g. `table.name` rather than [table.name].
```
\- https://circleci.com/gh/googleapis/nodejs-bigquery/183

I went through and corrected the locations where we were using the `[table]` pattern.
