### PR TITLE
refactor(typescript): convert index to es module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/*
 samples/node_modules/*
 src/**/doc/*
+build/*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ```javascript
 // Imports the Google Cloud client library
-const BigQuery = require('@google-cloud/bigquery');
+const {BigQuery} = require('@google-cloud/bigquery');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-const async = require('async');
-const fs = require('fs');
-const BigQuery = require('../src/index.js');
+import * as async from 'async';
+import * as fs from 'fs';
+import {BigQuery} from '../src';
 const env = require('../../../system-test/env.js');
 
 if (process.argv.length < 3) {
@@ -26,7 +26,7 @@ if (process.argv.length < 3) {
     `usage: '${process.argv[0]} ${process.argv[1]} <queries.json>'`);
 }
 
-const queryJson = fs.readFileSync(process.argv[2]);
+const queryJson = fs.readFileSync(process.argv[2], 'utf8');
 const queries = JSON.parse(queryJson);
 const client = new BigQuery(env);
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "pretest": "npm run compile"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.25.0",
+    "@google-cloud/common": "^0.26.0",
     "@google-cloud/paginator": "^0.1.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.0",
@@ -87,6 +87,7 @@
     "@google-cloud/nodejs-repo-tools": "^2.2.3",
     "@google-cloud/storage": "^2.0.0",
     "@types/mocha": "^5.2.5",
+    "@types/sinon": "^5.0.5",
     "async": "^2.6.0",
     "codecov": "^3.0.0",
     "eslint": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "benchmark": "time node benchmark/bench.js benchmark/queries.json",
     "docs": "jsdoc -c .jsdoc.js",
     "lint": "eslint samples/",
-    "prettier": "prettier --write samples/*.js samples/*/*.js",
     "cover": "nyc --reporter=lcov mocha test/*.js && nyc report",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "test": "mocha build/test",
@@ -66,7 +65,7 @@
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
-    "fix": "gts fix",
+    "fix": "eslint --fix '**/*.js'",
     "prepare": "npm run compile",
     "pretest": "npm run compile"
   },

