### PR TITLE
fix(types): Allows views to be configured using an object or a string

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -161,7 +161,12 @@ export interface TableMetadata {
   friendlyName: string;
   schema?: string|TableField[];
   partitioning?: string;
-  view?: string;
+  view?: string|ViewDefinition;
+}
+
+export interface ViewDefinition {
+  query: string;
+  useLegacySql?: boolean;
 }
 
 export interface FormattedMetadata {
@@ -170,7 +175,7 @@ export interface FormattedMetadata {
   name?: string;
   partitioning?: string;
   timePartitioning?: {type: string};
-  view: {query: string; useLegacySql: boolean;};
+  view: ViewDefinition;
 }
 
 export interface TableSchema {
@@ -582,7 +587,7 @@ class Table extends common.ServiceObject {
 
     if (is.string(options.view)) {
       body.view = {
-        query: options.view!,
+        query: options.view! as string,
         useLegacySql: false,
       };
     }

--- a/test/table.ts
+++ b/test/table.ts
@@ -30,7 +30,7 @@ import * as uuid from 'uuid';
 
 import {BigQuery} from '../src';
 import {Job, JobOptions} from '../src/job';
-import {CopyTableMetadata, JobLoadMetadata, Table, TableOptions} from '../src/table';
+import {CopyTableMetadata, JobLoadMetadata, Table, TableOptions, ViewDefinition} from '../src/table';
 
 let promisified = false;
 let makeWritableStreamOverride: Function|null;
@@ -452,6 +452,15 @@ describe('BigQuery/Table', () => {
       assert.strictEqual(formatted.view.query, VIEW);
       assert.strictEqual(formatted.view.useLegacySql, false);
     });
+
+    it('should allow the view option to be passed as a pre-formatted object',
+       () => {
+         const view: ViewDefinition = {query: 'abc', useLegacySql: false};
+
+         const {view: formattedView} = Table.formatMetadata_({view});
+
+         assert.deepEqual(formattedView, view);
+       });
   });
 
   describe('copy', () => {


### PR DESCRIPTION
Previously, only a string containing the view definition query could be provided. This allows an object, as described in the API documentation: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource.

Fixes #332

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] ~~Appropriate docs were updated (if necessary)~~
