### PR TITLE
fix(types): move JobLoadMetadata writeDisposition

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -119,8 +119,8 @@ export interface JobLoadMetadata {
     field?: string;
     requirePartitionFilter?: boolean;
     type?: string;
-    writeDisposition?: string;
   };
+  writeDisposition?: string;
 }
 
 export interface CreateExtractJobOptions {


### PR DESCRIPTION
The `writeDisposition` field for interface `JobLoadMetadata` appears to have been defined incorrectly; it does not belong under `timePartitioning`.

Typescript fails to compile if I define it under the root, but works as expected if I cast the options to `any` like so:

```javascript
new BigQuery({ projectId: "my-project-id" })
    .dataset("my_dataset")
    .table("my_table")
    .load("my_file.csv", {
        format: "csv",
        writeDisposition: "WRITE_TRUNCATE",
    } as any);
```

See:
https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
