### PR TITLE
Changing import of Big from big.js so it doesn't use default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import * as common from '@google-cloud/common';
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
-import Big from 'big.js';
+import {Big} from 'big.js';
 import * as extend from 'extend';
 
 const format = require('string-format-obj');


### PR DESCRIPTION
Fixes #269 (it's a good idea to open an issue first for discussion)

- [X] Tests and linter pass
- [n/a] Code coverage does not decrease (if any source code was changed)
- [n/a] Appropriate docs were updated (if necessary)


