### PR TITLE
feat: throw errors for missing resource ids

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -639,6 +639,10 @@ class Dataset extends ServiceObject {
    * const institutions = dataset.table('institution_data');
    */
   table(id: string, options?: TableOptions) {
+    if (typeof id !== 'string') {
+      throw new TypeError('A table ID is required.');
+    }
+
     options = extend(
         {
           location: this.location,

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -621,6 +621,8 @@ class Dataset extends ServiceObject {
   /**
    * Create a Table object.
    *
+   * @throws {TypeError} if table ID is missing.
+   *
    * @param {string} id The ID of the table.
    * @param {object} [options] Table options.
    * @param {string} [options.location] The geographic location of the table, by

--- a/src/index.ts
+++ b/src/index.ts
@@ -1163,6 +1163,10 @@ export class BigQuery extends common.Service {
    * const dataset = bigquery.dataset('higher_education');
    */
   dataset(id: string, options?: DataSetOptions) {
+    if (typeof id !== 'string') {
+      throw new TypeError('A dataset ID is required.');
+    }
+
     if (this.location) {
       options = extend({location: this.location}, options);
     }

--- a/test/dataset.ts
+++ b/test/dataset.ts
@@ -785,6 +785,11 @@ describe('BigQuery/Dataset', () => {
   });
 
   describe('table', () => {
+    it('should throw an error if the id is missing', () => {
+      const expectedErr = /A table ID is required\./;
+      assert.throws(() => ds.table(), expectedErr);
+    });
+
     it('should return a Table object', () => {
       const tableId = 'tableId';
       const table = ds.table(tableId);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1248,6 +1248,11 @@ describe('BigQuery', () => {
   describe('dataset', () => {
     const DATASET_ID = 'dataset-id';
 
+    it('should throw an error if the id is missing', () => {
+      const expectedErr = /A dataset ID is required\./;
+      assert.throws(() => bq.dataset(), expectedErr);
+    });
+
     it('returns a Dataset instance', () => {
       const ds = bq.dataset(DATASET_ID);
       assert(ds instanceof FakeDataset);


### PR DESCRIPTION
Fixes #325 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
