### PR TITLE
wait for job result before emitting complete.

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1231,7 +1231,10 @@ Table.prototype.createWriteStream = function(metadata) {
         });
 
         job.metadata = data;
-        dup.emit('complete', job);
+
+        job
+          .on('error', err => dup.destroy(err))
+          .on('complete', () => dup.emit('complete', job));
       }
     );
   });

--- a/src/table.ts
+++ b/src/table.ts
@@ -1142,9 +1142,12 @@ Table.prototype.createReadStream = paginator.streamify('getRows');
  *
  * request.get(csvUrl)
  *   .pipe(table.createWriteStream(metadata))
- *   .on('complete', function(job) {
+ *   .on('job', function(job) {
  *     // `job` is a Job object that can be used to check the status of the
  *     // request.
+ *   })
+ *   .on('complete', function(job) {
+ *     // The job has completed successfully.
  *   });
  *
  * //-
@@ -1154,7 +1157,13 @@ Table.prototype.createReadStream = paginator.streamify('getRows');
  *
  * fs.createReadStream('./test/testdata/testfile.json')
  *   .pipe(table.createWriteStream('json'))
- *   .on('complete', function(job) {});
+ *   .on('job', function(job) {
+ *     // `job` is a Job object that can be used to check the status of the
+ *     // request.
+ *   })
+ *   .on('complete', function(job) {
+ *     // The job has completed successfully.
+ *   });
  */
 Table.prototype.createWriteStream = function(metadata) {
   const self = this;
@@ -1231,6 +1240,8 @@ Table.prototype.createWriteStream = function(metadata) {
         });
 
         job.metadata = data;
+
+        dup.emit('job', job);
 
         job
           .on('error', err => dup.destroy(err))

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -740,10 +740,16 @@ describe('BigQuery', function() {
     });
 
     it('should insert rows via stream', function(done) {
+      let job;
+
       fs.createReadStream(TEST_DATA_JSON_PATH)
         .pipe(table.createWriteStream('json'))
         .on('error', done)
-        .on('complete', function() {
+        .on('complete', function(_job) {
+          job = _job;
+        })
+        .on('finish', function() {
+          assert.strictEqual(job.metadata.status.state, 'DONE');
           done();
         });
     });

--- a/test/table.ts
+++ b/test/table.ts
@@ -1387,10 +1387,16 @@ describe('BigQuery/Table', function() {
     });
 
     describe('writable stream', function() {
+      let fakeJob;
       let fakeJobId;
 
       beforeEach(function() {
+        fakeJob = new events.EventEmitter();
         fakeJobId = uuid.v4();
+
+        table.bigQuery.job = function(id, options) {
+          return fakeJob;
+        };
 
         fakeUuid.v4 = function() {
           return fakeJobId;
@@ -1407,15 +1413,6 @@ describe('BigQuery/Table', function() {
 
         stream = table.createWriteStream();
         stream.emit('writing');
-      });
-
-      it('should pass the connection', function(done) {
-        makeWritableStreamOverride = function(stream, options) {
-          assert.deepStrictEqual(options.connection, table.connection);
-          done();
-        };
-
-        table.createWriteStream().emit('writing');
       });
 
       it('should pass extended metadata', function(done) {
@@ -1504,17 +1501,22 @@ describe('BigQuery/Table', function() {
         table.createWriteStream(options).emit('writing');
       });
 
-      it('should create a job and emit it with complete', function(done) {
-        const jobId = 'job-id';
+      it('should create a job and emit it with job', function(done) {
         const metadata = {
-          jobReference: {jobId, location: LOCATION},
+          jobReference: {
+            jobId: 'job-id',
+            location: 'location',
+          },
           a: 'b',
           c: 'd',
         };
 
         table.bigQuery.job = function(id, options) {
-          assert.strictEqual(options.location, LOCATION);
-          return {id: id};
+          assert.strictEqual(id, metadata.jobReference.jobId);
+          assert.deepStrictEqual(options, {
+            location: metadata.jobReference.location,
+          });
+          return fakeJob;
         };
 
         makeWritableStreamOverride = function(stream, options, callback) {
@@ -1523,8 +1525,63 @@ describe('BigQuery/Table', function() {
 
         table
           .createWriteStream()
+          .on('job', function(job) {
+            assert.strictEqual(job, fakeJob);
+            assert.deepStrictEqual(job.metadata, metadata);
+            done();
+          })
+          .emit('writing');
+      });
+
+      it('should return an error if the job fails', function(done) {
+        const error = new Error('Error.');
+
+        const metadata = {
+          jobReference: {
+            jobId: 'job-id',
+            location: 'location',
+          },
+          a: 'b',
+          c: 'd',
+        };
+
+        makeWritableStreamOverride = function(stream, options, callback) {
+          callback(metadata);
+          setImmediate(function() {
+            fakeJob.emit('error', error);
+          });
+        };
+
+        table
+          .createWriteStream()
+          .on('error', function(err) {
+            assert.strictEqual(err, error);
+            done();
+          })
+          .emit('writing');
+      });
+
+      it('should emit complete when job is complete', function(done) {
+        const metadata = {
+          jobReference: {
+            jobId: 'job-id',
+            location: 'location',
+          },
+          a: 'b',
+          c: 'd',
+        };
+
+        makeWritableStreamOverride = function(stream, options, callback) {
+          callback(metadata);
+          setImmediate(function() {
+            fakeJob.emit('complete');
+          });
+        };
+
+        table
+          .createWriteStream()
           .on('complete', function(job) {
-            assert.strictEqual(job.id, jobId);
+            assert.strictEqual(job, fakeJob);
             assert.deepStrictEqual(job.metadata, metadata);
             done();
           })


### PR DESCRIPTION
Fixes #8 

**This would be a breaking change**

Currently, if you call `table.createWriteStream()`, the stream will emit "complete" with a Job object. You can then use that Job object to assign event handlers, as usual with an LRO. Judging from #8, I'm not sure this pattern is clear to the users. And aside from that, I'm not sure what we're doing is ideal, either.

Ideally, we would not emit "complete" until the Job finished, instead of making the user do it manually. This PR shows how easy it would be for us to implement. However, I *believe* this would be a breaking change, although it's hard to say if it's actually a bugfix.

I'm leaving this open for discussion on how we should handle this. Please share your thoughts!

---

### Before
```js
table.createWriteStream(...)
  .on('complete', job => {
    job
      .on('error', err => {
        // Job failed.
      })
      .on('complete', () => {
        // Job completed successfully.
      });
  });
```

### After
```js
table.createWriteStream(...)
  .on('error', err => {
    // Job failed.
  })
  .on('job', job => {
    // `job` is a Job object.
  })
  .on('finish', () => {
    // Job completed successfully.
  });
```

And, `complete` still works to combine those. I added the "finish" event, because that's the natural writable stream closing event.

```js
table.createWriteStream(...)
  .on('error', err => {
    // Job failed.
  })
  .on('complete', job => {
    // `job` is a Job object.
    // Job completed successfully.
  });
```