--- a/samples/datasets.js
+++ b/samples/datasets.js
@@ -18,7 +18,7 @@
 async function createDataset(datasetId, projectId) {
   // [START bigquery_create_dataset]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -38,7 +38,7 @@ async function createDataset(datasetId, projectId) {
 async function deleteDataset(datasetId, projectId) {
   // [START bigquery_delete_dataset]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -61,7 +61,7 @@ async function deleteDataset(datasetId, projectId) {
 async function listDatasets(projectId) {
   // [START bigquery_list_datasets]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/queries.js
+++ b/samples/queries.js
@@ -19,7 +19,7 @@ async function queryStackOverflow() {
   // [START bigquery_simple_app_all]
   // [START bigquery_simple_app_deps]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   // [END bigquery_simple_app_deps]
 
   // [START bigquery_simple_app_client]
@@ -63,7 +63,7 @@ async function queryStackOverflow() {
 async function query() {
   // [START bigquery_query]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   // Creates a client
   const bigquery = new BigQuery();
@@ -94,7 +94,7 @@ async function query() {
 async function queryDisableCache() {
   // [START bigquery_query_no_cache]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   // Creates a client
   const bigquery = new BigQuery();

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START bigquery_quickstart]
 // Imports the Google Cloud client library
-const BigQuery = require('@google-cloud/bigquery');
+const {BigQuery} = require('@google-cloud/bigquery');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/system-test/datasets.test.js
+++ b/samples/system-test/datasets.test.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const BigQuery = require(`@google-cloud/bigquery`);
+const {BigQuery} = require(`@google-cloud/bigquery`);
 const path = require(`path`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -69,7 +69,7 @@ test(`quickstart should create a dataset`, async t => {
     proxyquire(`../quickstart`, {
       '@google-cloud/bigquery': {
         BigQuery: sinon.stub().returns(bigqueryMock),
-      }
+      },
     });
   });
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -21,7 +21,7 @@ const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const uuid = require(`uuid`);
 
-const BigQuery = proxyquire(`@google-cloud/bigquery`, {});
+const {BigQuery} = proxyquire(`@google-cloud/bigquery`, {});
 const bigquery = new BigQuery();
 
 const expectedDatasetId = `my_new_dataset`;
@@ -67,7 +67,9 @@ test(`quickstart should create a dataset`, async t => {
     };
 
     proxyquire(`../quickstart`, {
-      '@google-cloud/bigquery': sinon.stub().returns(bigqueryMock),
+      '@google-cloud/bigquery': {
+        BigQuery: sinon.stub().returns(bigqueryMock),
+      }
     });
   });
 });

--- a/samples/system-test/tables.test.js
+++ b/samples/system-test/tables.test.js
@@ -18,11 +18,9 @@
 const test = require(`ava`);
 const path = require(`path`);
 const uuid = require(`uuid`);
-
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const {Storage} = require(`@google-cloud/storage`);
-
-const BigQuery = require(`@google-cloud/bigquery`);
+const {BigQuery} = require(`@google-cloud/bigquery`);
 
 const storage = new Storage();
 

--- a/samples/tables.js
+++ b/samples/tables.js
@@ -18,7 +18,7 @@
 async function createTable(datasetId, tableId, schema, projectId) {
   // [START bigquery_create_table]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -46,7 +46,7 @@ async function createTable(datasetId, tableId, schema, projectId) {
 async function deleteTable(datasetId, tableId, projectId) {
   // [START bigquery_delete_table]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -71,7 +71,7 @@ async function deleteTable(datasetId, tableId, projectId) {
 async function listTables(datasetId, projectId) {
   // [START bigquery_list_tables]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -93,7 +93,7 @@ async function listTables(datasetId, projectId) {
 async function browseRows(datasetId, tableId, projectId) {
   // [START bigquery_browse_table]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -125,7 +125,7 @@ async function copyTable(
 ) {
   // [START bigquery_copy_table]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -158,7 +158,7 @@ async function copyTable(
 async function loadLocalFile(datasetId, tableId, filename, projectId) {
   // [START bigquery_load_from_file]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -190,7 +190,7 @@ async function loadLocalFile(datasetId, tableId, filename, projectId) {
 async function loadORCFromGCS(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_orc]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -239,7 +239,7 @@ async function loadORCFromGCS(datasetId, tableId, projectId) {
 async function loadParquetFromGCS(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_parquet]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -288,7 +288,7 @@ async function loadParquetFromGCS(datasetId, tableId, projectId) {
 function loadCSVFromGCS(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_csv]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -355,7 +355,7 @@ function loadCSVFromGCS(datasetId, tableId, projectId) {
 function loadJSONFromGCS(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_json]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -421,7 +421,7 @@ function loadJSONFromGCS(datasetId, tableId, projectId) {
 function loadCSVFromGCSAutodetect(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_csv_autodetect]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -483,7 +483,7 @@ function loadCSVFromGCSAutodetect(datasetId, tableId, projectId) {
 function loadJSONFromGCSAutodetect(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_json_autodetect]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -544,7 +544,7 @@ function loadJSONFromGCSAutodetect(datasetId, tableId, projectId) {
 function loadCSVFromGCSTruncate(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_csv_truncate]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -613,7 +613,7 @@ function loadCSVFromGCSTruncate(datasetId, tableId, projectId) {
 function loadJSONFromGCSTruncate(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_json_truncate]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -681,7 +681,7 @@ function loadJSONFromGCSTruncate(datasetId, tableId, projectId) {
 function loadParquetFromGCSTruncate(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_parquet_truncate]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -743,7 +743,7 @@ function loadParquetFromGCSTruncate(datasetId, tableId, projectId) {
 function loadOrcFromGCSTruncate(datasetId, tableId, projectId) {
   // [START bigquery_load_table_gcs_orc_truncate]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -811,7 +811,7 @@ function extractTableToGCS(
 ) {
   // [START bigquery_extract_table]
   // Imports the Google Cloud client libraries
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
   const {Storage} = require('@google-cloud/storage');
 
   /**
@@ -858,7 +858,7 @@ function extractTableToGCS(
 function insertRowsAsStream(datasetId, tableId, rows, projectId) {
   // [START bigquery_table_insert_rows]
   // Imports the Google Cloud client library
-  const BigQuery = require('@google-cloud/bigquery');
+  const {BigQuery} = require('@google-cloud/bigquery');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -283,7 +283,9 @@ class Dataset extends ServiceObject {
    * @param {function} [callback] See {@link BigQuery#createQueryJob} for full documentation of this method.
    * @returns {Promise} See {@link BigQuery#createQueryJob} for full documentation of this method.
    */
-  createQueryJob(options, callback) {
+  createQueryJob(options): Promise<any>;
+  createQueryJob(options, callback): void;
+  createQueryJob(options, callback?): void|Promise<any> {
     if (is.string(options)) {
       options = {
         query: options,
@@ -508,7 +510,10 @@ class Dataset extends ServiceObject {
    *   const tables = data[0];
    * });
    */
-  getTables(options, callback) {
+  getTables(options?): Promise<any>;
+  getTables(options, callback): void;
+  getTables(callback): void;
+  getTables(options?, callback?): void|Promise<any> {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -592,7 +597,7 @@ class Dataset extends ServiceObject {
    *
    * const institutions = dataset.table('institution_data');
    */
-  table(id, options) {
+  table(id, options?) {
     options = extend(
       {
         location: this.location,

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -40,7 +40,7 @@ export interface DatasetDeleteOptions {
  *      Defaults to US.
  *
  * @example
- * const BigQuery = require('@google-cloud/bigquery');
+ * const {BigQuery} = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  * const dataset = bigquery.dataset('institutions');
  */
@@ -60,7 +60,7 @@ class Dataset extends ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('institutions');
        * dataset.create((err, dataset, apiResponse) => {
@@ -90,7 +90,7 @@ class Dataset extends ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('institutions');
        * dataset.exists((err, exists) => {});
@@ -123,7 +123,7 @@ class Dataset extends ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('institutions');
        * dataset.get((err, dataset, apiResponse) => {
@@ -156,7 +156,7 @@ class Dataset extends ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('institutions');
        * dataset.getMetadata((err, metadata, apiResponse) => {});
@@ -185,7 +185,7 @@ class Dataset extends ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('institutions');
        *
@@ -248,7 +248,7 @@ class Dataset extends ServiceObject {
      * @return {stream}
      *
      * @example
-     * const BigQuery = require('@google-cloud/bigquery');
+     * const {BigQuery} = require('@google-cloud/bigquery');
      * const bigquery = new BigQuery();
      * const dataset = bigquery.dataset('institutions');
      *
@@ -350,7 +350,7 @@ class Dataset extends ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('institutions');
    *
@@ -420,7 +420,7 @@ class Dataset extends ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('institutions');
    *
@@ -480,7 +480,7 @@ class Dataset extends ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('institutions');
    *
@@ -591,7 +591,7 @@ class Dataset extends ServiceObject {
    * @return {Table}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('institutions');
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ import { Table } from './table';
  * npm install --save @google-cloud/bigquery
  *
  * @example <caption>Import the client library</caption>
- * const BigQuery = require('@google-cloud/bigquery');
+ * const {BigQuery} = require('@google-cloud/bigquery');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const bigquery = new BigQuery();
@@ -232,7 +232,7 @@ export class BigQuery extends common.Service {
    * @param {string|number} value.day One or two digits.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const date = BigQuery.date('2017-01-01');
    *
    * //-
@@ -261,7 +261,7 @@ export class BigQuery extends common.Service {
    * @param {string|number} value.day One or two digits.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const date = bigquery.date('2017-01-01');
    *
@@ -301,7 +301,7 @@ export class BigQuery extends common.Service {
    *     precision.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const datetime = BigQuery.datetime('2017-01-01 13:00:00');
    *
    * //-
@@ -336,7 +336,7 @@ export class BigQuery extends common.Service {
    *     precision.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const datetime = bigquery.datetime('2017-01-01 13:00:00');
    *
@@ -374,7 +374,7 @@ export class BigQuery extends common.Service {
    *     precision.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const time = BigQuery.time('14:00:00'); // 2:00 PM
    *
    * //-
@@ -401,7 +401,7 @@ export class BigQuery extends common.Service {
    *     precision.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const time = bigquery.time('14:00:00'); // 2:00 PM
    *
@@ -430,7 +430,7 @@ export class BigQuery extends common.Service {
    * @param {date} value The time.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const timestamp = BigQuery.timestamp(new Date());
    */
 
@@ -442,7 +442,7 @@ export class BigQuery extends common.Service {
    * @param {date} value The time.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const timestamp = bigquery.timestamp(new Date());
    */
@@ -581,7 +581,7 @@ export class BigQuery extends common.Service {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * bigquery.createDataset('my-dataset', function(err, dataset, apiResponse) {});
@@ -668,7 +668,7 @@ export class BigQuery extends common.Service {
    * @throws {Error} If a Table is not provided as a destination.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
@@ -800,7 +800,7 @@ export class BigQuery extends common.Service {
    * @returns {stream}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
@@ -854,7 +854,7 @@ export class BigQuery extends common.Service {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const options = {
@@ -947,7 +947,7 @@ export class BigQuery extends common.Service {
    * @returns {Dataset}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('higher_education');
    */
@@ -978,7 +978,7 @@ export class BigQuery extends common.Service {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * bigquery.getDatasets(function(err, datasets) {
@@ -1062,7 +1062,7 @@ export class BigQuery extends common.Service {
    * @returns {stream}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * bigquery.getDatasetsStream()
@@ -1112,7 +1112,7 @@ export class BigQuery extends common.Service {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * bigquery.getJobs(function(err, jobs) {
@@ -1196,7 +1196,7 @@ export class BigQuery extends common.Service {
    * @returns {stream}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * bigquery.getJobsStream()
@@ -1228,7 +1228,7 @@ export class BigQuery extends common.Service {
    * @returns {Job}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const myExistingJob = bigquery.job('job-id');
@@ -1274,7 +1274,7 @@ export class BigQuery extends common.Service {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
@@ -1472,7 +1472,7 @@ export { Table };
  * npm install --save @google-cloud/bigquery
  *
  * @example <caption>Import the client library</caption>
- * const BigQuery = require('@google-cloud/bigquery');
+ * const {BigQuery} = require('@google-cloud/bigquery');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const bigquery = new BigQuery();

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,18 +19,17 @@
 import * as arrify from 'arrify';
 import * as Big from 'big.js';
 import * as common from '@google-cloud/common';
-import {promisifyAll} from '@google-cloud/promisify';
-import {paginator} from '@google-cloud/paginator';
+import { promisifyAll } from '@google-cloud/promisify';
+import { paginator } from '@google-cloud/paginator';
 import * as extend from 'extend';
 const format = require('string-format-obj');
 import * as is from 'is';
 import * as request from 'request';
-import * as util from 'util';
 import * as uuid from 'uuid';
 
-import {Dataset} from './dataset';
-import {Job} from './job';
-import {Table} from './table';
+import { Dataset } from './dataset';
+import { Job } from './job';
+import { Table } from './table';
 
 /**
  * @typedef {object} ClientConfig
@@ -97,1300 +96,1269 @@ import {Table} from './table';
  * region_tag:bigquery_quickstart
  * Full quickstart example:
  */
-function BigQuery(options) {
-  options = options || {};
-  const config = {
-    baseUrl: 'https://www.googleapis.com/bigquery/v2',
-    scopes: ['https://www.googleapis.com/auth/bigquery'],
-    packageJson: require('../../package.json'),
-    requestModule: request,
-  };
+export class BigQuery extends common.Service {
+  location: string;
+  createQueryStream;
+  getDatasetsStream;
+  getJobsStream;
+  constructor(options?) {
+    options = options || {};
+    const config = {
+      baseUrl: 'https://www.googleapis.com/bigquery/v2',
+      scopes: ['https://www.googleapis.com/auth/bigquery'],
+      packageJson: require('../../package.json'),
+      requestModule: request,
+    };
 
-  if (options.scopes) {
-    config.scopes = config.scopes.concat(options.scopes);
+    if (options.scopes) {
+      config.scopes = config.scopes.concat(options.scopes);
+    }
+
+    super(config, options);
+
+    /**
+     * @name BigQuery#location
+     * @type {string}
+     */
+    this.location = options.location;
+    this.createQueryStream = paginator.streamify('queryAsStream_');
+    this.getDatasetsStream = paginator.streamify('getDatasets');
+    this.getJobsStream = paginator.streamify('getJobs');
   }
-
-  common.Service.call(this, config, options);
 
   /**
-   * @name BigQuery#location
-   * @type {string}
+   * Merge a rowset returned from the API with a table schema.
+   *
+   * @private
+   *
+   * @param {object} schema
+   * @param {array} rows
+   * @returns {array} Fields using their matching names from the table's schema.
    */
-  this.location = options.location;
-}
+  static mergeSchemaWithRows_(schema, rows) {
+    return arrify(rows)
+      .map(mergeSchema)
+      .map(flattenRows);
 
-util.inherits(BigQuery, common.Service);
+    function mergeSchema(row) {
+      return row.f.map(function (field, index) {
+        const schemaField = schema.fields[index];
+        let value = field.v;
 
-/**
- * Merge a rowset returned from the API with a table schema.
- *
- * @private
- *
- * @param {object} schema
- * @param {array} rows
- * @returns {array} Fields using their matching names from the table's schema.
- */
-(BigQuery as any).mergeSchemaWithRows_ = BigQuery.prototype.mergeSchemaWithRows_ = function(
-  schema,
-  rows
-) {
-  return arrify(rows)
-    .map(mergeSchema)
-    .map(flattenRows);
+        if (schemaField.mode === 'REPEATED') {
+          value = value.map(function (val) {
+            return convert(schemaField, val.v);
+          });
+        } else {
+          value = convert(schemaField, value);
+        }
 
-  function mergeSchema(row) {
-    return row.f.map(function(field, index) {
-      const schemaField = schema.fields[index];
-      let value = field.v;
+        const fieldObject = {};
+        fieldObject[schemaField.name] = value;
+        return fieldObject;
+      });
+    }
 
-      if (schemaField.mode === 'REPEATED') {
-        value = value.map(function(val) {
-          return convert(schemaField, val.v);
-        });
-      } else {
-        value = convert(schemaField, value);
+    function convert(schemaField, value) {
+      if (is.nil(value)) {
+        return value;
       }
 
-      const fieldObject = {};
-      fieldObject[schemaField.name] = value;
-      return fieldObject;
-    });
-  }
+      switch (schemaField.type) {
+        case 'BOOLEAN':
+        case 'BOOL': {
+          value = value.toLowerCase() === 'true';
+          break;
+        }
+        case 'BYTES': {
+          value = Buffer.from(value, 'base64');
+          break;
+        }
+        case 'FLOAT':
+        case 'FLOAT64': {
+          value = parseFloat(value);
+          break;
+        }
+        case 'INTEGER':
+        case 'INT64': {
+          value = parseInt(value, 10);
+          break;
+        }
+        case 'NUMERIC': {
+          value = new Big(value);
+          break;
+        }
+        case 'RECORD': {
+          value = BigQuery.mergeSchemaWithRows_(schemaField, value).pop();
+          break;
+        }
+        case 'DATE': {
+          value = BigQuery.date(value);
+          break;
+        }
+        case 'DATETIME': {
+          value = BigQuery.datetime(value);
+          break;
+        }
+        case 'TIME': {
+          value = BigQuery.time(value);
+          break;
+        }
+        case 'TIMESTAMP': {
+          value = BigQuery.timestamp(new Date(value * 1000));
+          break;
+        }
+      }
 
-  function convert(schemaField, value) {
-    if (is.nil(value)) {
       return value;
     }
 
-    switch (schemaField.type) {
-      case 'BOOLEAN':
-      case 'BOOL': {
-        value = value.toLowerCase() === 'true';
-        break;
-      }
-      case 'BYTES': {
-        value = Buffer.from(value, 'base64');
-        break;
-      }
-      case 'FLOAT':
-      case 'FLOAT64': {
-        value = parseFloat(value);
-        break;
-      }
-      case 'INTEGER':
-      case 'INT64': {
-        value = parseInt(value, 10);
-        break;
-      }
-      case 'NUMERIC': {
-        value = new Big(value);
-        break;
-      }
-      case 'RECORD': {
-        value = (BigQuery as any).mergeSchemaWithRows_(schemaField, value).pop();
-        break;
-      }
-      case 'DATE': {
-        value = (BigQuery as any).date(value);
-        break;
-      }
-      case 'DATETIME': {
-        value = (BigQuery as any).datetime(value);
-        break;
-      }
-      case 'TIME': {
-        value = (BigQuery as any).time(value);
-        break;
-      }
-      case 'TIMESTAMP': {
-        value = (BigQuery as any).timestamp(new Date(value * 1000));
-        break;
-      }
+    function flattenRows(rows) {
+      return rows.reduce(function (acc, row) {
+        const key = Object.keys(row)[0];
+        acc[key] = row[key];
+        return acc;
+      }, {});
     }
-
-    return value;
   }
 
-  function flattenRows(rows) {
-    return rows.reduce(function(acc, row) {
-      const key = Object.keys(row)[0];
-      acc[key] = row[key];
-      return acc;
-    }, {});
-  }
-};
+  /**
+   * @method BigQuery.date
+   * @param {object|string} value The date. If a string, this should be in the
+   *     format the API describes: `YYYY-[M]M-[D]D`.
+   *     Otherwise, provide an object.
+   * @param {string|number} value.year Four digits.
+   * @param {string|number} value.month One or two digits.
+   * @param {string|number} value.day One or two digits.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const date = BigQuery.date('2017-01-01');
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const date2 = BigQuery.date({
+   *   year: 2017,
+   *   month: 1,
+   *   day: 1
+   * });
+   */
 
-/**
- * @method BigQuery.date
- * @param {object|string} value The date. If a string, this should be in the
- *     format the API describes: `YYYY-[M]M-[D]D`.
- *     Otherwise, provide an object.
- * @param {string|number} value.year Four digits.
- * @param {string|number} value.month One or two digits.
- * @param {string|number} value.day One or two digits.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const date = BigQuery.date('2017-01-01');
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const date2 = BigQuery.date({
- *   year: 2017,
- *   month: 1,
- *   day: 1
- * });
- */
-
-/**
- * The `DATE` type represents a logical calendar date, independent of time zone.
- * It does not represent a specific 24-hour time period. Rather, a given DATE
- * value represents a different 24-hour period when interpreted in different
- * time zones, and may represent a shorter or longer day during Daylight Savings
- * Time transitions.
- *
- * @method BigQuery#date
- * @param {object|string} value The date. If a string, this should be in the
- *     format the API describes: `YYYY-[M]M-[D]D`.
- *     Otherwise, provide an object.
- * @param {string|number} value.year Four digits.
- * @param {string|number} value.month One or two digits.
- * @param {string|number} value.day One or two digits.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- * const date = bigquery.date('2017-01-01');
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const date2 = bigquery.date({
- *   year: 2017,
- *   month: 1,
- *   day: 1
- * });
- */
-(BigQuery as any).date = BigQuery.prototype.date = function BigQueryDate(value) {
-  if (!(this instanceof (BigQuery as any).date)) {
-    return new (BigQuery as any).date(value);
+  /**
+   * The `DATE` type represents a logical calendar date, independent of time zone.
+   * It does not represent a specific 24-hour time period. Rather, a given DATE
+   * value represents a different 24-hour period when interpreted in different
+   * time zones, and may represent a shorter or longer day during Daylight Savings
+   * Time transitions.
+   *
+   * @method BigQuery#date
+   * @param {object|string} value The date. If a string, this should be in the
+   *     format the API describes: `YYYY-[M]M-[D]D`.
+   *     Otherwise, provide an object.
+   * @param {string|number} value.year Four digits.
+   * @param {string|number} value.month One or two digits.
+   * @param {string|number} value.day One or two digits.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   * const date = bigquery.date('2017-01-01');
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const date2 = bigquery.date({
+   *   year: 2017,
+   *   month: 1,
+   *   day: 1
+   * });
+   */
+  static date(value) {
+    return new BigQueryDate(value);
   }
 
-  if (is.object(value)) {
-    value = (BigQuery as any).datetime(value).value;
+  date(value) {
+    return BigQuery.date(value);
   }
 
-  this.value = value;
-};
+  /**
+   * A `DATETIME` data type represents a point in time. Unlike a `TIMESTAMP`,
+   * this does not refer to an absolute instance in time. Instead, it is the civil
+   * time, or the time that a user would see on a watch or calendar.
+   *
+   * @method BigQuery.datetime
+   * @param {object|string} value The time. If a string, this should be in the
+   *     format the API describes: `YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]`.
+   *     Otherwise, provide an object.
+   * @param {string|number} value.year Four digits.
+   * @param {string|number} value.month One or two digits.
+   * @param {string|number} value.day One or two digits.
+   * @param {string|number} [value.hours] One or two digits (`00` - `23`).
+   * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
+   * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
+   * @param {string|number} [value.fractional] Up to six digits for microsecond
+   *     precision.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const datetime = BigQuery.datetime('2017-01-01 13:00:00');
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const datetime = BigQuery.datetime({
+   *   year: 2017,
+   *   month: 1,
+   *   day: 1,
+   *   hours: 14,
+   *   minutes: 0,
+   *   seconds: 0
+   * });
+   */
 
-/**
- * A `DATETIME` data type represents a point in time. Unlike a `TIMESTAMP`,
- * this does not refer to an absolute instance in time. Instead, it is the civil
- * time, or the time that a user would see on a watch or calendar.
- *
- * @method BigQuery.datetime
- * @param {object|string} value The time. If a string, this should be in the
- *     format the API describes: `YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]`.
- *     Otherwise, provide an object.
- * @param {string|number} value.year Four digits.
- * @param {string|number} value.month One or two digits.
- * @param {string|number} value.day One or two digits.
- * @param {string|number} [value.hours] One or two digits (`00` - `23`).
- * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
- * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
- * @param {string|number} [value.fractional] Up to six digits for microsecond
- *     precision.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const datetime = BigQuery.datetime('2017-01-01 13:00:00');
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const datetime = BigQuery.datetime({
- *   year: 2017,
- *   month: 1,
- *   day: 1,
- *   hours: 14,
- *   minutes: 0,
- *   seconds: 0
- * });
- */
-
-/**
- * A `DATETIME` data type represents a point in time. Unlike a `TIMESTAMP`,
- * this does not refer to an absolute instance in time. Instead, it is the civil
- * time, or the time that a user would see on a watch or calendar.
- *
- * @method BigQuery#datetime
- * @param {object|string} value The time. If a string, this should be in the
- *     format the API describes: `YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]`.
- *     Otherwise, provide an object.
- * @param {string|number} value.year Four digits.
- * @param {string|number} value.month One or two digits.
- * @param {string|number} value.day One or two digits.
- * @param {string|number} [value.hours] One or two digits (`00` - `23`).
- * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
- * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
- * @param {string|number} [value.fractional] Up to six digits for microsecond
- *     precision.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- * const datetime = bigquery.datetime('2017-01-01 13:00:00');
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const datetime = bigquery.datetime({
- *   year: 2017,
- *   month: 1,
- *   day: 1,
- *   hours: 14,
- *   minutes: 0,
- *   seconds: 0
- * });
- */
-(BigQuery as any).datetime = BigQuery.prototype.datetime = function BigQueryDatetime(
-  value
-) {
-  if (!(this instanceof (BigQuery as any).datetime)) {
-    return new (BigQuery as any).datetime(value);
+  /**
+   * A `DATETIME` data type represents a point in time. Unlike a `TIMESTAMP`,
+   * this does not refer to an absolute instance in time. Instead, it is the civil
+   * time, or the time that a user would see on a watch or calendar.
+   *
+   * @method BigQuery#datetime
+   * @param {object|string} value The time. If a string, this should be in the
+   *     format the API describes: `YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]`.
+   *     Otherwise, provide an object.
+   * @param {string|number} value.year Four digits.
+   * @param {string|number} value.month One or two digits.
+   * @param {string|number} value.day One or two digits.
+   * @param {string|number} [value.hours] One or two digits (`00` - `23`).
+   * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
+   * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
+   * @param {string|number} [value.fractional] Up to six digits for microsecond
+   *     precision.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   * const datetime = bigquery.datetime('2017-01-01 13:00:00');
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const datetime = bigquery.datetime({
+   *   year: 2017,
+   *   month: 1,
+   *   day: 1,
+   *   hours: 14,
+   *   minutes: 0,
+   *   seconds: 0
+   * });
+   */
+  static datetime(value) {
+    return new BigQueryDatetime(value);
   }
 
-  if (is.object(value)) {
-    let time;
-
-    if (value.hours) {
-      time = (BigQuery as any).time(value).value;
-    }
-
-    value = format('{y}-{m}-{d}{time}', {
-      y: value.year,
-      m: value.month,
-      d: value.day,
-      time: time ? ' ' + time : '',
-    });
-  } else {
-    value = value.replace(/^(.*)T(.*)Z$/, '$1 $2');
+  datetime(value) {
+    return BigQuery.datetime(value);
   }
 
-  this.value = value;
-};
+  /**
+   * A `TIME` data type represents a time, independent of a specific date.
+   *
+   * @method BigQuery.time
+   * @param {object|string} value The time. If a string, this should be in the
+   *     format the API describes: `[H]H:[M]M:[S]S[.DDDDDD]`. Otherwise, provide
+   *     an object.
+   * @param {string|number} [value.hours] One or two digits (`00` - `23`).
+   * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
+   * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
+   * @param {string|number} [value.fractional] Up to six digits for microsecond
+   *     precision.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const time = BigQuery.time('14:00:00'); // 2:00 PM
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const time = BigQuery.time({
+   *   hours: 14,
+   *   minutes: 0,
+   *   seconds: 0
+   * });
+   */
 
-/**
- * A `TIME` data type represents a time, independent of a specific date.
- *
- * @method BigQuery.time
- * @param {object|string} value The time. If a string, this should be in the
- *     format the API describes: `[H]H:[M]M:[S]S[.DDDDDD]`. Otherwise, provide
- *     an object.
- * @param {string|number} [value.hours] One or two digits (`00` - `23`).
- * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
- * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
- * @param {string|number} [value.fractional] Up to six digits for microsecond
- *     precision.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const time = BigQuery.time('14:00:00'); // 2:00 PM
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const time = BigQuery.time({
- *   hours: 14,
- *   minutes: 0,
- *   seconds: 0
- * });
- */
-
-/**
- * A `TIME` data type represents a time, independent of a specific date.
- *
- * @method BigQuery#time
- * @param {object|string} value The time. If a string, this should be in the
- *     format the API describes: `[H]H:[M]M:[S]S[.DDDDDD]`. Otherwise, provide
- *     an object.
- * @param {string|number} [value.hours] One or two digits (`00` - `23`).
- * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
- * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
- * @param {string|number} [value.fractional] Up to six digits for microsecond
- *     precision.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- * const time = bigquery.time('14:00:00'); // 2:00 PM
- *
- * //-
- * // Alternatively, provide an object.
- * //-
- * const time = bigquery.time({
- *   hours: 14,
- *   minutes: 0,
- *   seconds: 0
- * });
- */
-(BigQuery as any).time = BigQuery.prototype.time = function BigQueryTime(value) {
-  if (!(this instanceof (BigQuery as any).time)) {
-    return new (BigQuery as any).time(value);
+  /**
+   * A `TIME` data type represents a time, independent of a specific date.
+   *
+   * @method BigQuery#time
+   * @param {object|string} value The time. If a string, this should be in the
+   *     format the API describes: `[H]H:[M]M:[S]S[.DDDDDD]`. Otherwise, provide
+   *     an object.
+   * @param {string|number} [value.hours] One or two digits (`00` - `23`).
+   * @param {string|number} [value.minutes] One or two digits (`00` - `59`).
+   * @param {string|number} [value.seconds] One or two digits (`00` - `59`).
+   * @param {string|number} [value.fractional] Up to six digits for microsecond
+   *     precision.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   * const time = bigquery.time('14:00:00'); // 2:00 PM
+   *
+   * //-
+   * // Alternatively, provide an object.
+   * //-
+   * const time = bigquery.time({
+   *   hours: 14,
+   *   minutes: 0,
+   *   seconds: 0
+   * });
+   */
+  static time(value) {
+    return new BigQueryTime(value);
   }
 
-  if (is.object(value)) {
-    value = format('{h}:{m}:{s}{f}', {
-      h: value.hours,
-      m: value.minutes || 0,
-      s: value.seconds || 0,
-      f: is.defined(value.fractional) ? '.' + value.fractional : '',
-    });
+  time(value) {
+    return BigQuery.time(value);
   }
 
-  this.value = value;
-};
+  /**
+   * A timestamp represents an absolute point in time, independent of any time
+   * zone or convention such as Daylight Savings Time.
+   *
+   * @method BigQuery.timestamp
+   * @param {date} value The time.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const timestamp = BigQuery.timestamp(new Date());
+   */
 
-/**
- * A timestamp represents an absolute point in time, independent of any time
- * zone or convention such as Daylight Savings Time.
- *
- * @method BigQuery.timestamp
- * @param {date} value The time.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const timestamp = BigQuery.timestamp(new Date());
- */
-
-/**
- * A timestamp represents an absolute point in time, independent of any time
- * zone or convention such as Daylight Savings Time.
- *
- * @method BigQuery#timestamp
- * @param {date} value The time.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- * const timestamp = bigquery.timestamp(new Date());
- */
-(BigQuery as any).timestamp = BigQuery.prototype.timestamp = function BigQueryTimestamp(
-  value
-) {
-  if (!(this instanceof (BigQuery as any).timestamp)) {
-    return new (BigQuery as any).timestamp(value);
+  /**
+   * A timestamp represents an absolute point in time, independent of any time
+   * zone or convention such as Daylight Savings Time.
+   *
+   * @method BigQuery#timestamp
+   * @param {date} value The time.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   * const timestamp = bigquery.timestamp(new Date());
+   */
+  static timestamp(value) {
+    return new BigQueryTimestamp(value);
   }
 
-  this.value = new Date(value).toJSON();
-};
-
-/**
- * Detect a value's type.
- *
- * @private
- *
- * @throws {error} If the type could not be detected.
- *
- * @see [Data Type]{@link https://cloud.google.com/bigquery/data-types}
- *
- * @param {*} value The value.
- * @returns {string} The type detected from the value.
- */
-(BigQuery as any).getType_ = function(value) {
-  let typeName;
-
-  if (value instanceof (BigQuery as any).date) {
-    typeName = 'DATE';
-  } else if (value instanceof (BigQuery as any).datetime) {
-    typeName = 'DATETIME';
-  } else if (value instanceof (BigQuery as any).time) {
-    typeName = 'TIME';
-  } else if (value instanceof (BigQuery as any).timestamp) {
-    typeName = 'TIMESTAMP';
-  } else if (value instanceof Buffer) {
-    typeName = 'BYTES';
-  } else if (value instanceof Big) {
-    typeName = 'NUMERIC';
-  } else if (is.array(value)) {
-    return {
-      type: 'ARRAY',
-      arrayType: (BigQuery as any).getType_(value[0]),
-    };
-  } else if (is.bool(value)) {
-    typeName = 'BOOL';
-  } else if (is.number(value)) {
-    typeName = value % 1 === 0 ? 'INT64' : 'FLOAT64';
-  } else if (is.object(value)) {
-    return {
-      type: 'STRUCT',
-      structTypes: Object.keys(value).map(function(prop) {
-        return {
-          name: prop,
-          type: (BigQuery as any).getType_(value[prop]),
-        };
-      }),
-    };
-  } else if (is.string(value)) {
-    typeName = 'STRING';
+  timestamp(value) {
+    return BigQuery.timestamp(value);
   }
 
-  if (!typeName) {
-    throw new Error(
-      [
-        'This value could not be translated to a BigQuery data type.',
-        value,
-      ].join('\n')
-    );
-  }
+  /**
+   * Detect a value's type.
+   *
+   * @private
+   *
+   * @throws {error} If the type could not be detected.
+   *
+   * @see [Data Type]{@link https://cloud.google.com/bigquery/data-types}
+   *
+   * @param {*} value The value.
+   * @returns {string} The type detected from the value.
+   */
+  static getType_(value) {
+    let typeName;
 
-  return {
-    type: typeName,
-  };
-};
-
-/**
- * Convert a value into a `queryParameter` object.
- *
- * @private
- *
- * @see [Jobs.query API Reference Docs (see `queryParameters`)]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#request-body}
- *
- * @param {*} value The value.
- * @returns {object} A properly-formed `queryParameter` object.
- */
-(BigQuery as any).valueToQueryParameter_ = function(value) {
-  if (is.date(value)) {
-    value = (BigQuery as any).timestamp(value);
-  }
-
-  const queryParameter = {
-    parameterType: (BigQuery as any).getType_(value),
-    parameterValue: {} as any,
-  };
-
-  const typeName = queryParameter.parameterType.type;
-
-  if (typeName.indexOf('TIME') > -1 || typeName.indexOf('DATE') > -1) {
-    value = value.value;
-  }
-
-  if (typeName === 'ARRAY') {
-    queryParameter.parameterValue.arrayValues = value.map(function(value) {
+    if (value instanceof BigQueryDate) {
+      typeName = 'DATE';
+    } else if (value instanceof BigQueryDatetime) {
+      typeName = 'DATETIME';
+    } else if (value instanceof BigQueryTime) {
+      typeName = 'TIME';
+    } else if (value instanceof BigQueryTimestamp) {
+      typeName = 'TIMESTAMP';
+    } else if (value instanceof Buffer) {
+      typeName = 'BYTES';
+    } else if (value instanceof Big) {
+      typeName = 'NUMERIC';
+    } else if (is.array(value)) {
       return {
-        value,
+        type: 'ARRAY',
+        arrayType: BigQuery.getType_(value[0]),
       };
-    });
-  } else if (typeName === 'STRUCT') {
-    queryParameter.parameterValue.structValues = Object.keys(value).reduce(
-      function(structValues, prop) {
-        const nestedQueryParameter = (BigQuery as any).valueToQueryParameter_(value[prop]);
-        structValues[prop] = nestedQueryParameter.parameterValue;
-        return structValues;
-      },
-      {}
-    );
-  } else {
-    queryParameter.parameterValue.value = value;
+    } else if (is.bool(value)) {
+      typeName = 'BOOL';
+    } else if (is.number(value)) {
+      typeName = value % 1 === 0 ? 'INT64' : 'FLOAT64';
+    } else if (is.object(value)) {
+      return {
+        type: 'STRUCT',
+        structTypes: Object.keys(value).map(prop => {
+          return {
+            name: prop,
+            type: BigQuery.getType_(value[prop]),
+          };
+        }),
+      };
+    } else if (is.string(value)) {
+      typeName = 'STRING';
+    }
+
+    if (!typeName) {
+      throw new Error(
+        [
+          'This value could not be translated to a BigQuery data type.',
+          value,
+        ].join('\n')
+      );
+    }
+
+    return {
+      type: typeName,
+    };
   }
 
-  return queryParameter;
-};
+  /**
+   * Convert a value into a `queryParameter` object.
+   *
+   * @private
+   *
+   * @see [Jobs.query API Reference Docs (see `queryParameters`)]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#request-body}
+   *
+   * @param {*} value The value.
+   * @returns {object} A properly-formed `queryParameter` object.
+   */
+  static valueToQueryParameter_(value) {
+    if (is.date(value)) {
+      value = BigQuery.timestamp(value);
+    }
 
-/**
- * Create a dataset.
- *
- * @see [Datasets: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/datasets/insert}
- *
- * @param {string} id ID of the dataset to create.
- * @param {object} [options] See a
- *     [Dataset resource](https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource).
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request
- * @param {Dataset} callback.dataset The newly created dataset
- * @param {object} callback.apiResponse The full API response.
- * @returns {Promise}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * bigquery.createDataset('my-dataset', function(err, dataset, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.createDataset('my-dataset').then(function(data) {
- *   const dataset = data[0];
- *   const apiResponse = data[1];
- * });
- */
-BigQuery.prototype.createDataset = function(id, options, callback) {
-  const that = this;
+    const queryParameter = {
+      parameterType: BigQuery.getType_(value),
+      parameterValue: {} as any,
+    };
 
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
+    const typeName = queryParameter.parameterType.type;
 
-  this.request(
-    {
-      method: 'POST',
-      uri: '/datasets',
-      json: extend(
-        true,
-        {
-          location: this.location,
+    if (typeName.indexOf('TIME') > -1 || typeName.indexOf('DATE') > -1) {
+      value = value.value;
+    }
+
+    if (typeName === 'ARRAY') {
+      queryParameter.parameterValue.arrayValues = value.map(function (value) {
+        return {
+          value,
+        };
+      });
+    } else if (typeName === 'STRUCT') {
+      queryParameter.parameterValue.structValues = Object.keys(value).reduce(
+        function (structValues, prop) {
+          const nestedQueryParameter = BigQuery.valueToQueryParameter_(value[prop]);
+          structValues[prop] = nestedQueryParameter.parameterValue;
+          return structValues;
         },
-        options,
-        {
-          datasetReference: {
-            datasetId: id,
-          },
-        }
-      ),
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
-
-      const dataset = that.dataset(id);
-      dataset.metadata = resp;
-
-      callback(null, dataset, resp);
-    }
-  );
-};
-
-/**
- * Run a query as a job. No results are immediately returned. Instead, your
- * callback will be executed with a {@link Job} object that you must
- * ping for the results. See the Job documentation for explanations of how to
- * check on the status of the job.
- *
- * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
- *
- * @param {object|string} options The configuration object. This must be in
- *     the format of the [`configuration.query`](http://goo.gl/wRpHvR) property
- *     of a Jobs resource. If a string is provided, this is used as the query
- *     string, and all other options are defaulted.
- * @param {Table} [options.destination] The table to save the
- *     query's results to. If omitted, a new table will be created.
- * @param {boolean} [options.dryRun] If set, don't actually run this job. A
- *     valid query will update the job with processing statistics. These can be
- *     accessed via `job.metadata`.
- * @param {string} [options.location] The geographic location of the job.
- *     Required except for US and EU.
- * @param {string} [options.jobId] Custom job id.
- * @param {string} [options.jobPrefix] Prefix to apply to the job id.
- * @param {string} options.query A query string, following the BigQuery query
- *     syntax, of the query to execute.
- * @param {boolean} [options.useLegacySql=false] Option to use legacy sql syntax.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Job} callback.job The newly created job for your
-       query.
- * @param {object} callback.apiResponse The full API response.
- * @returns {Promise}
- *
- * @throws {Error} If a query is not specified.
- * @throws {Error} If a Table is not provided as a destination.
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
- *
- * //-
- * // You may pass only a query string, having a new table created to store the
- * // results of the query.
- * //-
- * bigquery.createQueryJob(query, function(err, job) {});
- *
- * //-
- * // You can also control the destination table by providing a
- * // {@link Table} object.
- * //-
- * bigquery.createQueryJob({
- *   destination: bigquery.dataset('higher_education').table('institutions'),
- *   query: query
- * }, function(err, job) {});
- *
- * //-
- * // After you have run `createQueryJob`, your query will execute in a job. Your
- * // callback is executed with a {@link Job} object so that you may
- * // check for the results.
- * //-
- * bigquery.createQueryJob(query, function(err, job) {
- *   if (!err) {
- *     job.getQueryResults(function(err, rows, apiResponse) {});
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.createQueryJob(query).then(function(data) {
- *   const job = data[0];
- *   const apiResponse = data[1];
- *
- *   return job.getQueryResults();
- * });
- */
-BigQuery.prototype.createQueryJob = function(options, callback) {
-  if (is.string(options)) {
-    options = {
-      query: options,
-    };
-  }
-
-  if (!options || !options.query) {
-    throw new Error('A SQL query string is required.');
-  }
-
-  const query = extend(
-    true,
-    {
-      useLegacySql: false,
-    },
-    options
-  );
-
-  if (options.destination) {
-    if (!(options.destination instanceof Table)) {
-      throw new Error('Destination must be a Table object.');
-    }
-
-    query.destinationTable = {
-      datasetId: options.destination.dataset.id,
-      projectId: options.destination.dataset.bigQuery.projectId,
-      tableId: options.destination.id,
-    };
-
-    delete query.destination;
-  }
-
-  if (query.params) {
-    query.parameterMode = is.array(query.params) ? 'positional' : 'named';
-
-    if (query.parameterMode === 'named') {
-      query.queryParameters = [];
-
-      for (const namedParamater in query.params) {
-        const value = query.params[namedParamater];
-        const queryParameter = (BigQuery as any).valueToQueryParameter_(value);
-        queryParameter.name = namedParamater;
-        query.queryParameters.push(queryParameter);
-      }
+        {}
+      );
     } else {
-      query.queryParameters = query.params.map((BigQuery as any).valueToQueryParameter_);
+      queryParameter.parameterValue.value = value;
     }
 
-    delete query.params;
+    return queryParameter;
   }
 
-  const reqOpts = {
-    configuration: {
-      query,
-    } as any,
-  } as any;
+  /**
+   * Create a dataset.
+   *
+   * @see [Datasets: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/datasets/insert}
+   *
+   * @param {string} id ID of the dataset to create.
+   * @param {object} [options] See a
+   *     [Dataset resource](https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource).
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request
+   * @param {Dataset} callback.dataset The newly created dataset
+   * @param {object} callback.apiResponse The full API response.
+   * @returns {Promise}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * bigquery.createDataset('my-dataset', function(err, dataset, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.createDataset('my-dataset').then(function(data) {
+   *   const dataset = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  createDataset(id, options, callback) {
+    const that = this;
 
-  if (query.dryRun) {
-    reqOpts.configuration.dryRun = query.dryRun;
-    delete query.dryRun;
-  }
-
-  if (query.jobPrefix) {
-    reqOpts.jobPrefix = query.jobPrefix;
-    delete query.jobPrefix;
-  }
-
-  if (query.location) {
-    reqOpts.location = query.location;
-    delete query.location;
-  }
-
-  if (query.jobId) {
-    reqOpts.jobId = query.jobId;
-    delete query.jobId;
-  }
-
-  this.createJob(reqOpts, callback);
-};
-
-/**
- * Run a query scoped to your project as a readable object stream.
- *
- * @param {object} query Configuration object. See {@link Query} for a complete
- *     list of options.
- * @returns {stream}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
- *
- * bigquery.createQueryStream(query)
- *   .on('error', console.error)
- *   .on('data', function(row) {
- *     // row is a result from your query.
- *   })
- *   .on('end', function() {
- *     // All rows retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * bigquery.createQueryStream(query)
- *   .on('data', function(row) {
- *     this.end();
- *   });
- */
-BigQuery.prototype.createQueryStream = paginator.streamify(
-  'queryAsStream_'
-);
-
-/**
- * Creates a job. Typically when creating a job you'll have a very specific task
- * in mind. For this we recommend one of the following methods:
- *
- * - {@link BigQuery#createQueryJob}
- * - {@link Table#createCopyJob}
- * - {@link Table#createCopyFromJob}
- * - {@link Table#createExtractJob}
- * - {@link Table#createLoadJob}
- *
- * However in the event you need a finer level of control over the job creation,
- * you can use this method to pass in a raw [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs)
- * object.
- *
- * @see [Jobs Overview]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs}
- * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
- *
- * @param {object} options Object in the form of a [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs);
- * @param {string} [options.jobId] Custom job id.
- * @param {string} [options.jobPrefix] Prefix to apply to the job id.
- * @param {string} [options.location] The geographic location of the job.
- *     Required except for US and EU.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Job} callback.job The newly created job.
- * @param {object} callback.apiResponse The full API response.
- * @returns {Promise}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * const options = {
- *   configuration: {
- *     query: {
- *       query: 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100'
- *     }
- *   }
- * };
- *
- * bigquery.createJob(options, function(err, job) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   job.getQueryResults(function(err, rows) {});
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.createJob(options).then(function(data) {
- *   const job = data[0];
- *
- *   return job.getQueryResults();
- * });
- */
-BigQuery.prototype.createJob = function(options, callback) {
-  const self = this;
-
-  const reqOpts = extend({}, options);
-  let jobId = reqOpts.jobId || uuid.v4();
-
-  if (reqOpts.jobId) {
-    delete reqOpts.jobId;
-  }
-
-  if (reqOpts.jobPrefix) {
-    jobId = reqOpts.jobPrefix + jobId;
-    delete reqOpts.jobPrefix;
-  }
-
-  reqOpts.jobReference = {
-    projectId: this.projectId,
-    jobId,
-    location: this.location,
-  };
-
-  if (options.location) {
-    reqOpts.jobReference.location = options.location;
-    delete reqOpts.location;
-  }
-
-  this.request(
-    {
-      method: 'POST',
-      uri: '/jobs',
-      json: reqOpts,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
-
-      if (resp.status.errors) {
-        err = new common.util.ApiError({
-          errors: resp.status.errors,
-          response: resp,
-        } as any);
-      }
-
-      const job = self.job(jobId, {
-        location: resp.jobReference.location,
-      });
-
-      job.metadata = resp;
-      callback(err, job, resp);
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
     }
-  );
-};
 
-/**
- * Create a reference to a dataset.
- *
- * @param {string} id ID of the dataset.
- * @param {object} [options] Dataset options.
- * @param {string} [options.location] The geographic location of the dataset.
- *      Required except for US and EU.
- * @returns {Dataset}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- * const dataset = bigquery.dataset('higher_education');
- */
-BigQuery.prototype.dataset = function(id, options) {
-  if (this.location) {
-    options = extend({location: this.location}, options);
+    this.request(
+      {
+        method: 'POST',
+        uri: '/datasets',
+        json: extend(
+          true,
+          {
+            location: this.location,
+          },
+          options,
+          {
+            datasetReference: {
+              datasetId: id,
+            },
+          }
+        ),
+      },
+      function (err, resp) {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+
+        const dataset = that.dataset(id);
+        dataset.metadata = resp;
+
+        callback(null, dataset, resp);
+      }
+    );
   }
 
-  return new Dataset(this, id, options);
-};
-
-/**
- * List all or some of the datasets in your project.
- *
- * @see [Datasets: list API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/datasets/list}
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.all] List all datasets, including hidden ones.
- * @param {boolean} [options.autoPaginate] Have pagination handled automatically.
- *     Default: true.
- * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
- * @param {number} [options.maxResults] Maximum number of results to return.
- * @param {string} [options.pageToken] Token returned from a previous call, to
- *     request the next page of results.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request
- * @param {Dataset[]} callback.datasets The list of datasets in your project.
- * @returns {Promise}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * bigquery.getDatasets(function(err, datasets) {
- *   if (!err) {
- *     // datasets is an array of Dataset objects.
- *   }
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to `false`.
- * //-
- * function manualPaginationCallback(err, datasets, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     bigquery.getDatasets(nextQuery, manualPaginationCallback);
- *   }
- * }
- *
- * bigquery.getDatasets({
- *   autoPaginate: false
- * }, manualPaginationCallback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.getDatasets().then(function(datasets) {});
- */
-BigQuery.prototype.getDatasets = function(options, callback) {
-  const that = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  options = options || {};
-
-  this.request(
-    {
-      uri: '/datasets',
-      qs: options,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, null, resp);
-        return;
-      }
-
-      let nextQuery = null;
-
-      if (resp.nextPageToken) {
-        nextQuery = extend({}, options, {
-          pageToken: resp.nextPageToken,
-        });
-      }
-
-      const datasets = (resp.datasets || []).map(function(dataset) {
-        const ds = that.dataset(dataset.datasetReference.datasetId, {
-          location: dataset.location,
-        });
-
-        ds.metadata = dataset;
-        return ds;
-      });
-
-      callback(null, datasets, nextQuery, resp);
+  /**
+   * Run a query as a job. No results are immediately returned. Instead, your
+   * callback will be executed with a {@link Job} object that you must
+   * ping for the results. See the Job documentation for explanations of how to
+   * check on the status of the job.
+   *
+   * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
+   *
+   * @param {object|string} options The configuration object. This must be in
+   *     the format of the [`configuration.query`](http://goo.gl/wRpHvR) property
+   *     of a Jobs resource. If a string is provided, this is used as the query
+   *     string, and all other options are defaulted.
+   * @param {Table} [options.destination] The table to save the
+   *     query's results to. If omitted, a new table will be created.
+   * @param {boolean} [options.dryRun] If set, don't actually run this job. A
+   *     valid query will update the job with processing statistics. These can be
+   *     accessed via `job.metadata`.
+   * @param {string} [options.location] The geographic location of the job.
+   *     Required except for US and EU.
+   * @param {string} [options.jobId] Custom job id.
+   * @param {string} [options.jobPrefix] Prefix to apply to the job id.
+   * @param {string} options.query A query string, following the BigQuery query
+   *     syntax, of the query to execute.
+   * @param {boolean} [options.useLegacySql=false] Option to use legacy sql syntax.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Job} callback.job The newly created job for your
+         query.
+   * @param {object} callback.apiResponse The full API response.
+   * @returns {Promise}
+   *
+   * @throws {Error} If a query is not specified.
+   * @throws {Error} If a Table is not provided as a destination.
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
+   *
+   * //-
+   * // You may pass only a query string, having a new table created to store the
+   * // results of the query.
+   * //-
+   * bigquery.createQueryJob(query, function(err, job) {});
+   *
+   * //-
+   * // You can also control the destination table by providing a
+   * // {@link Table} object.
+   * //-
+   * bigquery.createQueryJob({
+   *   destination: bigquery.dataset('higher_education').table('institutions'),
+   *   query: query
+   * }, function(err, job) {});
+   *
+   * //-
+   * // After you have run `createQueryJob`, your query will execute in a job. Your
+   * // callback is executed with a {@link Job} object so that you may
+   * // check for the results.
+   * //-
+   * bigquery.createQueryJob(query, function(err, job) {
+   *   if (!err) {
+   *     job.getQueryResults(function(err, rows, apiResponse) {});
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.createQueryJob(query).then(function(data) {
+   *   const job = data[0];
+   *   const apiResponse = data[1];
+   *
+   *   return job.getQueryResults();
+   * });
+   */
+  createQueryJob(options): Promise<any>;
+  createQueryJob(options, callback): void;
+  createQueryJob(options, callback?): void|Promise<any> {
+    if (is.string(options)) {
+      options = {
+        query: options,
+      };
     }
-  );
-};
 
-/**
- * List all or some of the {@link Dataset} objects in your project as
- * a readable object stream.
- *
- * @param {object} [options] Configuration object. See
- *     {@link BigQuery#getDatasets} for a complete list of options.
- * @returns {stream}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * bigquery.getDatasetsStream()
- *   .on('error', console.error)
- *   .on('data', function(dataset) {
- *     // dataset is a Dataset object.
- *   })
- *   .on('end', function() {
- *     // All datasets retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * bigquery.getDatasetsStream()
- *   .on('data', function(dataset) {
- *     this.end();
- *   });
- */
-BigQuery.prototype.getDatasetsStream = paginator.streamify(
-  'getDatasets'
-);
+    if (!options || !options.query) {
+      throw new Error('A SQL query string is required.');
+    }
 
-/**
- * Get all of the jobs from your project.
- *
- * @see [Jobs: list API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/list}
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.allUsers] Display jobs owned by all users in the
- *     project.
- * @param {boolean} [options.autoPaginate] Have pagination handled
- *     automatically. Default: true.
- * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
- * @param {number} [options.maxResults] Maximum number of results to return.
- * @param {string} [options.pageToken] Token returned from a previous call, to
- *     request the next page of results.
- * @param {string} [options.projection] Restrict information returned to a set
- *     of selected fields. Acceptable values are "full", for all job data, and
- *     "minimal", to not include the job configuration.
- * @param {string} [options.stateFilter] Filter for job state. Acceptable
- *     values are "done", "pending", and "running". Sending an array to this
- *     option performs a disjunction.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request
- * @param {Job[]} callback.jobs The list of jobs in your
- *     project.
- * @returns {Promise}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * bigquery.getJobs(function(err, jobs) {
- *   if (!err) {
- *     // jobs is an array of Job objects.
- *   }
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to `false`.
- * //-
- * function manualPaginationCallback(err, jobs, nextQuery, apiRespose) {
- *   if (nextQuery) {
- *     // More results exist.
- *     bigquery.getJobs(nextQuery, manualPaginationCallback);
- *   }
- * }
- *
- * bigquery.getJobs({
- *   autoPaginate: false
- * }, manualPaginationCallback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.getJobs().then(function(data) {
- *   const jobs = data[0];
- * });
- */
-BigQuery.prototype.getJobs = function(options, callback) {
-  const that = this;
+    const query = extend(
+      true,
+      {
+        useLegacySql: false,
+      },
+      options
+    );
 
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  options = options || {};
-
-  this.request(
-    {
-      uri: '/jobs',
-      qs: options,
-      useQuerystring: true,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, null, resp);
-        return;
+    if (options.destination) {
+      if (!(options.destination instanceof Table)) {
+        throw new Error('Destination must be a Table object.');
       }
 
-      let nextQuery = null;
+      query.destinationTable = {
+        datasetId: options.destination.dataset.id,
+        projectId: options.destination.dataset.bigQuery.projectId,
+        tableId: options.destination.id,
+      };
 
-      if (resp.nextPageToken) {
-        nextQuery = extend({}, options, {
-          pageToken: resp.nextPageToken,
-        });
+      delete query.destination;
+    }
+
+    if (query.params) {
+      query.parameterMode = is.array(query.params) ? 'positional' : 'named';
+
+      if (query.parameterMode === 'named') {
+        query.queryParameters = [];
+
+        for (const namedParamater in query.params) {
+          const value = query.params[namedParamater];
+          const queryParameter = (BigQuery as any).valueToQueryParameter_(value);
+          queryParameter.name = namedParamater;
+          query.queryParameters.push(queryParameter);
+        }
+      } else {
+        query.queryParameters = query.params.map(BigQuery.valueToQueryParameter_);
       }
 
-      const jobs = (resp.jobs || []).map(function(jobObject) {
-        const job = that.job(jobObject.jobReference.jobId, {
-          location: jobObject.jobReference.location,
-        });
-
-        job.metadata = jobObject;
-        return job;
-      });
-
-      callback(null, jobs, nextQuery, resp);
+      delete query.params;
     }
-  );
-};
 
-/**
- * List all or some of the {@link Job} objects in your project as a
- * readable object stream.
- *
- * @param {object} [options] Configuration object. See
- *     {@link BigQuery#getJobs} for a complete list of options.
- * @returns {stream}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * bigquery.getJobsStream()
- *   .on('error', console.error)
- *   .on('data', function(job) {
- *     // job is a Job object.
- *   })
- *   .on('end', function() {
- *     // All jobs retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * bigquery.getJobsStream()
- *   .on('data', function(job) {
- *     this.end();
- *   });
- */
-BigQuery.prototype.getJobsStream = paginator.streamify('getJobs');
-
-/**
- * Create a reference to an existing job.
- *
- * @param {string} id ID of the job.
- * @param {object} [options] Configuration object.
- * @param {string} [options.location] The geographic location of the job.
- *      Required except for US and EU.
- * @returns {Job}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * const myExistingJob = bigquery.job('job-id');
- */
-BigQuery.prototype.job = function(id, options) {
-  if (this.location) {
-    options = extend({location: this.location}, options);
-  }
-
-  return new Job(this, id, options);
-};
-
-/**
- * Run a query scoped to your project. For manual pagination please refer to
- * {@link BigQuery#createQueryJob}.
- *
- * @see [Jobs: query API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/query}
- *
- * @param {string|object} query A string SQL query or configuration object.
- *     For all available options, see
- *     [Jobs: query request body](https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#request-body).
- * @param {string} [query.location] The geographic location of the job.
- *     Required except for US and EU.
- * @param {string} [query.jobId] Custom id for the underlying job.
- * @param {string} [query.jobPrefix] Prefix to apply to the underlying job id.
- * @param {object|Array<*>} query.params For positional SQL parameters, provide
- *     an array of values. For named SQL parameters, provide an object which
- *     maps each named parameter to its value. The supported types are integers,
- *     floats, {@link BigQuery#date} objects, {@link BigQuery#datetime}
- *     objects, {@link BigQuery#time} objects, {@link BigQuery#timestamp}
- *     objects, Strings, Booleans, and Objects.
- * @param {string} query.query A query string, following the BigQuery query
- *     syntax, of the query to execute.
- * @param {boolean} [query.useLegacySql=false] Option to use legacy sql syntax.
- * @param {object} [options] Configuration object for query results.
- * @param {number} [options.maxResults] Maximum number of results to read.
- * @param {number} [options.timeoutMs] How long to wait for the query to
- *     complete, in milliseconds, before returning. Default is to return
- *     immediately. If the timeout passes before the job completes, the request
- *     will fail with a `TIMEOUT` error.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request
- * @param {array} callback.rows The list of results from your query.
- * @returns {Promise}
- *
- * @example
- * const BigQuery = require('@google-cloud/bigquery');
- * const bigquery = new BigQuery();
- *
- * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
- *
- * bigquery.query(query, function(err, rows) {
- *   if (!err) {
- *     // rows is an array of results.
- *   }
- * });
- *
- * //-
- * // Positional SQL parameters are supported.
- * //-
- * bigquery.query({
- *   query: [
- *     'SELECT url',
- *     'FROM `publicdata.samples.github_nested`',
- *     'WHERE repository.owner = ?'
- *   ].join(' '),
- *
- *   params: [
- *     'google'
- *   ]
- * }, function(err, rows) {});
- *
- * //-
- * // Or if you prefer to name them, that's also supported.
- * //-
- * bigquery.query({
- *   query: [
- *     'SELECT url',
- *     'FROM `publicdata.samples.github_nested`',
- *     'WHERE repository.owner = @owner'
- *   ].join(' '),
-
- *   params: {
- *     owner: 'google'
- *   }
- * }, function(err, rows) {});
- *
- * //-
- * // If you need to use a `DATE`, `DATETIME`, `TIME`, or `TIMESTAMP` type in
- * // your query, see {@link BigQuery#date}, {@link BigQuery#datetime},
- * // {@link BigQuery#time}, and {@link BigQuery#timestamp}.
- * //-
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigquery.query(query).then(function(data) {
- *   const rows = data[0];
- * });
- */
-BigQuery.prototype.query = function(query, options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.createQueryJob(query, function(err, job, resp) {
-    if (err) {
-      callback(err, null, resp);
-      return;
-    }
+    const reqOpts = {
+      configuration: {
+        query,
+      } as any,
+    } as any;
 
     if (query.dryRun) {
-      callback(null, [], resp);
-      return;
+      reqOpts.configuration.dryRun = query.dryRun;
+      delete query.dryRun;
     }
 
-    job.getQueryResults(options, callback);
-  });
-};
+    if (query.jobPrefix) {
+      reqOpts.jobPrefix = query.jobPrefix;
+      delete query.jobPrefix;
+    }
 
-/**
- * This method will be called by `createQueryStream()`. It is required to
- * properly set the `autoPaginate` option value.
- *
- * @private
- */
-BigQuery.prototype.queryAsStream_ = function(query, callback) {
-  this.query(query, {autoPaginate: false}, callback);
-};
+    if (query.location) {
+      reqOpts.location = query.location;
+      delete query.location;
+    }
+
+    if (query.jobId) {
+      reqOpts.jobId = query.jobId;
+      delete query.jobId;
+    }
+
+    this.createJob(reqOpts, callback);
+  }
+
+  /**
+   * Run a query scoped to your project as a readable object stream.
+   *
+   * @param {object} query Configuration object. See {@link Query} for a complete
+   *     list of options.
+   * @returns {stream}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
+   *
+   * bigquery.createQueryStream(query)
+   *   .on('error', console.error)
+   *   .on('data', function(row) {
+   *     // row is a result from your query.
+   *   })
+   *   .on('end', function() {
+   *     // All rows retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * bigquery.createQueryStream(query)
+   *   .on('data', function(row) {
+   *     this.end();
+   *   });
+   */
+
+
+  /**
+   * Creates a job. Typically when creating a job you'll have a very specific task
+   * in mind. For this we recommend one of the following methods:
+   *
+   * - {@link BigQuery#createQueryJob}
+   * - {@link Table#createCopyJob}
+   * - {@link Table#createCopyFromJob}
+   * - {@link Table#createExtractJob}
+   * - {@link Table#createLoadJob}
+   *
+   * However in the event you need a finer level of control over the job creation,
+   * you can use this method to pass in a raw [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs)
+   * object.
+   *
+   * @see [Jobs Overview]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs}
+   * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
+   *
+   * @param {object} options Object in the form of a [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs);
+   * @param {string} [options.jobId] Custom job id.
+   * @param {string} [options.jobPrefix] Prefix to apply to the job id.
+   * @param {string} [options.location] The geographic location of the job.
+   *     Required except for US and EU.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Job} callback.job The newly created job.
+   * @param {object} callback.apiResponse The full API response.
+   * @returns {Promise}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * const options = {
+   *   configuration: {
+   *     query: {
+   *       query: 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100'
+   *     }
+   *   }
+   * };
+   *
+   * bigquery.createJob(options, function(err, job) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   job.getQueryResults(function(err, rows) {});
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.createJob(options).then(function(data) {
+   *   const job = data[0];
+   *
+   *   return job.getQueryResults();
+   * });
+   */
+  createJob(options, callback?) {
+    const self = this;
+
+    const reqOpts = extend({}, options);
+    let jobId = reqOpts.jobId || uuid.v4();
+
+    if (reqOpts.jobId) {
+      delete reqOpts.jobId;
+    }
+
+    if (reqOpts.jobPrefix) {
+      jobId = reqOpts.jobPrefix + jobId;
+      delete reqOpts.jobPrefix;
+    }
+
+    reqOpts.jobReference = {
+      projectId: this.projectId,
+      jobId,
+      location: this.location,
+    };
+
+    if (options.location) {
+      reqOpts.jobReference.location = options.location;
+      delete reqOpts.location;
+    }
+
+    this.request(
+      {
+        method: 'POST',
+        uri: '/jobs',
+        json: reqOpts,
+      },
+      function (err, resp) {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+
+        if (resp.status.errors) {
+          err = new common.util.ApiError({
+            errors: resp.status.errors,
+            response: resp,
+          } as any);
+        }
+
+        const job = self.job(jobId, {
+          location: resp.jobReference.location,
+        });
+
+        job.metadata = resp;
+        callback(err, job, resp);
+      }
+    );
+  }
+
+  /**
+   * Create a reference to a dataset.
+   *
+   * @param {string} id ID of the dataset.
+   * @param {object} [options] Dataset options.
+   * @param {string} [options.location] The geographic location of the dataset.
+   *      Required except for US and EU.
+   * @returns {Dataset}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   * const dataset = bigquery.dataset('higher_education');
+   */
+  dataset(id, options?) {
+    if (this.location) {
+      options = extend({ location: this.location }, options);
+    }
+
+    return new Dataset(this, id, options);
+  }
+
+  /**
+   * List all or some of the datasets in your project.
+   *
+   * @see [Datasets: list API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/datasets/list}
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.all] List all datasets, including hidden ones.
+   * @param {boolean} [options.autoPaginate] Have pagination handled automatically.
+   *     Default: true.
+   * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
+   * @param {number} [options.maxResults] Maximum number of results to return.
+   * @param {string} [options.pageToken] Token returned from a previous call, to
+   *     request the next page of results.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request
+   * @param {Dataset[]} callback.datasets The list of datasets in your project.
+   * @returns {Promise}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * bigquery.getDatasets(function(err, datasets) {
+   *   if (!err) {
+   *     // datasets is an array of Dataset objects.
+   *   }
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to `false`.
+   * //-
+   * function manualPaginationCallback(err, datasets, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     bigquery.getDatasets(nextQuery, manualPaginationCallback);
+   *   }
+   * }
+   *
+   * bigquery.getDatasets({
+   *   autoPaginate: false
+   * }, manualPaginationCallback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.getDatasets().then(function(datasets) {});
+   */
+  getDatasets(options?): Promise<any>;
+  getDatasets(options, callback): void;
+  getDatasets(callback): void;
+  getDatasets(options?, callback?): void|Promise<any> {
+    const that = this;
+
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    options = options || {};
+
+    this.request(
+      {
+        uri: '/datasets',
+        qs: options,
+      },
+      function (err, resp) {
+        if (err) {
+          callback(err, null, null, resp);
+          return;
+        }
+
+        let nextQuery = null;
+
+        if (resp.nextPageToken) {
+          nextQuery = extend({}, options, {
+            pageToken: resp.nextPageToken,
+          });
+        }
+
+        const datasets = (resp.datasets || []).map(function (dataset) {
+          const ds = that.dataset(dataset.datasetReference.datasetId, {
+            location: dataset.location,
+          });
+
+          ds.metadata = dataset;
+          return ds;
+        });
+
+        callback(null, datasets, nextQuery, resp);
+      }
+    );
+  }
+
+  /**
+   * List all or some of the {@link Dataset} objects in your project as
+   * a readable object stream.
+   *
+   * @param {object} [options] Configuration object. See
+   *     {@link BigQuery#getDatasets} for a complete list of options.
+   * @returns {stream}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * bigquery.getDatasetsStream()
+   *   .on('error', console.error)
+   *   .on('data', function(dataset) {
+   *     // dataset is a Dataset object.
+   *   })
+   *   .on('end', function() {
+   *     // All datasets retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * bigquery.getDatasetsStream()
+   *   .on('data', function(dataset) {
+   *     this.end();
+   *   });
+   */
+
+
+  /**
+   * Get all of the jobs from your project.
+   *
+   * @see [Jobs: list API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/list}
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.allUsers] Display jobs owned by all users in the
+   *     project.
+   * @param {boolean} [options.autoPaginate] Have pagination handled
+   *     automatically. Default: true.
+   * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
+   * @param {number} [options.maxResults] Maximum number of results to return.
+   * @param {string} [options.pageToken] Token returned from a previous call, to
+   *     request the next page of results.
+   * @param {string} [options.projection] Restrict information returned to a set
+   *     of selected fields. Acceptable values are "full", for all job data, and
+   *     "minimal", to not include the job configuration.
+   * @param {string} [options.stateFilter] Filter for job state. Acceptable
+   *     values are "done", "pending", and "running". Sending an array to this
+   *     option performs a disjunction.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request
+   * @param {Job[]} callback.jobs The list of jobs in your
+   *     project.
+   * @returns {Promise}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * bigquery.getJobs(function(err, jobs) {
+   *   if (!err) {
+   *     // jobs is an array of Job objects.
+   *   }
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to `false`.
+   * //-
+   * function manualPaginationCallback(err, jobs, nextQuery, apiRespose) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     bigquery.getJobs(nextQuery, manualPaginationCallback);
+   *   }
+   * }
+   *
+   * bigquery.getJobs({
+   *   autoPaginate: false
+   * }, manualPaginationCallback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.getJobs().then(function(data) {
+   *   const jobs = data[0];
+   * });
+   */
+  getJobs(options, callback?) {
+    const that = this;
+
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    options = options || {};
+
+    this.request(
+      {
+        uri: '/jobs',
+        qs: options,
+        useQuerystring: true,
+      },
+      function (err, resp) {
+        if (err) {
+          callback(err, null, null, resp);
+          return;
+        }
+
+        let nextQuery = null;
+
+        if (resp.nextPageToken) {
+          nextQuery = extend({}, options, {
+            pageToken: resp.nextPageToken,
+          });
+        }
+
+        const jobs = (resp.jobs || []).map(function (jobObject) {
+          const job = that.job(jobObject.jobReference.jobId, {
+            location: jobObject.jobReference.location,
+          });
+
+          job.metadata = jobObject;
+          return job;
+        });
+
+        callback(null, jobs, nextQuery, resp);
+      }
+    );
+  }
+
+  /**
+   * List all or some of the {@link Job} objects in your project as a
+   * readable object stream.
+   *
+   * @param {object} [options] Configuration object. See
+   *     {@link BigQuery#getJobs} for a complete list of options.
+   * @returns {stream}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * bigquery.getJobsStream()
+   *   .on('error', console.error)
+   *   .on('data', function(job) {
+   *     // job is a Job object.
+   *   })
+   *   .on('end', function() {
+   *     // All jobs retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * bigquery.getJobsStream()
+   *   .on('data', function(job) {
+   *     this.end();
+   *   });
+   */
+
+  /**
+   * Create a reference to an existing job.
+   *
+   * @param {string} id ID of the job.
+   * @param {object} [options] Configuration object.
+   * @param {string} [options.location] The geographic location of the job.
+   *      Required except for US and EU.
+   * @returns {Job}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * const myExistingJob = bigquery.job('job-id');
+   */
+  job(id, options?) {
+    if (this.location) {
+      options = extend({ location: this.location }, options);
+    }
+    return new Job(this, id, options);
+  }
+
+  /**
+   * Run a query scoped to your project. For manual pagination please refer to
+   * {@link BigQuery#createQueryJob}.
+   *
+   * @see [Jobs: query API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/query}
+   *
+   * @param {string|object} query A string SQL query or configuration object.
+   *     For all available options, see
+   *     [Jobs: query request body](https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#request-body).
+   * @param {string} [query.location] The geographic location of the job.
+   *     Required except for US and EU.
+   * @param {string} [query.jobId] Custom id for the underlying job.
+   * @param {string} [query.jobPrefix] Prefix to apply to the underlying job id.
+   * @param {object|Array<*>} query.params For positional SQL parameters, provide
+   *     an array of values. For named SQL parameters, provide an object which
+   *     maps each named parameter to its value. The supported types are integers,
+   *     floats, {@link BigQuery#date} objects, {@link BigQuery#datetime}
+   *     objects, {@link BigQuery#time} objects, {@link BigQuery#timestamp}
+   *     objects, Strings, Booleans, and Objects.
+   * @param {string} query.query A query string, following the BigQuery query
+   *     syntax, of the query to execute.
+   * @param {boolean} [query.useLegacySql=false] Option to use legacy sql syntax.
+   * @param {object} [options] Configuration object for query results.
+   * @param {number} [options.maxResults] Maximum number of results to read.
+   * @param {number} [options.timeoutMs] How long to wait for the query to
+   *     complete, in milliseconds, before returning. Default is to return
+   *     immediately. If the timeout passes before the job completes, the request
+   *     will fail with a `TIMEOUT` error.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request
+   * @param {array} callback.rows The list of results from your query.
+   * @returns {Promise}
+   *
+   * @example
+   * const BigQuery = require('@google-cloud/bigquery');
+   * const bigquery = new BigQuery();
+   *
+   * const query = 'SELECT url FROM `publicdata.samples.github_nested` LIMIT 100';
+   *
+   * bigquery.query(query, function(err, rows) {
+   *   if (!err) {
+   *     // rows is an array of results.
+   *   }
+   * });
+   *
+   * //-
+   * // Positional SQL parameters are supported.
+   * //-
+   * bigquery.query({
+   *   query: [
+   *     'SELECT url',
+   *     'FROM `publicdata.samples.github_nested`',
+   *     'WHERE repository.owner = ?'
+   *   ].join(' '),
+   *
+   *   params: [
+   *     'google'
+   *   ]
+   * }, function(err, rows) {});
+   *
+   * //-
+   * // Or if you prefer to name them, that's also supported.
+   * //-
+   * bigquery.query({
+   *   query: [
+   *     'SELECT url',
+   *     'FROM `publicdata.samples.github_nested`',
+   *     'WHERE repository.owner = @owner'
+   *   ].join(' '),
+
+   *   params: {
+   *     owner: 'google'
+   *   }
+   * }, function(err, rows) {});
+   *
+   * //-
+   * // If you need to use a `DATE`, `DATETIME`, `TIME`, or `TIMESTAMP` type in
+   * // your query, see {@link BigQuery#date}, {@link BigQuery#datetime},
+   * // {@link BigQuery#time}, and {@link BigQuery#timestamp}.
+   * //-
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigquery.query(query).then(function(data) {
+   *   const rows = data[0];
+   * });
+   */
+  query(query, options, callback?) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.createQueryJob(query, function (err, job, resp) {
+      if (err) {
+        callback(err, null, resp);
+        return;
+      }
+
+      if (query.dryRun) {
+        callback(null, [], resp);
+        return;
+      }
+
+      job.getQueryResults(options, callback);
+    });
+  }
+
+  /**
+   * This method will be called by `createQueryStream()`. It is required to
+   * properly set the `autoPaginate` option value.
+   *
+   * @private
+   */
+  queryAsStream_(query, callback?) {
+    this.query(query, { autoPaginate: false }, callback);
+  }
+}
 
 /*! Developer Documentation
  *
@@ -1407,6 +1375,62 @@ promisifyAll(BigQuery, {
   exclude: ['dataset', 'date', 'datetime', 'job', 'time', 'timestamp'],
 });
 
+export class BigQueryDate {
+  value;
+  constructor(value) {
+    if (is.object(value)) {
+      value = BigQuery.datetime(value).value;
+    }
+    this.value = value;
+  }
+}
+
+export class BigQueryTimestamp {
+  value;
+  constructor(value) {
+    this.value = new Date(value).toJSON();
+  }
+}
+
+export class BigQueryDatetime {
+  value;
+  constructor(value) {
+    if (is.object(value)) {
+      let time;
+
+      if (value.hours) {
+        time = BigQuery.time(value).value;
+      }
+
+      value = format('{y}-{m}-{d}{time}', {
+        y: value.year,
+        m: value.month,
+        d: value.day,
+        time: time ? ' ' + time : '',
+      });
+    } else {
+      value = value.replace(/^(.*)T(.*)Z$/, '$1 $2');
+    }
+
+    this.value = value;
+  }
+}
+
+export class BigQueryTime {
+  value: string;
+  constructor(value) {
+    if (is.object(value)) {
+      value = format('{h}:{m}:{s}{f}', {
+        h: value.hours,
+        m: value.minutes || 0,
+        s: value.seconds || 0,
+        f: is.defined(value.fractional) ? '.' + value.fractional : '',
+      });
+    }
+    this.value = value;
+  }
+}
+
 /**
  * {@link Dataset} class.
  *
@@ -1414,7 +1438,7 @@ promisifyAll(BigQuery, {
  * @see Dataset
  * @type {constructor}
  */
-(BigQuery as any).Dataset = Dataset;
+export { Dataset };
 
 /**
  * {@link Job} class.
@@ -1423,7 +1447,7 @@ promisifyAll(BigQuery, {
  * @see Job
  * @type {constructor}
  */
-(BigQuery as any).Job = Job;
+export { Job };
 
 /**
  * {@link Table} class.
@@ -1432,7 +1456,7 @@ promisifyAll(BigQuery, {
  * @see Table
  * @type {constructor}
  */
-(BigQuery as any).Table = Table;
+export { Table };
 
 /**
  * The default export of the `@google-cloud/bigquery` package is the {@link BigQuery}
@@ -1463,4 +1487,3 @@ promisifyAll(BigQuery, {
  * region_tag:bigquery_quickstart
  * Full quickstart example:
  */
-module.exports = BigQuery;

--- a/src/job.ts
+++ b/src/job.ts
@@ -26,6 +26,7 @@ import {paginator} from '@google-cloud/paginator';
 import * as extend from 'extend';
 import * as is from 'is';
 import * as request from 'request';
+import {BigQuery} from '../src';
 
 /**
  * Job objects are returned from various places in the BigQuery API:
@@ -417,7 +418,7 @@ class Job extends Operation {
         let rows = [];
 
         if (resp.schema && resp.rows) {
-          rows = this.bigQuery.mergeSchemaWithRows_(resp.schema, resp.rows);
+          rows = BigQuery.mergeSchemaWithRows_(resp.schema, resp.rows);
         }
 
         let nextQuery = null;

--- a/src/job.ts
+++ b/src/job.ts
@@ -51,7 +51,7 @@ import {BigQuery} from '../src';
  *      Required except for US and EU.
  *
  * @example
- * const BigQuery = require('@google-cloud/bigquery');
+ * const {BigQuery} = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  *
  * const job = bigquery.job('job-id');
@@ -99,7 +99,7 @@ class Job extends Operation {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        *
        * const job = bigquery.job('job-id');
@@ -126,7 +126,7 @@ class Job extends Operation {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        *
        * const job = bigquery.job('job-id');
@@ -161,7 +161,7 @@ class Job extends Operation {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        *
        * const job = bigquery.job('id');
@@ -196,7 +196,7 @@ class Job extends Operation {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        *
        * const metadata = {
@@ -245,7 +245,7 @@ class Job extends Operation {
     * @example
     * const through2 = require('through2');
     * const fs = require('fs');
-    * const BigQuery = require('@google-cloud/bigquery');
+    * const {BigQuery} = require('@google-cloud/bigquery');
     * const bigquery = new BigQuery();
     *
     * const job = bigquery.job('job-id');
@@ -274,7 +274,7 @@ class Job extends Operation {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const job = bigquery.job('job-id');
@@ -348,7 +348,7 @@ class Job extends Operation {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    *
    * const job = bigquery.job('job-id');

--- a/src/table.ts
+++ b/src/table.ts
@@ -68,7 +68,7 @@ const FORMATS = {
  *      table.
  *
  * @example
- * const BigQuery = require('@google-cloud/bigquery');
+ * const {BigQuery} = require('@google-cloud/bigquery');
  * const bigquery = new BigQuery();
  * const dataset = bigquery.dataset('my-dataset');
  *
@@ -91,7 +91,7 @@ class Table extends common.ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('my-dataset');
        *
@@ -126,7 +126,7 @@ class Table extends common.ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('my-dataset');
        *
@@ -154,7 +154,7 @@ class Table extends common.ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('my-dataset');
        *
@@ -191,7 +191,7 @@ class Table extends common.ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('my-dataset');
        *
@@ -225,7 +225,7 @@ class Table extends common.ServiceObject {
        * @returns {Promise}
        *
        * @example
-       * const BigQuery = require('@google-cloud/bigquery');
+       * const {BigQuery} = require('@google-cloud/bigquery');
        * const bigquery = new BigQuery();
        * const dataset = bigquery.dataset('my-dataset');
        *
@@ -281,7 +281,7 @@ class Table extends common.ServiceObject {
      * @returns {ReadableStream}
      *
      * @example
-     * const BigQuery = require('@google-cloud/bigquery');
+     * const {BigQuery} = require('@google-cloud/bigquery');
      * const bigquery = new BigQuery();
      * const dataset = bigquery.dataset('my-dataset');
      * const table = dataset.table('my-table');
@@ -447,7 +447,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If a destination other than a Table object is provided.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    *
@@ -511,7 +511,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If a source other than a Table object is provided.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -579,7 +579,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If a destination other than a Table object is provided.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -677,7 +677,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If a source other than a Table object is provided.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -788,7 +788,7 @@ class Table extends common.ServiceObject {
    *
    * @example
    * const {Storage} = require('@google-cloud/storage');
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -943,7 +943,7 @@ class Table extends common.ServiceObject {
    *
    * @example
    * const {Storage} = require('@google-cloud/storage');
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1226,7 +1226,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If source format isn't recognized.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1309,7 +1309,7 @@ class Table extends common.ServiceObject {
    *
    * @example
    * const Storage = require('@google-cloud/storage');
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1387,7 +1387,7 @@ class Table extends common.ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1516,7 +1516,7 @@ class Table extends common.ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1734,7 +1734,7 @@ class Table extends common.ServiceObject {
    * @throws {Error} If the source isn't a string file name or a File instance.
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');
@@ -1834,7 +1834,7 @@ class Table extends common.ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const BigQuery = require('@google-cloud/bigquery');
+   * const {BigQuery} = require('@google-cloud/bigquery');
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('my-dataset');
    * const table = dataset.table('my-table');

--- a/src/table.ts
+++ b/src/table.ts
@@ -18,7 +18,7 @@
 
 import * as arrify from 'arrify';
 import * as Big from 'big.js';
-import {ServiceObject, util, SetMetadataResponse, ResponseCallback} from '@google-cloud/common';
+import * as common from '@google-cloud/common';
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 const duplexify = require('duplexify');
@@ -30,6 +30,7 @@ import * as path from 'path';
 import * as request from 'request';
 const streamEvents = require('stream-events');
 import * as uuid from 'uuid';
+import {BigQuery} from '../src';
 
 export interface SetTableMetadataOptions {
   description?: string;
@@ -73,7 +74,7 @@ const FORMATS = {
  *
  * const table = dataset.table('my-table');
  */
-class Table extends ServiceObject {
+class Table extends common.ServiceObject {
   constructor(dataset, id, options?) {
 
     const methods = {
@@ -608,7 +609,10 @@ class Table extends ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  createCopyJob(destination, metadata, callback) {
+  createCopyJob(destination, metadata?): Promise<any>;
+  createCopyJob(destination, metadata, callback): void;
+  createCopyJob(destination, callback): void;
+  createCopyJob(destination, metadata?, callback?): void|Promise<any> {
     if (!(destination instanceof Table)) {
       throw new Error('Destination must be a Table object.');
     }
@@ -834,7 +838,10 @@ class Table extends ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  createExtractJob(destination, options, callback) {
+  createExtractJob(destination, options?): Promise<any>;
+  createExtractJob(destination, options, callback): void;
+  createExtractJob(destination, callback): void;
+  createExtractJob(destination, options?, callback?): void|Promise<any> {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -842,7 +849,7 @@ class Table extends ServiceObject {
 
     options = extend(true, options, {
       destinationUris: arrify(destination).map((dest) => {
-        if (!util.isCustomType(dest, 'storage/file')) {
+        if (!common.util.isCustomType(dest, 'storage/file')) {
           throw new Error('Destination must be a File object.');
         }
 
@@ -987,13 +994,13 @@ class Table extends ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  createLoadJob(source, metadata, callback) {
+  createLoadJob(source, metadata?, callback?) {
     if (is.fn(metadata)) {
       callback = metadata;
       metadata = {};
     }
 
-    callback = callback || util.noop;
+    callback = callback || common.util.noop;
     metadata = metadata || {};
 
     if (metadata.format) {
@@ -1058,7 +1065,7 @@ class Table extends ServiceObject {
 
     extend(true, body.configuration.load, metadata, {
       sourceUris: arrify(source).map((src) => {
-        if (!util.isCustomType(src, 'storage/file')) {
+        if (!common.util.isCustomType(src, 'storage/file')) {
           throw new Error('Source must be a File object.');
         }
 
@@ -1168,7 +1175,7 @@ class Table extends ServiceObject {
     const dup = streamEvents(duplexify());
 
     dup.once('writing', () => {
-      util.makeWritableStream(
+      common.util.makeWritableStream(
         dup,
         {
           makeAuthenticatedRequest: this.bigQuery.makeAuthenticatedRequest,
@@ -1346,7 +1353,7 @@ class Table extends ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  extract(destination, options, callback) {
+  extract(destination, options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1413,7 +1420,10 @@ class Table extends ServiceObject {
    *   const rows = data[0];
   });
   */
-  getRows(options, callback) {
+  getRows(options?): Promise<any>;
+  getRows(options, callback): void;
+  getRows(callback): void;
+  getRows(options?, callback?): void|Promise<any> {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1424,7 +1434,7 @@ class Table extends ServiceObject {
         callback(err, null, null, resp);
         return;
       }
-      rows = this.bigQuery.mergeSchemaWithRows_(this.metadata.schema, rows || []);
+      rows = BigQuery.mergeSchemaWithRows_(this.metadata.schema, rows || []);
       callback(null, rows, nextQuery, resp);
     };
 
@@ -1592,7 +1602,10 @@ class Table extends ServiceObject {
    *     }
    *   });
    */
-  insert(rows, options, callback) {
+  insert(rows, options?): Promise<any>;
+  insert(rows, options, callback): void;
+  insert(rows, callback): void;
+  insert(rows, options?, callback?): void|Promise<any> {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1682,7 +1695,7 @@ class Table extends ServiceObject {
         });
 
         if (partialFailures.length > 0) {
-          err = new util.PartialFailureError({
+          err = new common.util.PartialFailureError({
             errors: partialFailures,
             response: resp,
           } as any);
@@ -1766,7 +1779,10 @@ class Table extends ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  load(source, metadata, callback) {
+  load(source, metadata?): Promise<any>;
+  load(source, metadata, callback): void;
+  load(source, callback): void;
+  load(source, metadata, callback?): void|Promise<any> {
     if (is.fn(metadata)) {
       callback = metadata;
       metadata = {};
@@ -1839,9 +1855,9 @@ class Table extends ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  setMetadata(metadata: SetTableMetadataOptions): Promise<SetMetadataResponse>;
-  setMetadata(metadata: SetTableMetadataOptions, callback: ResponseCallback): void;
-  setMetadata(metadata: SetTableMetadataOptions, callback?: ResponseCallback): void|Promise<SetMetadataResponse> {
+  setMetadata(metadata: SetTableMetadataOptions): Promise<common.SetMetadataResponse>;
+  setMetadata(metadata: SetTableMetadataOptions, callback: common.ResponseCallback): void;
+  setMetadata(metadata: SetTableMetadataOptions, callback?: common.ResponseCallback): void|Promise<common.SetMetadataResponse> {
     const body = Table.formatMetadata_(metadata);
     super.setMetadata(body, callback!);
   }

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -27,10 +27,11 @@ import {Dataset} from '../src/dataset';
 import {Job} from '../src/job';
 import {Table} from '../src/table';
 
-const BigQuery = require('../src');
-const bigquery = new BigQuery();
+import {BigQuery} from '../src';
 import {Storage} from '@google-cloud/storage';
+import { ApiError } from '@google-cloud/common';
 
+const bigquery = new BigQuery();
 const storage = new Storage();
 
 describe('BigQuery', () => {
@@ -142,7 +143,7 @@ describe('BigQuery', () => {
     const maxApiCalls = 1;
     let numRequestsMade = 0;
 
-    const BigQuery = require('../src');
+    const {BigQuery} = require('../src');
     const bigquery = new BigQuery();
 
     bigquery.interceptors.push({
@@ -172,7 +173,7 @@ describe('BigQuery', () => {
     const maxApiCalls = 1;
     let numRequestsMade = 0;
 
-    const BigQuery = require('../src');
+    const {BigQuery} = require('../src');
     const bigquery = new BigQuery();
 
     bigquery.interceptors.push({
@@ -458,7 +459,7 @@ describe('BigQuery', () => {
           description: 'oh no!',
         },
         err => {
-          assert.strictEqual(err.code, 412); // precondition failed
+          assert.strictEqual((err as ApiError).code, 412); // precondition failed
           done();
         }
       );
@@ -581,7 +582,7 @@ describe('BigQuery', () => {
           const badJob = bigquery.job(job.id);
 
           badJob.getMetadata(err => {
-            assert.strictEqual(err.code, 404);
+            assert.strictEqual((err as ApiError).code, 404);
             done();
           });
         });
@@ -590,7 +591,7 @@ describe('BigQuery', () => {
           const badJob = bigquery.job(job.id, {location: 'US'});
 
           badJob.getMetadata(err => {
-            assert.strictEqual(err.code, 404);
+            assert.strictEqual((err as ApiError).code, 404);
             done();
           });
         });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1678,13 +1678,11 @@ describe('BigQuery', () => {
   describe('queryAsStream_', () => {
     it('should call query correctly', done => {
       const query = 'SELECT';
-
       bq.query = (query_, options, callback) => {
         assert.strictEqual(query_, query);
         assert.deepStrictEqual(options, {autoPaginate: false});
         callback(); // done()
       };
-
       bq.queryAsStream_(query, done);
     });
   });

--- a/test/job.ts
+++ b/test/job.ts
@@ -24,10 +24,15 @@ import * as pfy from '@google-cloud/promisify';
 import {util} from '@google-cloud/common';
 import * as sinon from 'sinon';
 
-function FakeOperation() {
-  this.calledWith_ = arguments;
-  this.interceptors = [];
-  this.id = this.calledWith_[0].id;
+class FakeOperation {
+  calledWith_: IArguments;
+  interceptors: {}[];
+  id: {};
+  constructor() {
+    this.calledWith_ = arguments;
+    this.interceptors = [];
+    this.id = this.calledWith_[0].id;
+  }
 }
 
 let promisified = false;

--- a/test/job.ts
+++ b/test/job.ts
@@ -23,6 +23,7 @@ import * as proxyquire from 'proxyquire';
 import * as pfy from '@google-cloud/promisify';
 import {util} from '@google-cloud/common';
 import * as sinon from 'sinon';
+import {BigQuery} from '../src';
 
 class FakeOperation {
   calledWith_: IArguments;
@@ -61,6 +62,10 @@ const fakePaginator = {
     },
   }
 };
+
+let sandbox: sinon.SinonSandbox;
+beforeEach(() => sandbox = sinon.createSandbox());
+afterEach(() => sandbox.restore());
 
 describe('BigQuery/Job', () => {
   const BIGQUERY: any = {
@@ -255,11 +260,11 @@ describe('BigQuery/Job', () => {
         callback(null, response);
       };
 
-      BIGQUERY.mergeSchemaWithRows_ = (schema, rows) => {
+      sandbox.stub(BigQuery, 'mergeSchemaWithRows_').callsFake((schema, rows) => {
         assert.strictEqual(schema, response.schema);
         assert.strictEqual(rows, response.rows);
         return mergedRows;
-      };
+      });
 
       job.getQueryResults((err, rows) => {
         assert.ifError(err);

--- a/test/job.ts
+++ b/test/job.ts
@@ -27,7 +27,7 @@ import {BigQuery} from '../src';
 
 class FakeOperation {
   calledWith_: IArguments;
-  interceptors: {}[];
+  interceptors: Array<{}>;
   id: {};
   constructor() {
     this.calledWith_ = arguments;

--- a/test/table.ts
+++ b/test/table.ts
@@ -26,6 +26,7 @@ import * as stream from 'stream';
 import * as uuid from 'uuid';
 import * as pfy from '@google-cloud/promisify';
 import {ServiceObject, util} from '@google-cloud/common';
+import * as sinon from 'sinon';
 
 let promisified = false;
 let makeWritableStreamOverride;
@@ -37,6 +38,7 @@ const fakeUtil = extend({}, util, {
   makeWritableStream: (...args) => {
     (makeWritableStreamOverride || util.makeWritableStream).apply(null, args);
   },
+  noop: () => {}
 });
 const fakePfy = extend({}, pfy, {
   promisifyAll: Class => {
@@ -74,6 +76,10 @@ class FakeServiceObject extends ServiceObject {
     this.calledWith_ = arguments;
   }
 }
+
+let sandbox: sinon.SinonSandbox;
+beforeEach(() => sandbox = sinon.createSandbox());
+afterEach(() => sandbox.restore());
 
 describe('BigQuery/Table', () => {
   const DATASET = {
@@ -1078,10 +1084,7 @@ describe('BigQuery/Table', () => {
     });
 
     it('should return a stream when a string is given', () => {
-      table.createWriteStream_ = () => {
-        return new stream.Writable();
-      };
-
+      sandbox.stub(table, 'createWriteStream_').returns(new stream.Writable());
       assert(table.createLoadJob(FILEPATH) instanceof stream.Stream);
     });
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -27,6 +27,7 @@ import * as uuid from 'uuid';
 import * as pfy from '@google-cloud/promisify';
 import {ServiceObject, util} from '@google-cloud/common';
 import * as sinon from 'sinon';
+import {BigQuery} from '../src';
 
 let promisified = false;
 let makeWritableStreamOverride;
@@ -158,9 +159,9 @@ describe('BigQuery/Table', () => {
     table = new Table(DATASET, TABLE_ID);
     table.bigQuery.request = util.noop;
     table.bigQuery.createJob = util.noop;
-    table.bigQuery.mergeSchemaWithRows_ = (schema, rows) => {
+    sandbox.stub(BigQuery, 'mergeSchemaWithRows_').callsFake((schema, rows) => {
       return rows;
-    };
+    });
   });
 
   describe('instantiation', () => {
@@ -1734,11 +1735,12 @@ describe('BigQuery/Table', () => {
           setImmediate(callback, null, {rows});
         };
 
-        table.bigQuery.mergeSchemaWithRows_ = (schema_, rows_) => {
+        sandbox.restore();
+        sandbox.stub(BigQuery, 'mergeSchemaWithRows_').callsFake((schema_, rows_) => {
           assert.strictEqual(schema_, schema);
           assert.strictEqual(rows_, rows);
           return mergedRows;
-        };
+        });
       });
 
       it('should refresh', done => {
@@ -1793,11 +1795,12 @@ describe('BigQuery/Table', () => {
         callback(null, {rows});
       };
 
-      table.bigQuery.mergeSchemaWithRows_ = (schema_, rows_) => {
+      sandbox.restore();
+      sandbox.stub(BigQuery, 'mergeSchemaWithRows_').callsFake((schema_, rows_) => {
         assert.strictEqual(schema_, schema);
         assert.strictEqual(rows_, rows);
         return merged;
-      };
+      });
 
       table.getRows((err, rows) => {
         assert.ifError(err);


### PR DESCRIPTION
BREAKING CHANGE: The import style of this library has been changed to be es module compatible.

### Old Code
```js
const BigQuery = require('@google-cloud/bigquery');
const bigquery = new BigQuery();
```

### New Code
```js
const {BigQuery} = require('@google-cloud/bigquery');
const bigquery = new BigQuery();
```