### PR TITLE
chore: prep release for 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/bigquery",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -100,7 +100,7 @@
         "request": "2.85.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
@@ -1757,7 +1757,7 @@
         "request": "2.85.0",
         "safe-buffer": "5.1.1",
         "snakeize": "0.1.0",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       },
@@ -1783,7 +1783,7 @@
             "request": "2.85.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
+            "stream-events": "1.0.3",
             "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           }
@@ -1796,7 +1796,7 @@
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.3.2",
+            "google-auth-library": "1.4.0",
             "request": "2.85.0"
           }
         }
@@ -2115,7 +2115,7 @@
         "clean-stack": "1.3.0",
         "clean-yaml-object": "0.1.0",
         "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
+        "cli-spinners": "1.3.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
         "code-excerpt": "2.1.1",
@@ -3007,9 +3007,9 @@
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.0.tgz",
+      "integrity": "sha512-ahr3q/EW26uLN3vqBaDQS4g1rUwKMbVSTRlyfyoY06VwwSJmMYRxhT3FTAiTz9Yam6OOb1e0ldwvbsnuThvuzA==",
       "dev": true
     },
     "cli-truncate": {
@@ -3322,7 +3322,7 @@
       "requires": {
         "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
@@ -3693,7 +3693,7 @@
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "stream-shift": "1.0.0"
       }
     },
@@ -3941,7 +3941,7 @@
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.4",
-        "esquery": "1.0.0",
+        "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
@@ -4144,9 +4144,9 @@
       }
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
@@ -4222,9 +4222,9 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -4411,7 +4411,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -5368,7 +5368,7 @@
         "google-auto-auth": "0.9.7",
         "pumpify": "1.4.0",
         "request": "2.85.0",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "through2": "2.0.3"
       },
       "dependencies": {
@@ -5380,7 +5380,7 @@
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.3.2",
+            "google-auth-library": "1.4.0",
             "request": "2.85.0"
           }
         }
@@ -5503,13 +5503,13 @@
       }
     },
     "google-auth-library": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.3.2.tgz",
-      "integrity": "sha512-aRz0om4Bs85uyR2Ousk3Gb8Nffx2Sr2RoKts1smg1MhRwrehE1aD1HC4RmprNt1HVJ88IDnQ8biJQ/aXjiIxlQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
+      "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
       "requires": {
         "axios": "0.18.0",
         "gcp-metadata": "0.6.3",
-        "gtoken": "2.2.0",
+        "gtoken": "2.3.0",
         "jws": "3.1.4",
         "lodash.isstring": "4.0.1",
         "lru-cache": "4.1.2",
@@ -5523,7 +5523,7 @@
       "requires": {
         "async": "2.6.0",
         "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.3.2",
+        "google-auth-library": "1.4.0",
         "request": "2.85.0"
       }
     },
@@ -5532,7 +5532,7 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.4",
+        "node-forge": "0.7.5",
         "pify": "3.0.0"
       }
     },
@@ -5591,9 +5591,9 @@
       "dev": true
     },
     "gtoken": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.2.0.tgz",
-      "integrity": "sha512-tvQs8B1z5+I1FzMPZnq/OCuxTWFOkvy7cUJcpNdBOK2L7yEtPZTVCPtZU181sSDF+isUPebSqFTNTkIejFASAQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
         "axios": "0.18.0",
         "google-p12-pem": "1.0.2",
@@ -5745,7 +5745,7 @@
         "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "http-cache-semantics": {
@@ -5865,7 +5865,7 @@
       "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
       "dev": true,
       "requires": {
-        "moment": "2.21.0",
+        "moment": "2.22.0",
         "sanitize-html": "1.18.2"
       }
     },
@@ -5879,7 +5879,7 @@
         "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
+        "external-editor": "2.2.0",
         "figures": "2.0.0",
         "lodash": "4.17.5",
         "mute-stream": "0.0.7",
@@ -6156,9 +6156,9 @@
       "dev": true
     },
     "is-stream-ended": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -6940,9 +6940,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz",
+      "integrity": "sha512-1muXCh8jb1N/gHRbn9VDUBr0GYb8A/aVcHlII9QSB68a50spqEVLIGN6KVmCOnSvJrUhC0edGgKU5ofnGXdYdg==",
       "dev": true
     },
     "ms": {
@@ -7021,9 +7021,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-      "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -10619,16 +10619,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -10640,7 +10640,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -11155,7 +11155,7 @@
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
         "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "is-stream-ended": "0.1.4"
       }
     },
     "sprintf-js": {
@@ -11196,9 +11196,9 @@
       "dev": true
     },
     "stream-events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-      "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.3.tgz",
+      "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
       "requires": {
         "stubs": "3.0.0"
       }
