### PR TITLE
Pass an empty object.

### DIFF
--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -895,7 +895,7 @@ describe('BigQuery', () => {
 
       before(done => {
         fs.createReadStream(TEST_DATA_JSON_PATH)
-          .pipe(file.createWriteStream())
+          .pipe(file.createWriteStream({}))
           .on('error', done)
           .on('finish', done);
       });


### PR DESCRIPTION
An argument isn't actually required to `file.createWriteStream()`, but CI is failing: https://circleci.com/gh/googleapis/nodejs-bigquery/4374, which is blocking #190.