### PR TITLE
Remove duplicate declaration of setMetadata & fix docs.

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -233,44 +233,6 @@ function Table(dataset, id, options) {
      * });
      */
     getMetadata: true,
-
-    /**
-     * Set the metadata for this Table. This can be useful for updating table
-     * labels.
-     *
-     * @see [Tables: patch API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/tables/patch}
-     *
-     * @method Table#setMetadata
-     * @param {object} metadata Metadata to save on the Table.
-     * @param {function} [callback] The callback function.
-     * @param {?error} callback.err An error returned while making this
-     *     request.
-     * @param {object} callback.apiResponse The full API response.
-     * @returns {Promise}
-     *
-     * @example
-     * const BigQuery = require('@google-cloud/bigquery');
-     * const bigquery = new BigQuery();
-     * const dataset = bigquery.dataset('my-dataset');
-     *
-     * const table = dataset.table('my-table');
-     *
-     * const metadata = {
-     *   labels: {
-     *     foo: 'bar'
-     *   }
-     * };
-     *
-     * table.setMetadata(metadata, function(err, apiResponse) {});
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * table.setMetadata(metadata).then(function(data) {
-     *   const apiResponse = data[0];
-     * });
-     */
-    setMetadata: true,
   };
 
   common.ServiceObject.call(this, {
@@ -1798,7 +1760,7 @@ Table.prototype.query = function(query, callback) {
 /**
  * Set the metadata on the table.
  *
- * @see [Tables: update API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/tables/update}
+ * @see [Tables: patch API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/tables/patch}
  *
  * @param {object} metadata The metadata key/value object to set.
  * @param {string} metadata.description A user-friendly description of the

--- a/test/table.js
+++ b/test/table.js
@@ -188,7 +188,6 @@ describe('BigQuery/Table', function() {
         exists: true,
         get: true,
         getMetadata: true,
-        setMetadata: true,
       });
     });
 


### PR DESCRIPTION
Fixes #95 

That was kind of confusing. Somewhere along the line, we switched from using the default `setMetadata` method inherited from `common.ServiceObject` to a custom method. When we switched, it looks like we forgot to remove the original `setMetadata` docs.

Then, they say we're using the `update` API, but we are actually using `PATCH`.

@callmehiphop could you verify this is all correct?