### PR TITLE
chore: make samples test work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ jobs:
           environment:
             GCLOUD_PROJECT: long-door-651
             GOOGLE_APPLICATION_CREDENTIALS: /home/node/bigquery-samples/.circleci/key.json
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json


### PR DESCRIPTION
Fixing samples tests CI broken since yesterday.

I made a mistake manually editing this config file yesterday, fixing it. `npm link` will not work using non-root account unless this variable is defined.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
