### PR TITLE
fix(query): exit early when dryRun is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1283,6 +1283,11 @@ BigQuery.prototype.query = function(query, options, callback) {
       return;
     }
 
+    if (query.dryRun) {
+      callback(null, [], resp);
+      return;
+    }
+
     job.getQueryResults(options, callback);
   });
 };

--- a/system-test/bigquery.js
+++ b/system-test/bigquery.js
@@ -338,6 +338,21 @@ describe('BigQuery', function() {
     );
   });
 
+  it('should accept the dryRun option', function(done) {
+    bigquery.query(
+      {
+        query,
+        dryRun: true,
+      },
+      function(err, rows, resp) {
+        assert.ifError(err);
+        assert.deepEqual(rows, []);
+        assert(resp.statistics.query);
+        done();
+      }
+    );
+  });
+
   it('should get a list of jobs', function(done) {
     bigquery.getJobs(function(err, jobs) {
       assert.ifError(err);

--- a/test/index.js
+++ b/test/index.js
@@ -1392,9 +1392,28 @@ describe('BigQuery', function() {
         callback(error, null, FAKE_RESPONSE);
       };
 
-      bq.query(QUERY_STRING, function(err, job, resp) {
+      bq.query(QUERY_STRING, function(err, rows, resp) {
         assert.strictEqual(err, error);
-        assert.strictEqual(job, null);
+        assert.strictEqual(rows, null);
+        assert.strictEqual(resp, FAKE_RESPONSE);
+        done();
+      });
+    });
+
+    it('should exit early if dryRun is set', function(done) {
+      var options = {
+        query: QUERY_STRING,
+        dryRun: true,
+      };
+
+      bq.createQueryJob = function(query, callback) {
+        assert.strictEqual(query, options);
+        callback(null, null, FAKE_RESPONSE);
+      };
+
+      bq.query(options, function(err, rows, resp) {
+        assert.ifError(err);
+        assert.deepEqual(rows, []);
         assert.strictEqual(resp, FAKE_RESPONSE);
         done();
       });


### PR DESCRIPTION
Fixes #62

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