@@ -11236,9 +11236,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -11332,7 +11332,7 @@
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "mime": {
@@ -11441,7 +11441,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/bigquery",
   "description": "Google BigQuery Client Library for Node.js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -81,14 +81,14 @@
       }
     },
     "@google-cloud/bigquery": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "requires": {
         "@google-cloud/common": "0.17.0",
         "arrify": "1.0.1",
         "duplexify": "3.5.4",
         "extend": "3.0.1",
         "is": "3.2.1",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "uuid": "3.2.1"
       },
@@ -174,7 +174,7 @@
             "request": "2.85.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
+            "stream-events": "1.0.3",
             "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           }
@@ -1616,7 +1616,7 @@
             "request": "2.85.0",
             "safe-buffer": "5.1.1",
             "snakeize": "0.1.0",
-            "stream-events": "1.0.2",
+            "stream-events": "1.0.3",
             "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           },
@@ -1640,7 +1640,7 @@
                 "request": "2.85.0",
                 "retry-request": "3.3.1",
                 "split-array-stream": "1.0.3",
-                "stream-events": "1.0.2",
+                "stream-events": "1.0.3",
                 "string-format-obj": "1.1.1",
                 "through2": "2.0.3"
               }
@@ -1651,7 +1651,7 @@
               "requires": {
                 "async": "2.6.0",
                 "gcp-metadata": "0.6.3",
-                "google-auth-library": "1.3.2",
+                "google-auth-library": "1.4.0",
                 "request": "2.85.0"
               }
             }
@@ -1897,7 +1897,7 @@
             "clean-stack": "1.3.0",
             "clean-yaml-object": "0.1.0",
             "cli-cursor": "2.1.0",
-            "cli-spinners": "1.1.0",
+            "cli-spinners": "1.3.0",
             "cli-truncate": "1.1.0",
             "co-with-promise": "4.6.0",
             "code-excerpt": "2.1.1",
@@ -2625,7 +2625,7 @@
           }
         },
         "cli-spinners": {
-          "version": "1.1.0",
+          "version": "1.3.0",
           "bundled": true
         },
         "cli-truncate": {
@@ -2869,7 +2869,7 @@
           "requires": {
             "buffer-from": "1.0.0",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "typedarray": "0.0.6"
           }
         },
@@ -3160,7 +3160,7 @@
           "requires": {
             "end-of-stream": "1.4.1",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "stream-shift": "1.0.0"
           }
         },
@@ -3360,7 +3360,7 @@
             "eslint-scope": "3.7.1",
             "eslint-visitor-keys": "1.0.0",
             "espree": "3.5.4",
-            "esquery": "1.0.0",
+            "esquery": "1.0.1",
             "esutils": "2.0.2",
             "file-entry-cache": "2.0.0",
             "functional-red-black-tree": "1.0.1",
@@ -3531,7 +3531,7 @@
           }
         },
         "esquery": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "estraverse": "4.2.0"
@@ -3592,7 +3592,7 @@
           "bundled": true
         },
         "external-editor": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
@@ -3739,7 +3739,7 @@
           "bundled": true,
           "requires": {
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           }
         },
         "fs-extra": {
@@ -3781,7 +3781,7 @@
             "google-auto-auth": "0.9.7",
             "pumpify": "1.4.0",
             "request": "2.85.0",
-            "stream-events": "1.0.2",
+            "stream-events": "1.0.3",
             "through2": "2.0.3"
           },
           "dependencies": {
@@ -3791,7 +3791,7 @@
               "requires": {
                 "async": "2.6.0",
                 "gcp-metadata": "0.6.3",
-                "google-auth-library": "1.3.2",
+                "google-auth-library": "1.4.0",
                 "request": "2.85.0"
               }
             }
@@ -3887,12 +3887,12 @@
           }
         },
         "google-auth-library": {
-          "version": "1.3.2",
+          "version": "1.4.0",
           "bundled": true,
           "requires": {
             "axios": "0.18.0",
             "gcp-metadata": "0.6.3",
-            "gtoken": "2.2.0",
+            "gtoken": "2.3.0",
             "jws": "3.1.4",
             "lodash.isstring": "4.0.1",
             "lru-cache": "4.1.2",
@@ -3905,7 +3905,7 @@
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.3.2",
+            "google-auth-library": "1.4.0",
             "request": "2.85.0"
           }
         },
@@ -3913,7 +3913,7 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "node-forge": "0.7.4",
+            "node-forge": "0.7.5",
             "pify": "3.0.0"
           }
         },
@@ -3962,7 +3962,7 @@
           "bundled": true
         },
         "gtoken": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
             "axios": "0.18.0",
@@ -4083,7 +4083,7 @@
             "domutils": "1.7.0",
             "entities": "1.1.1",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           }
         },
         "http-cache-semantics": {
@@ -4175,7 +4175,7 @@
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "moment": "2.21.0",
+            "moment": "2.22.0",
             "sanitize-html": "1.18.2"
           }
         },
