### PR TITLE
chore: fix prettier incompatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,7 +2117,7 @@
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
         "make-dir": "1.3.0",
-        "matcher": "1.1.0",
+        "matcher": "1.1.1",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
         "ms": "2.0.0",
@@ -2127,7 +2127,7 @@
         "package-hash": "2.0.0",
         "pkg-conf": "2.1.0",
         "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
+        "pretty-ms": "3.2.0",
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.2",
@@ -2413,7 +2413,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espower-location-detector": "1.0.0",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -2560,7 +2560,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -2584,7 +2584,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -2736,9 +2736,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -2808,7 +2808,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "deep-equal": "1.0.1",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -3119,7 +3119,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -3182,9 +3182,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "core-assert": {
@@ -3198,9 +3198,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -3224,7 +3224,7 @@
       "requires": {
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -3248,7 +3248,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "dashdash": {
@@ -3301,9 +3301,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -3507,7 +3507,7 @@
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "empower-core": "0.6.2"
       }
     },
@@ -3527,7 +3527,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "end-of-stream": {
@@ -3565,9 +3565,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.44",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
+      "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -3588,7 +3588,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3599,7 +3599,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -3613,7 +3613,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3626,7 +3626,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "es6-weak-map": {
@@ -3636,7 +3636,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -3920,7 +3920,7 @@
       "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "esquery": {
@@ -3960,7 +3960,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "execa": {
@@ -5938,9 +5938,9 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "longest": {
@@ -6005,9 +6005,9 @@
       "dev": true
     },
     "matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
-      "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
@@ -6370,7 +6370,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -9507,7 +9507,7 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -9519,7 +9519,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
       },
@@ -9538,7 +9538,7 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "estraverse": "4.2.0"
       }
     },
@@ -9548,7 +9548,7 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -9579,7 +9579,7 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "diff-match-patch": "1.0.1",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -9592,7 +9592,7 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -9635,19 +9635,18 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.2.tgz",
+      "integrity": "sha512-D9oFKkJ7g76fRxkRh9MWBh4j2vbNGO4rtEUJbj46zId5wnm0dwHruoyg4Od9Zqh3WNl0jwxnWSlEGAnl+/thWA==",
       "dev": true
     },
     "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
+        "parse-ms": "1.0.1"
       },
       "dependencies": {
         "parse-ms": {
@@ -9776,12 +9775,12 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -9907,7 +9906,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "safe-buffer": "5.1.2"
       }
     },
@@ -9917,7 +9916,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -10246,7 +10245,7 @@
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "nise": "1.3.3",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
@@ -10300,7 +10299,7 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -10444,7 +10443,7 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -10514,7 +10513,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
@@ -10923,9 +10922,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mocha": "^5.0.0",
     "nyc": "^11.3.0",
     "power-assert": "^1.4.4",
-    "prettier": "^1.8.2",
+    "prettier": "^1.13.2",
     "propprop": "^0.3.0",
     "proxyquire": "^2.0.0"
   }

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1901,7 +1901,7 @@
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
             "make-dir": "1.3.0",
-            "matcher": "1.1.0",
+            "matcher": "1.1.1",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
             "ms": "2.0.0",
@@ -1911,7 +1911,7 @@
             "package-hash": "2.0.0",
             "pkg-conf": "2.1.0",
             "plur": "2.1.2",
-            "pretty-ms": "3.1.0",
+            "pretty-ms": "3.2.0",
             "require-precompiled": "0.1.0",
             "resolve-cwd": "2.0.0",
             "safe-buffer": "5.1.2",
