### PR TITLE
fix: correctly iterate query results within stream

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -1633,7 +1633,6 @@ describe('BigQuery', () => {
     it('should call job#getQueryResults', done => {
       const fakeJob = {
         getQueryResults: (options: {}, callback: Function) => {
-          assert.deepStrictEqual(options, {});
           callback(null, FAKE_ROWS, FAKE_RESPONSE);
         },
       };
@@ -1650,11 +1649,27 @@ describe('BigQuery', () => {
       });
     });
 
+    it('should assign Job on the options', done => {
+      const fakeJob = {
+        getQueryResults: (options: {}, callback: Function) => {
+          assert.deepStrictEqual(options, {job: fakeJob});
+          done();
+        },
+      };
+
+      bq.createQueryJob = (query: {}, callback: Function) => {
+        callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      bq.query(QUERY_STRING, assert.ifError);
+    });
+
     it('should optionally accept options', done => {
       const fakeOptions = {};
       const fakeJob = {
         getQueryResults: (options: {}) => {
-          assert.strictEqual(options, fakeOptions);
+          assert.notStrictEqual(options, fakeOptions);
+          assert.deepStrictEqual(options, {job: fakeJob});
           done();
         },
       };


### PR DESCRIPTION
Fixes #303 

In a stream, we-- y'know what, @oliverwoodings explained it best: https://github.com/googleapis/nodejs-bigquery/issues/303#issuecomment-452288078

> - My code calls `bigquery.createQueryStream()` with a query. Note that this function has been wrapped by @google-cloud/paginator
> - This calls `queryAsStream_` (https://github.com/googleapis/nodejs-bigquery/blob/master/src/index.ts#L1515), which ends up calling `createQueryJob`
> - After we have a job, we call `job.getQueryResults` (https://github.com/googleapis/nodejs-bigquery/blob/master/src/index.ts#L1505).
> - After getting the job status, the job i'm running hasn't completed, so we call back with no rows and no page token (https://github.com/googleapis/nodejs-bigquery/blob/master/src/job.ts#L418-L428)
> - The `callback` given to `getQueryResults` that is called at this point is actually the results handler from @google-cloud/paginator (https://github.com/googleapis/nodejs-paginator/blob/master/src/index.ts#L315)
> - Because there is a `nextQuery` given to `onResultSet` of the paginator, and there are still rows to send, the paginator executes the request again (https://github.com/googleapis/nodejs-paginator/blob/master/src/index.ts#L332-L335)
> - `makeRequest` in the paginator calls `originalMethod`, which in this case is actually `BigQuery.queryAsStream_`, which means it tries to create an entire new query job, instead of just polling for more results?!