### PR TITLE
Update table.js

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -279,7 +279,7 @@ util.inherits(Table, common.ServiceObject);
   return str.split(/\s*,\s*/).reduce(
     function(acc, pair) {
       acc.fields.push({
-        name: pair.split(':')[0],
+        name: pair.split(':')[0].trim(),
         type: (pair.split(':')[1] || 'STRING').toUpperCase().trim(),
       });
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -280,7 +280,7 @@ util.inherits(Table, common.ServiceObject);
     function(acc, pair) {
       acc.fields.push({
         name: pair.split(':')[0],
-        type: (pair.split(':')[1] || 'STRING').toUpperCase(),
+        type: (pair.split(':')[1] || 'STRING').toUpperCase().trim(),
       });
 
       return acc;

--- a/test/table.ts
+++ b/test/table.ts
@@ -266,6 +266,16 @@ describe('BigQuery/Table', function() {
         SCHEMA_OBJECT
       );
     });
+
+    it('should trim names', function() {
+      var schema = Table.createSchemaFromString_(' name :type');
+      assert.strictEqual(schema.fields[0].name, 'name');
+    });
+
+    it('should trim types', function() {
+      var schema = Table.createSchemaFromString_('name: type ');
+      assert.strictEqual(schema.fields[0].type, 'TYPE');
+    });
   });
 
   describe('encodeValue_', function() {


### PR DESCRIPTION
Fixes #77

[trim function corrected the error.](https://github.com/googleapis/nodejs-bigquery/blob/master/src/table.js#L306) api gives an error when there is a space.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
