### PR TITLE
[hotfix] CopyTableMetadata type can’t receive optional values when ‘s…

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -124,12 +124,9 @@ export interface JobCallback {
 }
 
 export interface CreateCopyJobMetadata extends CopyTableMetadata {
-  createDisposition?: 'CREATE_IF_NEEDED'|'CREATE_NEVER';
-  destinationEncryptionConfiguration?: {kmsKeyName?: string;};
   destinationTable?: {datasetId: string; projectId: string; tableId: string;};
   sourceTable?: {datasetId: string; projectId: string; tableId: string;};
   sourceTables: Array<{datasetId: string; projectId: string; tableId: string;}>;
-  writeDisposition?: 'WRITE_TRUNCATE'|'WRITE_APPEND'|'WRITE_EMPTY';
 }
 
 export interface SetTableMetadataOptions {
@@ -140,6 +137,9 @@ export interface SetTableMetadataOptions {
 export interface CopyTableMetadata {
   jobId?: string;
   jobPrefix?: string;
+  createDisposition?: 'CREATE_IF_NEEDED'|'CREATE_NEVER';
+  writeDisposition?: 'WRITE_TRUNCATE'|'WRITE_APPEND'|'WRITE_EMPTY';
+  destinationEncryptionConfiguration?: {kmsKeyName?: string;};
 }
 
 export interface TableMetadata {

--- a/test/table.ts
+++ b/test/table.ts
@@ -28,6 +28,7 @@ import * as pfy from '@google-cloud/promisify';
 import {ServiceObject, util} from '@google-cloud/common';
 import * as sinon from 'sinon';
 import {BigQuery} from '../src';
+import {CopyTableMetadata} from '../src/table';
 
 let promisified = false;
 let makeWritableStreamOverride;
@@ -461,7 +462,10 @@ describe('BigQuery/Table', () => {
 
     it('should pass the arguments to createCopyJob', done => {
       const fakeDestination = {};
-      const fakeMetadata = {};
+      const fakeMetadata: CopyTableMetadata = {
+        createDisposition: 'CREATE_NEVER',
+        writeDisposition: 'WRITE_TRUNCATE'
+      };
 
       table.createCopyJob = (destination, metadata) => {
         assert.strictEqual(destination, fakeDestination);


### PR DESCRIPTION
…trict:true’

This is a Hotfix.
I think that it is necessary to receive all possible options.


Fixes #252

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
