### PR TITLE
testing: remove nextQuery assertion

### DIFF
--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -176,7 +176,6 @@ describe('BigQuery', () => {
       filter: `labels.${GCLOUD_TESTS_PREFIX}`,
     });
     assert(datasets[0] instanceof Dataset);
-    assert.strictEqual(nextQuery, null);
     assert(apiResponse);
   });
 


### PR DESCRIPTION
Fixes #375 

Since we refactored our strategy for dealing with lingering resources, sometimes `nextQuery` will be populated with a page of resources from a different test run. 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
