### PR TITLE
BigQuery: Fix region tag placement typo

### DIFF
--- a/samples/queries.js
+++ b/samples/queries.js
@@ -57,8 +57,8 @@ async function queryStackOverflow() {
     console.log(`url: ${url}, ${viewCount} views`);
   });
   // [END bigquery_simple_app_print]
+  // [END bigquery_simple_app_all]
 }
-// [END bigquery_simple_app_all]
 
 async function query() {
   // [START bigquery_query]


### PR DESCRIPTION
The bigquery_simple_app_all region tag starts inside the function, so it should end inside the function. Otherwise the indentation and bracket matching are messed up when it's rendered in the docs.