### PR TITLE
fix(ts): explicit usage of Duplex

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -19,7 +19,7 @@ import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as r from 'request';
-import {Readable} from 'stream';
+import {Duplex, Readable} from 'stream';
 import {teenyRequest} from 'teeny-request';
 
 import {BigQuery, DatasetCallback, Query, QueryRowsResponse, SimpleQueryRowsCallback} from '.';
@@ -343,7 +343,7 @@ class Dataset extends ServiceObject {
    *     documentation of this method.
    * @returns {stream}
    */
-  createQueryStream(options: Query|string) {
+  createQueryStream(options: Query|string): Duplex {
     if (typeof options === 'string') {
       options = {
         query: options,

--- a/src/table.ts
+++ b/src/table.ts
@@ -31,7 +31,7 @@ import * as streamEvents from 'stream-events';
 import * as uuid from 'uuid';
 import {BigQuery, Job, Dataset, Query, SimpleQueryRowsResponse, SimpleQueryRowsCallback} from '../src';
 import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
-import {Writable, Readable} from 'stream';
+import {Duplex, Readable, Writable} from 'stream';
 import {teenyRequest} from 'teeny-request';
 import {JobMetadata} from './job';
 
@@ -1325,7 +1325,7 @@ class Table extends common.ServiceObject {
    * @returns {stream} See {@link BigQuery#createQueryStream} for full
    *     documentation of this method.
    */
-  createQueryStream(query: Query) {
+  createQueryStream(query: Query): Duplex {
     return this.dataset.createQueryStream(query);
   }
 


### PR DESCRIPTION
because otherwise, we get syntax error messages when we try to import bigquery in another project

Fixes #299 (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

The `npm run lint` command has errors but not explicitly in the part I've modified:

```
❯ npm run lint

> @google-cloud/bigquery@2.0.3 lint /Users/bchhun/projects/nodejs-bigquery
> gts check && eslint samples/


/Users/bchhun/projects/nodejs-bigquery/samples/datasets.js
  21:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  41:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  64:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require

/Users/bchhun/projects/nodejs-bigquery/samples/queries.js
  22:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  66:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  97:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require

/Users/bchhun/projects/nodejs-bigquery/samples/quickstart.js
  20:28  error  "@google-cloud/bigquery" is not found  node/no-missing-require

/Users/bchhun/projects/nodejs-bigquery/samples/system-test/datasets.test.js
  18:28  error  "@google-cloud/bigquery" is not found  node/no-missing-require

/Users/bchhun/projects/nodejs-bigquery/samples/system-test/tables.test.js
  23:28  error  "@google-cloud/bigquery" is not found  node/no-missing-require

/Users/bchhun/projects/nodejs-bigquery/samples/tables.js
   21:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
   49:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
   74:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
   96:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  128:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  161:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  193:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  242:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  291:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  358:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  417:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  472:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  526:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  588:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  649:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  704:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  765:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require
  805:30  error  "@google-cloud/bigquery" is not found  node/no-missing-require

✖ 27 problems (27 errors, 0 warnings)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @google-cloud/bigquery@2.0.3 lint: `gts check && eslint samples/`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @google-cloud/bigquery@2.0.3 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/bchhun/.npm/_logs/2018-12-10T22_40_17_760Z-debug.log
```