@@ -2150,7 +2150,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "espower-location-detector": "1.0.0",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
@@ -2267,7 +2267,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -2287,7 +2287,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2409,7 +2409,7 @@
           "bundled": true
         },
         "buffer-from": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "bundled": true
         },
         "builtin-modules": {
@@ -2466,7 +2466,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "deep-equal": "1.0.1",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
@@ -2702,7 +2702,7 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.0.0",
+            "buffer-from": "1.1.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.6",
             "typedarray": "0.0.6"
@@ -2755,7 +2755,7 @@
           "bundled": true
         },
         "cookiejar": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true
         },
         "core-assert": {
@@ -2767,7 +2767,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.6",
+          "version": "2.5.7",
           "bundled": true
         },
         "core-util-is": {
@@ -2787,7 +2787,7 @@
           "requires": {
             "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "which": "1.3.1"
           }
         },
         "crypto-random-string": {
@@ -2805,7 +2805,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "dashdash": {
@@ -2846,7 +2846,7 @@
           "bundled": true
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true
         },
         "deep-is": {
@@ -3006,7 +3006,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "empower-core": "0.6.2"
           }
         },
@@ -3022,7 +3022,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.6"
+            "core-js": "2.5.7"
           }
         },
         "end-of-stream": {
@@ -3052,7 +3052,7 @@
           }
         },
         "es5-ext": {
-          "version": "0.10.42",
+          "version": "0.10.44",
           "bundled": true,
           "requires": {
             "es6-iterator": "2.0.3",
@@ -3069,7 +3069,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-symbol": "3.1.1"
           }
         },
@@ -3078,7 +3078,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-set": "0.1.5",
             "es6-symbol": "3.1.1",
@@ -3090,7 +3090,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1",
             "event-emitter": "0.3.5"
@@ -3101,7 +3101,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "es6-weak-map": {
@@ -3109,7 +3109,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1"
           }
@@ -3345,7 +3345,7 @@
           "version": "1.8.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6"
+            "core-js": "2.5.7"
           }
         },
         "esquery": {
@@ -3375,7 +3375,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "execa": {
@@ -4493,7 +4493,7 @@
           "bundled": true
         },
         "lolex": {
-          "version": "2.6.0",
+          "version": "2.7.0",
           "bundled": true
         },
         "longest": {
@@ -4543,7 +4543,7 @@
           "bundled": true
         },
         "matcher": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "escape-string-regexp": "1.0.5"
@@ -4823,7 +4823,7 @@
           "requires": {
             "@sinonjs/formatio": "2.0.0",
             "just-extend": "1.1.27",
-            "lolex": "2.6.0",
+            "lolex": "2.7.0",
             "path-to-regexp": "1.7.0",
             "text-encoding": "0.6.4"
           }
@@ -7519,7 +7519,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -7529,7 +7529,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
           },
@@ -7544,7 +7544,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "estraverse": "4.2.0"
           }
         },
@@ -7552,7 +7552,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -7577,7 +7577,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "diff-match-patch": "1.0.1",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -7588,7 +7588,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -7621,15 +7621,14 @@
           "bundled": true
         },
         "prettier": {
-          "version": "1.12.1",
+          "version": "1.13.2",
           "bundled": true
         },
         "pretty-ms": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
-            "parse-ms": "1.0.1",
-            "plur": "2.1.2"
+            "parse-ms": "1.0.1"
           },
           "dependencies": {
             "parse-ms": {
@@ -7730,10 +7729,10 @@
           }
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.5.1",
+            "deep-extend": "0.6.0",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -7834,7 +7833,7 @@
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7",
+            "rc": "1.2.8",
             "safe-buffer": "5.1.2"
           }
         },
