### PR TITLE
Release @google-cloud/bigquery v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/bigquery?activeTab=versions
 
+## v2.0.4
+
+12-19-2018 14:35 PST
+
+### Implementation Changes
+- fix(ts): explicit usage of Duplex ([#300](https://github.com/googleapis/nodejs-bigquery/pull/300))
+- fix: fix typescript compilation ([#295](https://github.com/googleapis/nodejs-bigquery/pull/295))
+
+### Dependencies
+- fix(deps): update dependency @google-cloud/common to ^0.28.0 ([#308](https://github.com/googleapis/nodejs-bigquery/pull/308))
+- chore(deps): update dependency @types/sinon to v7 ([#307](https://github.com/googleapis/nodejs-bigquery/pull/307))
+- fix(deps): update dependency @google-cloud/common to ^0.27.0 ([#274](https://github.com/googleapis/nodejs-bigquery/pull/274))
+
+### Documentation
+- fix(docs): move doc comments so stream methods show up in docs correctly ([#309](https://github.com/googleapis/nodejs-bigquery/pull/309))
+
+### Internal / Testing Changes
+- chore(build): inject yoshi automation key ([#306](https://github.com/googleapis/nodejs-bigquery/pull/306))
+- chore: update nyc and eslint configs ([#305](https://github.com/googleapis/nodejs-bigquery/pull/305))
+- chore: fix publish.sh permission +x ([#302](https://github.com/googleapis/nodejs-bigquery/pull/302))
+- fix(build): fix Kokoro release script ([#301](https://github.com/googleapis/nodejs-bigquery/pull/301))
+- build: add Kokoro configs for autorelease ([#298](https://github.com/googleapis/nodejs-bigquery/pull/298))
+
 ## v2.0.3
 
 12-06-2018 17:10 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/bigquery",
   "description": "Google BigQuery Client Library for Node.js",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "cover": "nyc --reporter=lcov --cache mocha system-test/*.test.js --timeout 1800000 && nyc report"
   },
   "dependencies": {
-    "@google-cloud/bigquery": "^2.0.3",
+    "@google-cloud/bigquery": "^2.0.4",
     "@google-cloud/storage": "^2.0.0",
     "yargs": "^12.0.0"
   },


### PR DESCRIPTION
As with any changes in types, I'm a little held back whether it should qualify as a patch vs a minor release. Please let me know if a patch release here doesn't make sense.