### PR TITLE
fix: update samples and docs to match rubric

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -6,11 +6,22 @@
   "release_quality": "ga",
   "samples": [
     {
-      "id": "datasets",
-      "name": "Datasets",
-      "file": "datasets.js",
-      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/",
-      "usage": "node datasets.js --help"
+      "id": "dataset-create",
+      "name": "Dataset create",
+      "file": "createDataset.js",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/"
+    },
+    {
+      "id": "dataset-delete",
+      "name": "Dataset delete",
+      "file": "deleteDataset.js",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/"
+    },
+    {
+      "id": "dataset-list",
+      "name": "Dataset list",
+      "file": "listDatasets.js",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigquery/latest/"
     },
     {
       "id": "tables",

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@
 1. Try an example:
 
 ```javascript
-async function createDataset(
-  datasetName = 'my_new_dataset' // Name for the new dataset
-) {
   // Imports the Google Cloud client library
   const {BigQuery} = require('@google-cloud/bigquery');
 
@@ -47,7 +44,6 @@ async function createDataset(
   // Create the dataset
   const [dataset] = await bigquery.createDataset(datasetName);
   console.log(`Dataset ${dataset.id} created.`);
-}
 ```
 
 ## Samples
@@ -57,7 +53,9 @@ has instructions for running the samples.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
-| Datasets | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/datasets.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/datasets.js,samples/README.md) |
+| Dataset create | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/createDataset.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/createDataset.js,samples/README.md) |
+| Dataset delete | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/deleteDataset.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/deleteDataset.js,samples/README.md) |
+| Dataset list | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/listDatasets.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/listDatasets.js,samples/README.md) |
 | Tables | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/tables.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/tables.js,samples/README.md) |
 | Queries | [source code](https://github.com/googleapis/nodejs-bigquery/blob/master/samples/queries.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/queries.js,samples/README.md) |
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "docs-test": "linkinator docs -r --skip www.googleapis.com",
-    "predocs-test": "npm run docs"
+    "predocs-test": "npm run docs",
+    "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json"
   },
   "dependencies": {
     "@google-cloud/common": "^0.31.0",

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,57 +1,57 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `npm run generate-scaffolding`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
 # Google BigQuery: Node.js Samples
 
-[![Build](https://storage.googleapis.com/.svg)]()
+[![Open in Cloud Shell][shell_img]][shell_link]
 
 [BigQuery](https://cloud.google.com/bigquery/docs) is Google&#x27;s fully managed, petabyte scale, low cost analytics data warehouse. BigQuery is NoOps—there is no infrastructure to manage and you don&#x27;t need a database administrator—so you can focus on analyzing data to find meaningful insights, use familiar SQL, and take advantage of our pay-as-you-go model.
 
 ## Table of Contents
 
-* [Setup](#setup)
+* [Before you begin](#before-you-begin)
 * [Samples](#samples)
-  * [Datasets](#datasets)
+  * [Dataset create](#dataset-create)
+  * [Dataset delete](#dataset-delete)
+  * [Dataset list](#dataset-list)
   * [Tables](#tables)
   * [Queries](#queries)
-* [Running the tests](#running-the-tests)
 
-## Setup
+## Before you begin
 
+Before running the samples, make sure you've followed the steps in the
+[Before you begin section](../README.md#before-you-begin) of the client
+library's README.
 
 ## Samples
 
-### Datasets
+### Dataset create
 
-View the [documentation][datasets_0_docs] or the [source code][datasets_0_code].
+View the [source code][dataset-create_0_code].
 
-__Usage:__ `node datasets.js --help`
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/createDataset.js,samples/README.md)[dataset-create_0_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
+[dataset-create_0_code]: createDataset.js
 
-```
-datasets.js <command>
+### Dataset delete
 
-Commands:
-  datasets.js create <projectId> <datasetId>  Creates a new dataset.
-  datasets.js delete <projectId> <datasetId>  Deletes a dataset.
-  datasets.js list <projectId>                Lists datasets.
+View the [source code][dataset-delete_1_code].
 
-Options:
-  --version  Show version number                                                                               [boolean]
-  --help     Show help                                                                                         [boolean]
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/deleteDataset.js,samples/README.md)[dataset-delete_1_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
+[dataset-delete_1_code]: deleteDataset.js
 
-Examples:
-  node datasets.js create my-project-id my_dataset  Creates a new dataset named "my_dataset".
-  node datasets.js delete my-project-id my_dataset  Deletes a dataset named "my_dataset".
-  node datasets.js list my-project-id               Lists all datasets in my-project-id.
+### Dataset list
 
-For more information, see https://cloud.google.com/bigquery/docs
-```
+View the [source code][dataset-list_2_code].
 
-[datasets_0_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
-[datasets_0_code]: datasets.js
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/listDatasets.js,samples/README.md)[dataset-list_2_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
+[dataset-list_2_code]: listDatasets.js
 
 ### Tables
 
-View the [documentation][tables_1_docs] or the [source code][tables_1_code].
+View the [source code][tables_3_code].
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/tables.js,samples/README.md)
 
 __Usage:__ `node tables.js --help`
 
@@ -120,12 +120,14 @@ Examples:
 For more information, see https://cloud.google.com/bigquery/docs
 ```
 
-[tables_1_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
-[tables_1_code]: tables.js
+[tables_3_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
+[tables_3_code]: tables.js
 
 ### Queries
 
-View the [documentation][queries_2_docs] or the [source code][queries_2_code].
+View the [source code][queries_4_code].
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/queries.js,samples/README.md)
 
 __Usage:__ `node queries.js --help`
 
@@ -149,8 +151,8 @@ Examples:
 For more information, see https://cloud.google.com/bigquery/docs
 ```
 
-[queries_2_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
-[queries_2_code]: queries.js
+[queries_4_docs]: https://cloud.google.com/nodejs/docs/reference/bigquery/latest/
+[queries_4_code]: queries.js
 
-## Running the tests
-
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigquery&page=editor&open_in_editor=samples/README.md

--- a/samples/createDataset.js
+++ b/samples/createDataset.js
@@ -12,24 +12,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
-// [START bigquery_delete_dataset]
-async function bigquery_delete_dataset(DATASET_ID = 'YOUR_DATASET_ID') {
+async function createDataset(DATASET_ID = 'YOUR_DATASET_ID') {
+  // [START bigquery_create_dataset]
   // Imports the Google Cloud client library
   const {BigQuery} = require('@google-cloud/bigquery');
 
   // Creates a client
   const bigquery = new BigQuery();
 
-  // Creates a reference to the existing dataset
-  const dataset = bigquery.dataset(DATASET_ID);
-
-  // Deletes the dataset
-  await dataset.delete();
-  console.log(`Dataset ${dataset.id} deleted.`);
+  // Creates a new dataset
+  const [dataset] = await bigquery.createDataset(DATASET_ID);
+  console.log(`Dataset ${dataset.id} created.`);
+  // [END bigquery_create_dataset]
 }
-// [END bigquery_delete_dataset]
 
-bigquery_delete_dataset(...process.argv.slice(2)).catch(console.error);
+createDataset(...process.argv.slice(2)).catch(console.error);

--- a/samples/deleteDataset.js
+++ b/samples/deleteDataset.js
@@ -12,20 +12,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 'use strict';
 
-// [START bigquery_create_dataset]
-async function bigquery_create_dataset(DATASET_ID = 'YOUR_DATASET_ID') {
+async function deleteDataset(DATASET_ID = 'YOUR_DATASET_ID') {
+  // [START bigquery_delete_dataset]
   // Imports the Google Cloud client library
   const {BigQuery} = require('@google-cloud/bigquery');
 
   // Creates a client
   const bigquery = new BigQuery();
 
-  // Creates a new dataset
-  const [dataset] = await bigquery.createDataset(DATASET_ID);
-  console.log(`Dataset ${dataset.id} created.`);
-}
-// [END bigquery_create_dataset]
+  // Creates a reference to the existing dataset
+  const dataset = bigquery.dataset(DATASET_ID);
 
-bigquery_create_dataset(...process.argv.slice(2)).catch(console.error);
+  // Deletes the dataset
+  await dataset.delete();
+  console.log(`Dataset ${dataset.id} deleted.`);
+  // [END bigquery_delete_dataset]
+}
+
+deleteDataset(...process.argv.slice(2)).catch(console.error);

--- a/samples/listDatasets.js
+++ b/samples/listDatasets.js
@@ -14,8 +14,8 @@
  */
 'use strict';
 
-// [START bigquery_list_datasets]
-async function bigquery_list_datasets() {
+async function listDatasets() {
+  // [START bigquery_list_datasets]
   // Imports the Google Cloud client library
   const {BigQuery} = require('@google-cloud/bigquery');
 
@@ -26,7 +26,7 @@ async function bigquery_list_datasets() {
   const [datasets] = await bigquery.getDatasets();
   console.log('Datasets:');
   datasets.forEach(dataset => console.log(dataset.id));
+  // [END bigquery_list_datasets]
 }
-// [END bigquery_list_datasets]
 
-bigquery_list_datasets(...process.argv.slice(2)).catch(console.error);
+listDatasets(...process.argv.slice(2)).catch(console.error);

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -15,10 +15,10 @@
 
 'use strict';
 
-// [START bigquery_quickstart]
 async function createDataset(
   datasetName = 'my_new_dataset' // Name for the new dataset
 ) {
+  // [START bigquery_quickstart]
   // Imports the Google Cloud client library
   const {BigQuery} = require('@google-cloud/bigquery');
 
@@ -28,8 +28,8 @@ async function createDataset(
   // Create the dataset
   const [dataset] = await bigquery.createDataset(datasetName);
   console.log(`Dataset ${dataset.id} created.`);
+  // [END bigquery_quickstart]
 }
-// [END bigquery_quickstart]
 
 const args = process.argv.slice(2);
 createDataset(...args).catch(console.error);

--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const {BigQuery} = require('@google-cloud/bigquery');
@@ -18,23 +33,20 @@ describe(`Datasets`, () => {
   });
 
   it(`should create a dataset`, async () => {
-    const REGION_TAG = 'bigquery_create_dataset';
-    const output = await exec(`node ${REGION_TAG}.js ${DATASET_ID}`);
+    const output = await exec(`node createDataset.js ${DATASET_ID}`);
     assert.strictEqual(output, `Dataset ${DATASET_ID} created.`);
     const [exists] = await bigquery.dataset(DATASET_ID).exists();
     assert.ok(exists);
   });
 
   it(`should list datasets`, async () => {
-    const REGION_TAG = 'bigquery_list_datasets';
-    const output = await exec(`node ${REGION_TAG}.js`);
+    const output = await exec(`node listDatasets.js`);
     assert.match(output, /Datasets:/);
     assert.match(output, new RegExp(DATASET_ID));
   });
 
   it(`should delete a dataset`, async () => {
-    const REGION_TAG = 'bigquery_delete_dataset';
-    const output = await exec(`node ${REGION_TAG}.js ${DATASET_ID}`);
+    const output = await exec(`node deleteDataset.js ${DATASET_ID}`);
     assert.strictEqual(output, `Dataset ${DATASET_ID} deleted.`);
     const [exists] = await bigquery.dataset(DATASET_ID).exists();
     assert.strictEqual(exists, false);

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -170,21 +170,14 @@ describe('BigQuery', () => {
         });
   });
 
-  it('should allow for manual pagination in promise mode', () => {
-    return bigquery
-        .getDatasets({
-          autoPaginate: false,
-          filter: `labels.${GCLOUD_TESTS_PREFIX}`,
-        } as GetDatasetsOptions)
-        .then(data => {
-          const datasets = data[0];
-          const nextQuery = data[1];
-          const apiResponse = data[2];
-
-          assert(datasets[0] instanceof Dataset);
-          assert.strictEqual(nextQuery, null);
-          assert(apiResponse);
-        });
+  it('should allow for manual pagination in promise mode', async () => {
+    const [datasets, nextQuery, apiResponse] = await bigquery.getDatasets({
+      autoPaginate: false,
+      filter: `labels.${GCLOUD_TESTS_PREFIX}`,
+    });
+    assert(datasets[0] instanceof Dataset);
+    assert.strictEqual(nextQuery, null);
+    assert(apiResponse);
   });
 
   it('should list datasets as a stream', done => {


### PR DESCRIPTION
So... I made a few mistakes. During the code review of #368, a few things slipped:
1. Renames the sample files from `bigquery_dataset_bleh.js` to `createDataset.js`
1. Moves the region tags *inside* of the function definition, to match the rubric
1. Update `cloud-repo-tools.json` to include the new samples
1. Runs the repo-tools generation step to update the documentation 