@@ -7842,7 +7841,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7"
+            "rc": "1.2.8"
           }
         },
         "regjsgen": {
@@ -8095,7 +8094,7 @@
             "@sinonjs/formatio": "2.0.0",
             "diff": "3.5.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.6.0",
+            "lolex": "2.7.0",
             "nise": "1.3.3",
             "supports-color": "5.4.0",
             "type-detect": "4.0.8"
@@ -8135,7 +8134,7 @@
           "version": "0.5.6",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.0.0",
+            "buffer-from": "1.1.0",
             "source-map": "0.6.1"
           },
           "dependencies": {
@@ -8249,7 +8248,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -8302,7 +8301,7 @@
           "bundled": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
+            "cookiejar": "2.1.2",
             "debug": "3.1.0",
             "extend": "3.0.1",
             "form-data": "2.3.2",
@@ -8619,7 +8618,7 @@
           "bundled": true
         },
         "which": {
-          "version": "1.3.0",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
             "isexe": "2.0.0"
@@ -8902,7 +8901,7 @@
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
             "make-dir": "1.3.0",
-            "matcher": "1.1.0",
+            "matcher": "1.1.1",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
             "ms": "2.1.1",
@@ -8912,7 +8911,7 @@
             "package-hash": "2.0.0",
             "pkg-conf": "2.1.0",
             "plur": "2.1.2",
-            "pretty-ms": "3.1.0",
+            "pretty-ms": "3.2.0",
             "require-precompiled": "0.1.0",
             "resolve-cwd": "2.0.0",
             "safe-buffer": "5.1.2",
@@ -8943,7 +8942,7 @@
             "diff": "3.5.0",
             "formatio": "1.2.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.6.0",
+            "lolex": "2.7.0",
             "nise": "1.3.3",
             "supports-color": "4.5.0",
             "type-detect": "4.0.8"
@@ -9237,7 +9236,7 @@
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
         "make-dir": "1.3.0",
-        "matcher": "1.1.0",
+        "matcher": "1.1.1",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
         "ms": "2.1.1",
@@ -9247,7 +9246,7 @@
         "package-hash": "2.0.0",
         "pkg-conf": "2.1.0",
         "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
+        "pretty-ms": "3.2.0",
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.2",
@@ -9297,7 +9296,7 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.0.0",
+            "buffer-from": "1.1.0",
             "source-map": "0.6.1"
           }
         },
@@ -9592,7 +9591,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espower-location-detector": "1.0.0",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -9739,7 +9738,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -9752,7 +9751,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -9901,9 +9900,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -9950,7 +9949,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "deep-equal": "1.0.1",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -10208,7 +10207,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -10259,9 +10258,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "core-assert": {
@@ -10275,9 +10274,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -10300,7 +10299,7 @@
       "requires": {
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -10372,9 +10371,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "delayed-stream": {
@@ -10446,7 +10445,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "end-of-stream": {
@@ -10513,7 +10512,7 @@
       "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "estraverse": {
@@ -12144,9 +12143,9 @@
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
     },
     "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "longest": {
@@ -12204,9 +12203,9 @@
       "dev": true
     },
     "matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
-      "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
@@ -12495,7 +12494,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -14486,13 +14485,12 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
+        "parse-ms": "1.0.1"
       }
     },
     "private": {
@@ -14577,12 +14575,12 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -14702,7 +14700,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "safe-buffer": "5.1.2"
       }
     },
@@ -14712,7 +14710,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -14930,7 +14928,7 @@
         "diff": "3.5.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "nise": "1.3.3",
         "supports-color": "4.5.0",
         "type-detect": "4.0.8"
@@ -15178,7 +15176,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
@@ -15539,9 +15537,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "2.0.0"
       }

--- a/system-test/bigquery.js
+++ b/system-test/bigquery.js
@@ -736,8 +736,7 @@ describe('BigQuery', function() {
     });
 
     it('should insert rows via stream', function(done) {
-      fs
-        .createReadStream(TEST_DATA_JSON_PATH)
+      fs.createReadStream(TEST_DATA_JSON_PATH)
         .pipe(table.createWriteStream('json'))
         .on('error', done)
         .on('complete', function() {
@@ -881,8 +880,7 @@ describe('BigQuery', function() {
       var file = bucket.file('kitten-test-data-backup.json');
 
       before(function(done) {
-        fs
-          .createReadStream(TEST_DATA_JSON_PATH)
+        fs.createReadStream(TEST_DATA_JSON_PATH)
           .pipe(file.createWriteStream())
           .on('error', done)
           .on('finish', done);


### PR DESCRIPTION
`lint` tasks started failing in nightly because new prettier minor release had an incompatible change in formatting rules. Fixing that and updating lock files to force using the new version.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
