### PR TITLE
BigQuery Orc & Parquet Samples

### DIFF
--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -110,10 +110,10 @@ test.serial(`should list tables`, async t => {
     .start();
 });
 
-test.serial(`should load a local file`, async t => {
+test.serial(`should load a local CSV file`, async t => {
   t.plan(1);
   const output = await tools.runAsync(
-    `${cmd} load ${projectId} ${datasetId} ${tableId} ${localFilePath}`,
+    `${cmd} load-local-csv ${projectId} ${datasetId} ${tableId} ${localFilePath}`,
     cwd
   );
   t.regex(output, /completed\./);

--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -217,12 +217,52 @@ test(`should load a GCS CSV file with explicit schema`, async t => {
     .start();
 });
 
+test(`should load a GCS JSON file with explicit schema`, async t => {
+  t.plan(1);
+  const tableId = generateUuid();
+
+  const output = await tools.runAsync(
+    `${cmd} load-gcs-json ${projectId} ${datasetId} ${tableId}`,
+    cwd
+  );
+  t.regex(output, /completed\./);
+  await tools
+    .tryTest(async assert => {
+      const [rows] = await bigquery
+        .dataset(datasetId)
+        .table(tableId)
+        .getRows();
+      assert(rows.length > 0);
+    })
+    .start();
+});
+
 test(`should load a GCS CSV file with autodetected schema`, async t => {
   t.plan(1);
   const tableId = generateUuid();
 
   const output = await tools.runAsync(
     `${cmd} load-gcs-csv-autodetect ${projectId} ${datasetId} ${tableId}`,
+    cwd
+  );
+  t.regex(output, /completed\./);
+  await tools
+    .tryTest(async assert => {
+      const [rows] = await bigquery
+        .dataset(datasetId)
+        .table(tableId)
+        .getRows();
+      assert(rows.length > 0);
+    })
+    .start();
+});
+
+test(`should load a GCS JSON file with autodetected schema`, async t => {
+  t.plan(1);
+  const tableId = generateUuid();
+
+  const output = await tools.runAsync(
+    `${cmd} load-gcs-json-autodetect ${projectId} ${datasetId} ${tableId}`,
     cwd
   );
   t.regex(output, /completed\./);
@@ -263,6 +303,26 @@ test(`should load a GCS CSV file truncate table`, async t => {
 
   const output = await tools.runAsync(
     `${cmd} load-gcs-csv-truncate ${projectId} ${datasetId} ${tableId}`,
+    cwd
+  );
+  t.regex(output, /completed\./);
+  await tools
+    .tryTest(async assert => {
+      const [rows] = await bigquery
+        .dataset(datasetId)
+        .table(tableId)
+        .getRows();
+      assert(rows.length > 0);
+    })
+    .start();
+});
+
+test(`should load a GCS JSON file truncate table`, async t => {
+  t.plan(1);
+  const tableId = generateUuid();
+
+  const output = await tools.runAsync(
+    `${cmd} load-gcs-json-truncate ${projectId} ${datasetId} ${tableId}`,
     cwd
   );
   t.regex(output, /completed\./);

--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -177,7 +177,7 @@ test(`should load a GCS ORC file`, async t => {
     .start();
 });
 
-test(`should load a GCS Parquet file with explicit schema`, async t => {
+test(`should load a GCS Parquet file`, async t => {
   t.plan(1);
   const tableId = generateUuid();
 

--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -277,6 +277,46 @@ test(`should load a GCS CSV file truncate table`, async t => {
     .start();
 });
 
+test(`should load a GCS parquet file truncate table`, async t => {
+  t.plan(1);
+  const tableId = generateUuid();
+
+  const output = await tools.runAsync(
+    `${cmd} load-gcs-parquet-truncate ${projectId} ${datasetId} ${tableId}`,
+    cwd
+  );
+  t.regex(output, /completed\./);
+  await tools
+    .tryTest(async assert => {
+      const [rows] = await bigquery
+        .dataset(datasetId)
+        .table(tableId)
+        .getRows();
+      assert(rows.length > 0);
+    })
+    .start();
+});
+
+test(`should load a GCS ORC file truncate table`, async t => {
+  t.plan(1);
+  const tableId = generateUuid();
+
+  const output = await tools.runAsync(
+    `${cmd} load-gcs-orc-truncate ${projectId} ${datasetId} ${tableId}`,
+    cwd
+  );
+  t.regex(output, /completed\./);
+  await tools
+    .tryTest(async assert => {
+      const [rows] = await bigquery
+        .dataset(datasetId)
+        .table(tableId)
+        .getRows();
+      assert(rows.length > 0);
+    })
+    .start();
+});
+
 test.serial(`should copy a table`, async t => {
   t.plan(1);
   const output = await tools.runAsync(

--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -157,7 +157,7 @@ test.serial(`should extract a table to GCS`, async t => {
     .start();
 });
 
-test(`should load a GCS ORC file with explicit schema`, async t => {
+test(`should load a GCS ORC file`, async t => {
   t.plan(1);
   const tableId = generateUuid();
 

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -270,7 +270,7 @@ function loadORCFromGCS(datasetId, tableId, projectId) {
   // Configure the load job. For full list of options, see:
   // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
   const metadata = {
-    sourceFormat: 'ORC'
+    sourceFormat: 'ORC',
   };
 
   // Loads data from a Google Cloud Storage file into the table
@@ -330,7 +330,7 @@ function loadParquetFromGCS(datasetId, tableId, projectId) {
   // Configure the load job. For full list of options, see:
   // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
   const metadata = {
-    sourceFormat: 'PARQUET'
+    sourceFormat: 'PARQUET',
   };
 
   // Loads data from a Google Cloud Storage file into the table
@@ -1085,7 +1085,7 @@ require(`yargs`)
     }
   )
   .command(
-    `load <projectId> <datasetId> <tableId> <fileName>`,
+    `load-local-csv <projectId> <datasetId> <tableId> <fileName>`,
     `Loads data from a local file into a table.`,
     {},
     opts => {
@@ -1166,7 +1166,7 @@ require(`yargs`)
     `Loads sample JSON data from GCS, replacing an existing table.`,
     {},
     opts => {
-      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+      loadJSONFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
     }
   )
   .command(
@@ -1174,7 +1174,7 @@ require(`yargs`)
     `Loads sample Parquet data from GCS, replacing an existing table.`,
     {},
     opts => {
-      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+      loadParquetFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
     }
   )
   .command(
@@ -1182,7 +1182,7 @@ require(`yargs`)
     `Loads sample Orc data from GCS, replacing an existing table.`,
     {},
     opts => {
-      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+      loadOrcFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
     }
   )
   .command(

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -270,13 +270,7 @@ function loadORCFromGCS(datasetId, tableId, projectId) {
   // Configure the load job. For full list of options, see:
   // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
   const metadata = {
-    sourceFormat: 'ORC',
-    schema: {
-      fields: [
-        {name: 'name', type: 'STRING'},
-        {name: 'post_abbr', type: 'STRING'},
-      ],
-    },
+    sourceFormat: 'ORC'
   };
 
   // Loads data from a Google Cloud Storage file into the table

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -423,6 +423,72 @@ function loadCSVFromGCS(datasetId, tableId, projectId) {
   // [END bigquery_load_table_gcs_csv]
 }
 
+function loadJSONFromGCS(datasetId, tableId, projectId) {
+  // [START bigquery_load_table_gcs_json]
+  // Imports the Google Cloud client libraries
+  const BigQuery = require('@google-cloud/bigquery');
+  const {Storage} = require('@google-cloud/storage');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = "your-project-id";
+  // const datasetId = "my_dataset";
+  // const tableId = "my_table";
+
+  /**
+   * This sample loads the json file at
+   * https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.json
+   *
+   * TODO(developer): Replace the following lines with the path to your file.
+   */
+  const bucketName = 'cloud-samples-data';
+  const filename = 'bigquery/us-states/us-states.json';
+
+  // Instantiates clients
+  const bigquery = new BigQuery({
+    projectId: projectId,
+  });
+
+  const storage = new Storage({
+    projectId: projectId,
+  });
+
+  // Configure the load job. For full list of options, see:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
+  const metadata = {
+    sourceFormat: 'NEWLINE_DELIMITED_JSON',
+    schema: {
+      fields: [
+        {name: 'name', type: 'STRING'},
+        {name: 'post_abbr', type: 'STRING'},
+      ],
+    },
+  };
+
+  // Loads data from a Google Cloud Storage file into the table
+  bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .load(storage.bucket(bucketName).file(filename), metadata)
+    .then(results => {
+      const job = results[0];
+
+      // load() waits for the job to finish
+      console.log(`Job ${job.id} completed.`);
+
+      // Check the job's status for errors
+      const errors = job.status.errors;
+      if (errors && errors.length > 0) {
+        throw errors;
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END bigquery_load_table_gcs_json]
+}
+
 function loadCSVFromGCSAutodetect(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_csv_autodetect]
   // Imports the Google Cloud client libraries
@@ -483,6 +549,67 @@ function loadCSVFromGCSAutodetect(datasetId, tableId, projectId) {
       console.error('ERROR:', err);
     });
   // [END bigquery_load_table_gcs_csv_autodetect]
+}
+
+function loadJSONFromGCSAutodetect(datasetId, tableId, projectId) {
+  // [START bigquery_load_table_gcs_json_autodetect]
+  // Imports the Google Cloud client libraries
+  const BigQuery = require('@google-cloud/bigquery');
+  const {Storage} = require('@google-cloud/storage');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = "your-project-id";
+  // const datasetId = "my_dataset";
+  // const tableId = "my_table";
+
+  /**
+   * This sample loads the JSON file at
+   * https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.json
+   *
+   * TODO(developer): Replace the following lines with the path to your file.
+   */
+  const bucketName = 'cloud-samples-data';
+  const filename = 'bigquery/us-states/us-states.json';
+
+  // Instantiates clients
+  const bigquery = new BigQuery({
+    projectId: projectId,
+  });
+
+  const storage = new Storage({
+    projectId: projectId,
+  });
+
+  // Configure the load job. For full list of options, see:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
+  const metadata = {
+    sourceFormat: 'NEWLINE_DELIMITED_JSON',
+    autodetect: true,
+  };
+
+  // Loads data from a Google Cloud Storage file into the table
+  bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .load(storage.bucket(bucketName).file(filename), metadata)
+    .then(results => {
+      const job = results[0];
+
+      // load() waits for the job to finish
+      console.log(`Job ${job.id} completed.`);
+
+      // Check the job's status for errors
+      const errors = job.status.errors;
+      if (errors && errors.length > 0) {
+        throw errors;
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END bigquery_load_table_gcs_json_autodetect]
 }
 
 function loadCSVFromGCSAppend(datasetId, tableId, projectId) {
@@ -621,6 +748,74 @@ function loadCSVFromGCSTruncate(datasetId, tableId, projectId) {
       console.error('ERROR:', err);
     });
   // [END bigquery_load_table_gcs_csv_truncate]
+}
+
+function loadJSONFromGCSTruncate(datasetId, tableId, projectId) {
+  // [START bigquery_load_table_gcs_json_truncate]
+  // Imports the Google Cloud client libraries
+  const BigQuery = require('@google-cloud/bigquery');
+  const {Storage} = require('@google-cloud/storage');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = "your-project-id";
+  // const datasetId = "my_dataset";
+  // const tableId = "my_table";
+
+  /**
+   * This sample loads the JSON file at
+   * https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.json
+   *
+   * TODO(developer): Replace the following lines with the path to your file.
+   */
+  const bucketName = 'cloud-samples-data';
+  const filename = 'bigquery/us-states/us-states.json';
+
+  // Instantiates clients
+  const bigquery = new BigQuery({
+    projectId: projectId,
+  });
+
+  const storage = new Storage({
+    projectId: projectId,
+  });
+
+  // Configure the load job. For full list of options, see:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
+  const metadata = {
+    sourceFormat: 'NEWLINE_DELIMITED_JSON',
+    schema: {
+      fields: [
+        {name: 'name', type: 'STRING'},
+        {name: 'post_abbr', type: 'STRING'},
+      ],
+    },
+    // Set the write disposition to append to an existing table.
+    writeDisposition: 'WRITE_TRUNCATE',
+  };
+
+  // Loads data from a Google Cloud Storage file into the table
+  bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .load(storage.bucket(bucketName).file(filename), metadata)
+    .then(results => {
+      const job = results[0];
+
+      // load() waits for the job to finish
+      console.log(`Job ${job.id} completed.`);
+
+      // Check the job's status for errors
+      const errors = job.status.errors;
+      if (errors && errors.length > 0) {
+        throw errors;
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END bigquery_load_table_gcs_json_truncate]
 }
 
 function loadParquetFromGCSTruncate(datasetId, tableId, projectId) {
@@ -927,11 +1122,27 @@ require(`yargs`)
     }
   )
   .command(
+    `load-gcs-json <projectId> <datasetId> <tableId>`,
+    `Loads sample JSON data from a Google Cloud Storage file into a table.`,
+    {},
+    opts => {
+      loadJSONFromGCS(opts.datasetId, opts.tableId, opts.projectId);
+    }
+  )
+  .command(
     `load-gcs-csv-autodetect <projectId> <datasetId> <tableId>`,
     `Loads sample CSV data from a Google Cloud Storage file into a table.`,
     {},
     opts => {
       loadCSVFromGCSAutodetect(opts.datasetId, opts.tableId, opts.projectId);
+    }
+  )
+  .command(
+    `load-gcs-json-autodetect <projectId> <datasetId> <tableId>`,
+    `Loads sample JSON data from a Google Cloud Storage file into a table.`,
+    {},
+    opts => {
+      loadJSONFromGCSAutodetect(opts.datasetId, opts.tableId, opts.projectId);
     }
   )
   .command(
@@ -945,6 +1156,14 @@ require(`yargs`)
   .command(
     `load-gcs-csv-truncate <projectId> <datasetId> <tableId>`,
     `Loads sample CSV data from GCS, replacing an existing table.`,
+    {},
+    opts => {
+      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+    }
+  )
+  .command(
+    `load-gcs-json-truncate <projectId> <datasetId> <tableId>`,
+    `Loads sample JSON data from GCS, replacing an existing table.`,
     {},
     opts => {
       loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -623,6 +623,130 @@ function loadCSVFromGCSTruncate(datasetId, tableId, projectId) {
   // [END bigquery_load_table_gcs_csv_truncate]
 }
 
+function loadParquetFromGCSTruncate(datasetId, tableId, projectId) {
+  // [START bigquery_load_table_gcs_parquet_truncate]
+  // Imports the Google Cloud client libraries
+  const BigQuery = require('@google-cloud/bigquery');
+  const {Storage} = require('@google-cloud/storage');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = "your-project-id";
+  // const datasetId = "my_dataset";
+  // const tableId = "my_table";
+
+  /**
+   * This sample loads the CSV file at
+   * https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.csv
+   *
+   * TODO(developer): Replace the following lines with the path to your file.
+   */
+  const bucketName = 'cloud-samples-data';
+  const filename = 'bigquery/us-states/us-states.parquet';
+
+  // Instantiates clients
+  const bigquery = new BigQuery({
+    projectId: projectId,
+  });
+
+  const storage = new Storage({
+    projectId: projectId,
+  });
+
+  // Configure the load job. For full list of options, see:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
+  const metadata = {
+    sourceFormat: 'PARQUET',
+    // Set the write disposition to append to an existing table.
+    writeDisposition: 'WRITE_TRUNCATE',
+  };
+
+  // Loads data from a Google Cloud Storage file into the table
+  bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .load(storage.bucket(bucketName).file(filename), metadata)
+    .then(results => {
+      const job = results[0];
+
+      // load() waits for the job to finish
+      console.log(`Job ${job.id} completed.`);
+
+      // Check the job's status for errors
+      const errors = job.status.errors;
+      if (errors && errors.length > 0) {
+        throw errors;
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END bigquery_load_table_gcs_parquet_truncate]
+}
+
+function loadOrcFromGCSTruncate(datasetId, tableId, projectId) {
+  // [START bigquery_load_table_gcs_orc_truncate]
+  // Imports the Google Cloud client libraries
+  const BigQuery = require('@google-cloud/bigquery');
+  const {Storage} = require('@google-cloud/storage');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = "your-project-id";
+  // const datasetId = "my_dataset";
+  // const tableId = "my_table";
+
+  /**
+   * This sample loads the CSV file at
+   * https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.csv
+   *
+   * TODO(developer): Replace the following lines with the path to your file.
+   */
+  const bucketName = 'cloud-samples-data';
+  const filename = 'bigquery/us-states/us-states.orc';
+
+  // Instantiates clients
+  const bigquery = new BigQuery({
+    projectId: projectId,
+  });
+
+  const storage = new Storage({
+    projectId: projectId,
+  });
+
+  // Configure the load job. For full list of options, see:
+  // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
+  const metadata = {
+    sourceFormat: 'ORC',
+    // Set the write disposition to append to an existing table.
+    writeDisposition: 'WRITE_TRUNCATE',
+  };
+
+  // Loads data from a Google Cloud Storage file into the table
+  bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .load(storage.bucket(bucketName).file(filename), metadata)
+    .then(results => {
+      const job = results[0];
+
+      // load() waits for the job to finish
+      console.log(`Job ${job.id} completed.`);
+
+      // Check the job's status for errors
+      const errors = job.status.errors;
+      if (errors && errors.length > 0) {
+        throw errors;
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END bigquery_load_table_gcs_orc_truncate]
+}
+
 function extractTableToGCS(
   datasetId,
   tableId,
@@ -821,6 +945,22 @@ require(`yargs`)
   .command(
     `load-gcs-csv-truncate <projectId> <datasetId> <tableId>`,
     `Loads sample CSV data from GCS, replacing an existing table.`,
+    {},
+    opts => {
+      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+    }
+  )
+  .command(
+    `load-gcs-parquet-truncate <projectId> <datasetId> <tableId>`,
+    `Loads sample Parquet data from GCS, replacing an existing table.`,
+    {},
+    opts => {
+      loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);
+    }
+  )
+  .command(
+    `load-gcs-orc-truncate <projectId> <datasetId> <tableId>`,
+    `Loads sample Orc data from GCS, replacing an existing table.`,
     {},
     opts => {
       loadCSVFromGCSTruncate(opts.datasetId, opts.tableId, opts.projectId);

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -330,13 +330,7 @@ function loadParquetFromGCS(datasetId, tableId, projectId) {
   // Configure the load job. For full list of options, see:
   // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
   const metadata = {
-    sourceFormat: 'PARQUET',
-    schema: {
-      fields: [
-        {name: 'name', type: 'STRING'},
-        {name: 'post_abbr', type: 'STRING'},
-      ],
-    },
+    sourceFormat: 'PARQUET'
   };
 
   // Loads data from a Google Cloud Storage file into the table


### PR DESCRIPTION
This PR:
+ Adds load truncate samples for Orc and Parquet file formats
+ Adds load, load autodetect, and load truncate samples for JSON
+ Updates Orc and Parquet samples to not specify schema. The schema is inferred for these formats, so it should not be supplied (sources: [parquet schemas](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet#parquet_schemas), [orc schemas](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc#orc_schemas))