### PR TITLE
docs: regenerate README.md

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -2,28 +2,28 @@
   "requiresKeyFile": true,
   "requiresProjectId": true,
   "product": "bigquery",
-  "client_reference_url": "https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery",
+  "client_reference_url": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/",
   "release_quality": "ga",
   "samples": [
     {
       "id": "datasets",
       "name": "Datasets",
       "file": "datasets.js",
-      "docs_link": "https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery/dataset",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/",
       "usage": "node datasets.js --help"
     },
     {
       "id": "tables",
       "name": "Tables",
       "file": "tables.js",
-      "docs_link": "https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/latest/bigquery/table",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/",
       "usage": "node tables.js --help"
     },
     {
       "id": "queries",
       "name": "Queries",
       "file": "queries.js",
-      "docs_link": "https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/",
       "usage": "node queries.js --help"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -8,87 +8,46 @@
 [![npm version](https://img.shields.io/npm/v/@google-cloud/bigquery.svg)](https://www.npmjs.org/package/@google-cloud/bigquery)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-bigquery/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-bigquery)
 
-> Node.js idiomatic client for [BigQuery][product-docs].
-
 [BigQuery](https://cloud.google.com/bigquery/docs) is Google&#x27;s fully managed, petabyte scale, low cost analytics data warehouse. BigQuery is NoOps—there is no infrastructure to manage and you don&#x27;t need a database administrator—so you can focus on analyzing data to find meaningful insights, use familiar SQL, and take advantage of our pay-as-you-go model.
 
 
-* [BigQuery Node.js Client API Reference][client-docs]
-* [github.com/googleapis/nodejs-bigquery](https://github.com/googleapis/nodejs-bigquery)
-* [BigQuery Documentation][product-docs]
-
-Read more about the client libraries for Cloud APIs, including the older
-Google APIs Client Libraries, in [Client Libraries Explained][explained].
-
-[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
-
-**Table of contents:**
-
-* [Quickstart](#quickstart)
-  * [Before you begin](#before-you-begin)
-  * [Installing the client library](#installing-the-client-library)
-  * [Using the client library](#using-the-client-library)
+* [Using the client library](#using-the-client-library)
 * [Samples](#samples)
 * [Versioning](#versioning)
 * [Contributing](#contributing)
 * [License](#license)
 
-## Quickstart
+## Using the client library
 
-### Before you begin
+1.  [Select or create a Cloud Platform project][projects].
 
-1.  Select or create a Cloud Platform project.
+1.  [Enable billing for your project][billing].
 
-    [Go to the projects page][projects]
-
-1.  Enable billing for your project.
-
-    [Enable billing][billing]
-
-1.  Enable the Google BigQuery API.
-
-    [Enable the API][enable_api]
+1.  [Enable the Google BigQuery API][enable_api].
 
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
-[projects]: https://console.cloud.google.com/project
-[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquery-json.googleapis.com
-[auth]: https://cloud.google.com/docs/authentication/getting-started
+1. Install the client library:
 
-### Installing the client library
+        npm install --save @google-cloud/bigquery
 
-    npm install --save @google-cloud/bigquery
-
-### Using the client library
+1. Try an example:
 
 ```javascript
-// Imports the Google Cloud client library
-const {BigQuery} = require('@google-cloud/bigquery');
+async function createDataset(
+  datasetName = 'my_new_dataset' // Name for the new dataset
+) {
+  // Imports the Google Cloud client library
+  const {BigQuery} = require('@google-cloud/bigquery');
 
-// Your Google Cloud Platform project ID
-const projectId = 'YOUR_PROJECT_ID';
+  // Creates a client
+  const bigquery = new BigQuery();
 
-// Creates a client
-const bigquery = new BigQuery({
-  projectId: projectId,
-});
-
-// The name for the new dataset
-const datasetName = 'my_new_dataset';
-
-// Creates the new dataset
-bigquery
-  .createDataset(datasetName)
-  .then(results => {
-    const dataset = results[0];
-
-    console.log(`Dataset ${dataset.id} created.`);
-  })
-  .catch(err => {
-    console.error('ERROR:', err);
-  });
+  // Create the dataset
+  const [dataset] = await bigquery.createDataset(datasetName);
+  console.log(`Dataset ${dataset.id} created.`);
+}
 ```
 
 ## Samples
@@ -129,7 +88,21 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-bigquery/blob/master/LICENSE)
 
-[client-docs]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery
+## What's Next
+
+* [BigQuery Documentation][product-docs]
+* [BigQuery Node.js Client API Reference][client-docs]
+* [github.com/googleapis/nodejs-bigquery](https://github.com/googleapis/nodejs-bigquery)
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+[client-docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
 [product-docs]: https://cloud.google.com/bigquery/docs
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-
+[projects]: https://console.cloud.google.com/project
+[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
+[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquery-json.googleapis.com
+[auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,34 +1,28 @@
-[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
-[//]: # "To regenerate it, use `npm run generate-scaffolding`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
 # Google BigQuery: Node.js Samples
 
-[![Open in Cloud Shell][shell_img]][shell_link]
+[![Build](https://storage.googleapis.com/.svg)]()
 
 [BigQuery](https://cloud.google.com/bigquery/docs) is Google&#x27;s fully managed, petabyte scale, low cost analytics data warehouse. BigQuery is NoOps—there is no infrastructure to manage and you don&#x27;t need a database administrator—so you can focus on analyzing data to find meaningful insights, use familiar SQL, and take advantage of our pay-as-you-go model.
 
 ## Table of Contents
 
-* [Before you begin](#before-you-begin)
+* [Setup](#setup)
 * [Samples](#samples)
   * [Datasets](#datasets)
   * [Tables](#tables)
   * [Queries](#queries)
+* [Running the tests](#running-the-tests)
 
-## Before you begin
+## Setup
 
-Before running the samples, make sure you've followed the steps in the
-[Before you begin section](../README.md#before-you-begin) of the client
-library's README.
 
 ## Samples
 
 ### Datasets
 
-View the [source code][datasets_0_code].
-
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/datasets.js,samples/README.md)
+View the [documentation][datasets_0_docs] or the [source code][datasets_0_code].
 
 __Usage:__ `node datasets.js --help`
 
@@ -52,14 +46,12 @@ Examples:
 For more information, see https://cloud.google.com/bigquery/docs
 ```
 
-[datasets_0_docs]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery/dataset
+[datasets_0_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
 [datasets_0_code]: datasets.js
 
 ### Tables
 
-View the [source code][tables_1_code].
-
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/tables.js,samples/README.md)
+View the [documentation][tables_1_docs] or the [source code][tables_1_code].
 
 __Usage:__ `node tables.js --help`
 
@@ -73,14 +65,27 @@ Commands:
   tables.js copy <projectId> <srcDatasetId> <srcTableId>        Makes a copy of a table.
   <destDatasetId> <destTableId>
   tables.js browse <projectId> <datasetId> <tableId>            Lists rows in a table.
-  tables.js load <projectId> <datasetId> <tableId> <fileName>   Loads data from a local file into a table.
-  tables.js load-gcs <projectId> <datasetId> <tableId>          Loads data from a Google Cloud Storage file into a
-  <bucketName> <fileName>                                       table.
+  tables.js load-local-csv <projectId> <datasetId> <tableId>    Loads data from a local file into a table.
+  <fileName>
+  tables.js load-gcs-orc <projectId> <datasetId> <tableId>      Loads sample ORC data from a Google Cloud Storage file
+                                                                into a table.
+  tables.js load-gcs-parquet <projectId> <datasetId> <tableId>  Loads sample Parquet data from a Google Cloud Storage
+                                                                file into a table.
   tables.js load-gcs-csv <projectId> <datasetId> <tableId>      Loads sample CSV data from a Google Cloud Storage file
+                                                                into a table.
+  tables.js load-gcs-json <projectId> <datasetId> <tableId>     Loads sample JSON data from a Google Cloud Storage file
                                                                 into a table.
   tables.js load-gcs-csv-autodetect <projectId> <datasetId>     Loads sample CSV data from a Google Cloud Storage file
   <tableId>                                                     into a table.
+  tables.js load-gcs-json-autodetect <projectId> <datasetId>    Loads sample JSON data from a Google Cloud Storage file
+  <tableId>                                                     into a table.
   tables.js load-gcs-csv-truncate <projectId> <datasetId>       Loads sample CSV data from GCS, replacing an existing
+  <tableId>                                                     table.
+  tables.js load-gcs-json-truncate <projectId> <datasetId>      Loads sample JSON data from GCS, replacing an existing
+  <tableId>                                                     table.
+  tables.js load-gcs-parquet-truncate <projectId> <datasetId>   Loads sample Parquet data from GCS, replacing an
+  <tableId>                                                     existing table.
+  tables.js load-gcs-orc-truncate <projectId> <datasetId>       Loads sample Orc data from GCS, replacing an existing
   <tableId>                                                     table.
   tables.js extract <projectId> <datasetId> <tableId>           Extract a table from BigQuery to Google Cloud Storage.
   <bucketName> <fileName>
@@ -115,14 +120,12 @@ Examples:
 For more information, see https://cloud.google.com/bigquery/docs
 ```
 
-[tables_1_docs]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/latest/bigquery/table
+[tables_1_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
 [tables_1_code]: tables.js
 
 ### Queries
 
-View the [source code][queries_2_code].
-
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/queries.js,samples/README.md)
+View the [documentation][queries_2_docs] or the [source code][queries_2_code].
 
 __Usage:__ `node queries.js --help`
 
@@ -130,26 +133,24 @@ __Usage:__ `node queries.js --help`
 queries.js <command>
 
 Commands:
-  queries.js sync <projectId> <sqlQuery>   Run the specified synchronous query.
-  queries.js async <projectId> <sqlQuery>  Start the specified asynchronous query.
-  queries.js stackoverflow <projectId>     Queries a public Stack Overflow dataset.
+  queries.js stackoverflow  Queries a public Stack Overflow dataset.
+  queries.js query          Queries the US Names dataset.
+  queries.js disable-cache  Queries the Shakespeare dataset with the cache disabled.
 
 Options:
   --version  Show version number                                                                               [boolean]
   --help     Show help                                                                                         [boolean]
 
 Examples:
-  node queries.js sync my-project-id "SELECT * FROM             Synchronously queries the natality dataset.
-  publicdata.samples.natality LIMIT 5;"
-  node queries.js async my-project-id "SELECT * FROM            Queries the natality dataset as a job.
-  publicdata.samples.natality LIMIT 5;"
-  node queries.js shakespeare my-project-id                     Queries a public Shakespeare dataset.
+  node queries.js stackoverflow  Queries a public Stackoverflow dataset.
+  node queries.js query          Queries the US Names dataset.
+  node queries.js disable-cache  Queries the Shakespeare dataset with the cache disabled.
 
 For more information, see https://cloud.google.com/bigquery/docs
 ```
 
-[queries_2_docs]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/bigquery/latest/bigquery
+[queries_2_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
 [queries_2_code]: queries.js
 
-[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/README.md
+## Running the tests
+


### PR DESCRIPTION
The README.md's haven't been updated for a long time - it still has links from when we hosted docs on `googleapis.github.io`