@@ -4187,7 +4187,7 @@
             "chalk": "2.3.2",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
+            "external-editor": "2.2.0",
             "figures": "2.0.0",
             "lodash": "4.17.5",
             "mute-stream": "0.0.7",
@@ -4392,7 +4392,7 @@
           "bundled": true
         },
         "is-stream-ended": {
-          "version": "0.1.3",
+          "version": "0.1.4",
           "bundled": true
         },
         "is-typedarray": {
@@ -4996,7 +4996,7 @@
           "bundled": true
         },
         "moment": {
-          "version": "2.21.0",
+          "version": "2.22.0",
           "bundled": true
         },
         "ms": {
@@ -5053,7 +5053,7 @@
           }
         },
         "node-forge": {
-          "version": "0.7.4",
+          "version": "0.7.5",
           "bundled": true
         },
         "normalize-package-data": {
@@ -8122,7 +8122,7 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.5",
+          "version": "2.3.6",
           "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -8130,7 +8130,7 @@
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
@@ -8140,7 +8140,7 @@
           "requires": {
             "graceful-fs": "4.1.11",
             "minimatch": "3.0.4",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "set-immediate-shim": "1.0.1"
           }
         },
@@ -8537,7 +8537,7 @@
           "bundled": true,
           "requires": {
             "async": "2.6.0",
-            "is-stream-ended": "0.1.3"
+            "is-stream-ended": "0.1.4"
           }
         },
         "sprintf-js": {
@@ -8571,7 +8571,7 @@
           "bundled": true
         },
         "stream-events": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "requires": {
             "stubs": "3.0.0"
@@ -8602,7 +8602,7 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -8677,7 +8677,7 @@
             "methods": "1.1.2",
             "mime": "1.6.0",
             "qs": "6.5.1",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "mime": {
@@ -8761,7 +8761,7 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "xtend": "4.0.1"
           }
         },
@@ -9175,7 +9175,7 @@
         "request": "2.85.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
@@ -9233,7 +9233,7 @@
             "clean-stack": "1.3.0",
             "clean-yaml-object": "0.1.0",
             "cli-cursor": "2.1.0",
-            "cli-spinners": "1.1.0",
+            "cli-spinners": "1.3.0",
             "cli-truncate": "1.1.0",
             "co-with-promise": "4.6.0",
             "code-excerpt": "2.1.1",
@@ -9357,7 +9357,7 @@
         "request": "2.85.0",
         "safe-buffer": "5.1.1",
         "snakeize": "0.1.0",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
@@ -9568,7 +9568,7 @@
         "clean-stack": "1.3.0",
         "clean-yaml-object": "0.1.0",
         "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
+        "cli-spinners": "1.3.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
         "code-excerpt": "2.1.1",
@@ -10464,9 +10464,9 @@
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.0.tgz",
+      "integrity": "sha512-ahr3q/EW26uLN3vqBaDQS4g1rUwKMbVSTRlyfyoY06VwwSJmMYRxhT3FTAiTz9Yam6OOb1e0ldwvbsnuThvuzA==",
       "dev": true
     },
     "cli-truncate": {
@@ -10589,7 +10589,7 @@
       "requires": {
         "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
@@ -10815,7 +10815,7 @@
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "stream-shift": "1.0.0"
       }
     },
@@ -11932,7 +11932,7 @@
         "google-auto-auth": "0.7.2",
         "pumpify": "1.4.0",
         "request": "2.85.0",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "through2": "2.0.3"
       },
       "dependencies": {
@@ -12102,7 +12102,7 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
       "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
       "requires": {
-        "node-forge": "0.7.4"
+        "node-forge": "0.7.5"
       }
     },
     "got": {
@@ -12579,9 +12579,9 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-stream-ended": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -13238,9 +13238,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-      "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -15371,16 +15371,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -15392,7 +15392,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -15795,7 +15795,7 @@
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
         "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "is-stream-ended": "0.1.4"
       }
     },
     "sprintf-js": {
@@ -15826,9 +15826,9 @@
       "dev": true
     },
     "stream-events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-      "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.3.tgz",
+      "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
       "requires": {
         "stubs": "3.0.0"
       }
@@ -15879,9 +15879,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -15954,7 +15954,7 @@
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "supertest": {
@@ -16008,7 +16008,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc --reporter=lcov --cache ava -T 3m --verbose test/*.test.js system-test/*.test.js && nyc report"
   },
   "dependencies": {
-    "@google-cloud/bigquery": "1.1.0",
+    "@google-cloud/bigquery": "1.2.0",
     "@google-cloud/storage": "1.5.1",
     "yargs": "10.0.3"
   },


### PR DESCRIPTION
## Fixes

- (#62, #87) Exit early when `dryRun` is set on `BigQuery#query` requests.

## Features

- (#86, #88) Support custom Job IDs
- (#81) Support Job location parameter.