### PR TITLE
fix(ts): provide complete and correct types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "presystem-test": "npm run compile",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p .",
+    "compile": "tsc -p . && cp src/types.d.ts build/src/",
     "fix": "gts fix && eslint --fix '**/*.js'",
     "predocs": "npm run compile",
     "prepare": "npm run compile",

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -24,7 +24,7 @@ import {teenyRequest} from 'teeny-request';
 
 import {BigQuery, DatasetCallback, PagedCallback, PagedRequest, PagedResponse, Query, QueryRowsResponse, ResourceCallback, SimpleQueryRowsCallback} from '.';
 import {JobCallback, JobResponse, Table, TableMetadata, TableOptions} from './table';
-import {bigquery} from './types';
+import bigquery from './types';
 
 export interface DatasetDeleteOptions {
   force?: boolean;
@@ -36,11 +36,11 @@ export interface DataSetOptions {
 
 export type CreateDatasetOptions = bigquery.IDataset;
 
-export type GetTablesOptions = PagedRequest<bigquery.IListTablesRequest>;
+export type GetTablesOptions = PagedRequest<bigquery.tables.IListParams>;
 export type GetTablesResponse =
-    PagedResponse<Table, GetTablesOptions, bigquery.IListTablesResponse>;
+    PagedResponse<Table, GetTablesOptions, bigquery.ITableList>;
 export type GetTablesCallback =
-    PagedCallback<Table, GetTablesOptions, bigquery.IListTablesResponse>;
+    PagedCallback<Table, GetTablesOptions, bigquery.ITableList>;
 
 export type TableResponse = [Table, bigquery.ITable];
 export type TableCallback = ResourceCallback<Table, bigquery.ITable>;

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -30,7 +30,7 @@ export interface DatasetDeleteOptions {
   force?: boolean;
 }
 
-export interface DataSetOptions {
+export interface DatasetOptions {
   location?: string;
 }
 
@@ -65,7 +65,7 @@ class Dataset extends ServiceObject {
   bigQuery: BigQuery;
   location?: string;
   getTablesStream: (options?: GetTablesOptions) => ResourceStream<Table>;
-  constructor(bigQuery: BigQuery, id: string, options?: DataSetOptions) {
+  constructor(bigQuery: BigQuery, id: string, options?: DatasetOptions) {
     const methods = {
       /**
        * Create a dataset.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@google-cloud/common';
-import {paginator} from '@google-cloud/paginator';
+import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
 import {Big} from 'big.js';
@@ -28,113 +28,76 @@ import * as uuid from 'uuid';
 import {teenyRequest} from 'teeny-request';
 
 import {Dataset, DataSetOptions} from './dataset';
-import {Job, JobOptions} from './job';
+import {Job, JobOptions, QueryResultsOptions} from './job';
 import {Table, TableField, TableSchema, TableRow, TableRowField, JobCallback, JobResponse, RowsCallback, RowsResponse, RowMetadata} from './table';
 import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
 import {Readable, Duplex} from 'stream';
+import {bigquery} from './types';
 
-// tslint:disable-next-line no-any
-export type QueryRowsResponse = [any[], Query, r.Response];
-export interface QueryRowsCallback {
-  // tslint:disable-next-line no-any
-  (err: Error|null, rows?: any[]|null, nextQuery?: Query|null,
-   apiResponse?: r.Response): void;
+export interface RequestCallback<T> {
+  (err: Error|null, response?: T|null): void;
 }
 
-// tslint:disable-next-line no-any
-export type SimpleQueryRowsResponse = [any[], r.Response];
-export interface SimpleQueryRowsCallback {
-  // tslint:disable-next-line no-any
-  (err: Error|null, rows?: any[]|null, apiResponse?: r.Response): void;
+export interface ResourceCallback<T, R> {
+  (err: Error|null, resource?: T|null, response?: R|null): void;
 }
 
-export interface Query {
-  dryRun?: boolean;
-  location?: string;
-  job?: Job;
+export type PagedResponse<T, Q, R> = [T[]]|[T[], Q | null, R];
+export interface PagedCallback<T, Q, R> {
+  (err: Error|null, resource?: T[]|null, nextQuery?: Q|null,
+   response?: R|null): void;
+}
+
+export type JobRequest<J> = J&{
   jobId?: string;
   jobPrefix?: string;
-  // tslint:disable-next-line no-any
-  params?: any;
-  query?: string;
-  useLegacySql?: boolean;
-  maxResults?: number;
-  timeoutMs?: number;
-  pageToken?: string;
-  destination?: Table;
-  defaultDataset?: Dataset;
-}
-
-export interface QueryOptions {
-  maxResults?: number;
-  timeoutMs?: number;
-  autoPaginate?: boolean;
-}
-
-export interface DatasetResource {
-  etag?: string;
-  id?: string;
-  selfLink?: string;
-  datasetReference?: {datasetId?: string, projectId?: string};
-  friendlyName?: string;
-  description?: string;
-  defaultTableExpirationMs?: number;
-  defaultPartitionExpirationMs?: number;
-  labels?: {[index: string]: string};
-  access?: [{
-    role?: string;
-    userByEmail?: string;
-    groupByEmail?: string;
-    domain?: string;
-    specialGroup?: string;
-    view?: {projectId?: string; datasetId?: string; tableId?: string;}
-  }];
-  creationTime?: number;
-  lastModifiedTime?: number;
   location?: string;
-}
+};
 
-export interface ValueType {
-  type: string;
-  arrayType?: ValueType;
-  structTypes?: Array<{name: string; type: ValueType;}>;
-}
-
-export interface GetDatasetsOptions {
-  all?: boolean;
-  filter?: string;
+export type PagedRequest<P> = P&{
   autoPaginate?: boolean;
   maxApiCalls?: number;
+};
+
+export type QueryRowsResponse =
+    PagedResponse<RowMetadata, Query, bigquery.IListTableDataResponse>;
+export type QueryRowsCallback =
+    PagedCallback<RowMetadata, Query, bigquery.IListTableDataResponse>;
+
+export type SimpleQueryRowsResponse = [RowMetadata[], bigquery.IJob];
+export type SimpleQueryRowsCallback =
+    ResourceCallback<RowMetadata[], bigquery.IJob>;
+
+export type Query = JobRequest<bigquery.IJobConfigurationQuery>&{
+  destination?: Table;
+  // tslint:disable-next-line no-any
+  params?: any[]|{[param: string]: any};
+  dryRun?: boolean;
+  defaultDataset?: Dataset;
+  job?: Job;
   maxResults?: number;
+  timeoutMs?: number;
   pageToken?: string;
-}
+};
 
-export type DatasetsResponse = [Dataset[], GetDatasetsOptions, r.Response];
-export interface DatasetsCallback {
-  (err: Error|null, datasets?: Dataset[]|null,
-   nextQuery?: GetDatasetsOptions|null, apiResponse?: r.Response): void;
-}
+export type QueryOptions = QueryResultsOptions;
+export type DatasetResource = bigquery.IDataset;
+export type ValueType = bigquery.IQueryParameterType;
 
-export type DatasetResponse = [Dataset, r.Response];
-export interface DatasetCallback {
-  (err: Error|null, dataset?: Dataset|null, apiResponse?: r.Response): void;
-}
+export type GetDatasetsOptions = PagedRequest<bigquery.IListDatasetsRequest>;
+export type DatasetsResponse =
+    PagedResponse<Dataset, GetDatasetsOptions, bigquery.IListDatasetsResponse>;
+export type DatasetsCallback =
+    PagedCallback<Dataset, GetDatasetsOptions, bigquery.IListDatasetsResponse>;
 
-export interface GetJobsOptions {
-  allUsers?: boolean;
-  autoPaginate?: boolean;
-  maxApiCalls?: number;
-  maxResults?: number;
-  pageToken?: string;
-  projection?: 'full'|'minimal';
-  stateFilter?: 'done'|'pending'|'running';
-}
+export type DatasetResponse = [Dataset, bigquery.IDataset];
+export type DatasetCallback = ResourceCallback<Dataset, bigquery.IDataset>;
 
-export type GetJobsResponse = [Job[], r.Response];
-export interface GetJobsCallback {
-  (err: Error|null, jobs: Job[]|null, nextQuery?: {}|null,
-   apiResponse?: r.Response): void;
-}
+export type GetJobsOptions = PagedRequest<bigquery.IListJobsRequest>;
+export type GetJobsResponse =
+    PagedResponse<Job, GetJobsOptions, bigquery.IListJobsResponse>;
+export type GetJobsCallback =
+    PagedCallback<Job, GetJobsOptions, bigquery.IListJobsResponse>;
 
 export interface BigQueryTimeOptions {
   hours?: number|string;
@@ -159,11 +122,7 @@ export interface BigQueryDatetimeOptions {
   fractional?: string|number;
 }
 
-export interface QueryParameter {
-  name?: string;
-  parameterType: ValueType;
-  parameterValue: {arrayValues?: Array<{}>; structValues?: {}; value?: {}};
-}
+export type QueryParameter = bigquery.IQueryParameter;
 
 /**
  * @typedef {object} BigQueryOptions
@@ -242,9 +201,9 @@ export interface BigQueryOptions extends common.GoogleAuthOptions {
 export class BigQuery extends common.Service {
   location?: string;
 
-  createQueryStream: (options?: Query|string) => Duplex;
-  getDatasetsStream: () => Readable;
-  getJobsStream: () => Readable;
+  createQueryStream: (options?: Query|string) => ResourceStream<RowMetadata>;
+  getDatasetsStream: (options?: GetDatasetsOptions) => ResourceStream<Dataset>;
+  getJobsStream: (options?: GetJobsOptions) => ResourceStream<Job>;
 
   constructor(options?: BigQueryOptions) {
     options = options || {};
@@ -298,7 +257,7 @@ export class BigQuery extends common.Service {
      *     this.end();
      *   });
      */
-    this.createQueryStream = paginator.streamify('queryAsStream_');
+    this.createQueryStream = paginator.streamify<RowMetadata>('queryAsStream_');
 
     /**
      * List all or some of the {@link Dataset} objects in your project as
@@ -330,7 +289,7 @@ export class BigQuery extends common.Service {
      *     this.end();
      *   });
      */
-    this.getDatasetsStream = paginator.streamify('getDatasets');
+    this.getDatasetsStream = paginator.streamify<Dataset>('getDatasets');
 
     /**
      * List all or some of the {@link Job} objects in your project as a
@@ -362,7 +321,7 @@ export class BigQuery extends common.Service {
      *     this.end();
      *   });
      */
-    this.getJobsStream = paginator.streamify('getJobs');
+    this.getJobsStream = paginator.streamify<Job>('getJobs');
   }
 
   /**
@@ -378,7 +337,7 @@ export class BigQuery extends common.Service {
       schema: TableSchema|TableField, rows: TableRow[]) {
     return arrify(rows).map(mergeSchema).map(flattenRows);
     function mergeSchema(row: TableRow) {
-      return row.f.map((field: TableRowField, index: number) => {
+      return row.f!.map((field: TableRowField, index: number) => {
         const schemaField = schema.fields![index];
         let value = field.v;
         if (schemaField.mode === 'REPEATED') {
@@ -390,7 +349,7 @@ export class BigQuery extends common.Service {
         }
         // tslint:disable-next-line no-any
         const fieldObject: any = {};
-        fieldObject[schemaField.name] = value;
+        fieldObject[schemaField.name!] = value;
         return fieldObject;
       });
     }
@@ -774,16 +733,17 @@ export class BigQuery extends common.Service {
     const parameterType = BigQuery.getType_(value);
     const queryParameter: QueryParameter = {parameterType, parameterValue: {}};
 
-    const typeName = parameterType.type;
+
+    const typeName = queryParameter!.parameterType!.type!;
 
     if (typeName === 'ARRAY') {
-      queryParameter.parameterValue.arrayValues =
+      queryParameter.parameterValue!.arrayValues =
           (value as Array<{}>).map(itemValue => {
             const value = getValue(itemValue, parameterType.arrayType!);
-            return {value};
+            return {value} as bigquery.IQueryParameterValue;
           });
     } else if (typeName === 'STRUCT') {
-      queryParameter.parameterValue.structValues =
+      queryParameter.parameterValue!.structValues =
           Object.keys(value).reduce((structValues, prop) => {
             const nestedQueryParameter =
                 BigQuery.valueToQueryParameter_(value[prop]);
@@ -792,7 +752,7 @@ export class BigQuery extends common.Service {
             return structValues;
           }, {});
     } else {
-      queryParameter.parameterValue.value = getValue(value, parameterType);
+      queryParameter.parameterValue!.value = getValue(value, parameterType);
     }
 
     return queryParameter;
@@ -803,7 +763,7 @@ export class BigQuery extends common.Service {
     }
 
     function isCustomType({type}: ValueType): boolean {
-      return type.indexOf('TIME') > -1 || type.indexOf('DATE') > -1;
+      return type!.indexOf('TIME') > -1 || type!.indexOf('DATE') > -1;
     }
   }
 
@@ -1254,14 +1214,15 @@ export class BigQuery extends common.Service {
           }
 
           // tslint:disable-next-line no-any
-          const datasets = (resp.datasets || []).map((dataset: any) => {
-            const ds = this.dataset(dataset.datasetReference.datasetId, {
-              location: dataset.location,
-            });
+          const datasets =
+              (resp.datasets || []).map((dataset: bigquery.IDataset) => {
+                const ds = this.dataset(dataset.datasetReference!.datasetId!, {
+                  location: dataset.location!,
+                });
 
-            ds.metadata = dataset;
-            return ds;
-          });
+                ds.metadata = dataset!;
+                return ds;
+              });
 
           callback!(null, datasets, nextQuery, resp);
         });
@@ -1357,12 +1318,12 @@ export class BigQuery extends common.Service {
           }
 
           // tslint:disable-next-line no-any
-          const jobs = (resp.jobs || []).map((jobObject: any) => {
-            const job = that.job(jobObject.jobReference.jobId, {
-              location: jobObject.jobReference.location,
+          const jobs = (resp.jobs || []).map((jobObject: bigquery.IJob) => {
+            const job = that.job(jobObject.jobReference!.jobId!, {
+              location: jobObject.jobReference!.location!,
             });
 
-            job.metadata = jobObject;
+            job.metadata = jobObject!;
             return job;
           });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import * as r from 'request';
 import * as uuid from 'uuid';
 import {teenyRequest} from 'teeny-request';
 
-import {Dataset, DataSetOptions} from './dataset';
+import {Dataset, DatasetOptions} from './dataset';
 import {Job, JobOptions, QueryResultsOptions} from './job';
 import {Table, TableField, TableSchema, TableRow, TableRowField, JobCallback, JobResponse, RowsCallback, RowsResponse, RowMetadata} from './table';
 import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
@@ -1124,7 +1124,7 @@ export class BigQuery extends common.Service {
    * const bigquery = new BigQuery();
    * const dataset = bigquery.dataset('higher_education');
    */
-  dataset(id: string, options?: DataSetOptions) {
+  dataset(id: string, options?: DatasetOptions) {
     if (typeof id !== 'string') {
       throw new TypeError('A dataset ID is required.');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {Job, JobOptions, QueryResultsOptions} from './job';
 import {Table, TableField, TableSchema, TableRow, TableRowField, JobCallback, JobResponse, RowsCallback, RowsResponse, RowMetadata} from './table';
 import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
 import {Readable, Duplex} from 'stream';
-import {bigquery} from './types';
+import bigquery from './types';
 
 export interface RequestCallback<T> {
   (err: Error|null, response?: T|null): void;
@@ -60,9 +60,9 @@ export type PagedRequest<P> = P&{
 };
 
 export type QueryRowsResponse =
-    PagedResponse<RowMetadata, Query, bigquery.IListTableDataResponse>;
+    PagedResponse<RowMetadata, Query, bigquery.ITableDataList>;
 export type QueryRowsCallback =
-    PagedCallback<RowMetadata, Query, bigquery.IListTableDataResponse>;
+    PagedCallback<RowMetadata, Query, bigquery.ITableDataList>;
 
 export type SimpleQueryRowsResponse = [RowMetadata[], bigquery.IJob];
 export type SimpleQueryRowsCallback =
@@ -84,20 +84,20 @@ export type QueryOptions = QueryResultsOptions;
 export type DatasetResource = bigquery.IDataset;
 export type ValueType = bigquery.IQueryParameterType;
 
-export type GetDatasetsOptions = PagedRequest<bigquery.IListDatasetsRequest>;
+export type GetDatasetsOptions = PagedRequest<bigquery.datasets.IListParams>;
 export type DatasetsResponse =
-    PagedResponse<Dataset, GetDatasetsOptions, bigquery.IListDatasetsResponse>;
+    PagedResponse<Dataset, GetDatasetsOptions, bigquery.IDatasetList>;
 export type DatasetsCallback =
-    PagedCallback<Dataset, GetDatasetsOptions, bigquery.IListDatasetsResponse>;
+    PagedCallback<Dataset, GetDatasetsOptions, bigquery.IDatasetList>;
 
 export type DatasetResponse = [Dataset, bigquery.IDataset];
 export type DatasetCallback = ResourceCallback<Dataset, bigquery.IDataset>;
 
-export type GetJobsOptions = PagedRequest<bigquery.IListJobsRequest>;
+export type GetJobsOptions = PagedRequest<bigquery.jobs.IListParams>;
 export type GetJobsResponse =
-    PagedResponse<Job, GetJobsOptions, bigquery.IListJobsResponse>;
+    PagedResponse<Job, GetJobsOptions, bigquery.IJobList>;
 export type GetJobsCallback =
-    PagedCallback<Job, GetJobsOptions, bigquery.IListJobsResponse>;
+    PagedCallback<Job, GetJobsOptions, bigquery.IJobList>;
 
 export interface BigQueryTimeOptions {
   hours?: number|string;

--- a/src/job.ts
+++ b/src/job.ts
@@ -19,36 +19,25 @@
  */
 
 import {Metadata, MetadataCallback, Operation, util} from '@google-cloud/common';
-import {paginator} from '@google-cloud/paginator';
+import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as r from 'request';
 import {Readable} from 'stream';
 import {teenyRequest} from 'teeny-request';
 
-import {BigQuery, QueryRowsCallback, QueryRowsResponse} from '../src';
+import {BigQuery, JobRequest, PagedRequest, QueryRowsCallback, QueryRowsResponse, RequestCallback} from '../src';
+import {RowMetadata} from './table';
+import {bigquery} from './types';
 
-// tslint:disable-next-line no-any
-export type JobMetadata = any;
+export type JobMetadata = bigquery.IJob;
+export type JobOptions = JobRequest<JobMetadata>;
 
-// tslint:disable-next-line no-any
-export type JobOptions = any;
+export type CancelCallback = RequestCallback<bigquery.ICancelJobResponse>;
+export type CancelResponse = [bigquery.ICancelJobResponse];
 
-export interface CancelCallback {
-  (err: Error|null, apiResponse?: r.Response): void;
-}
-
-export type CancelResponse = [r.Response];
-
-
-export interface QueryResultsOptions {
-  autoPaginate?: boolean;
-  maxApiCalls?: number;
-  maxResults?: number;
-  pageToken?: string;
-  startIndex?: number;
-  timeoutMs?: number;
-}
+export type QueryResultsOptions =
+    PagedRequest<bigquery.IGetQueryResultsRequest>;
 
 /**
  * @callback QueryResultsCallback
@@ -121,7 +110,8 @@ export interface QueryResultsOptions {
 class Job extends Operation {
   bigQuery: BigQuery;
   location?: string;
-  getQueryResultsStream: (options?: QueryResultsOptions) => Readable;
+  getQueryResultsStream:
+      (options?: QueryResultsOptions) => ResourceStream<RowMetadata>;
   constructor(bigQuery: BigQuery, id: string, options?: JobOptions) {
     let location;
     if (options && options.location) {
@@ -261,7 +251,7 @@ class Job extends Operation {
      *   .pipe(fs.createWriteStream('./test/testdata/testfile.json'));
      */
     this.getQueryResultsStream =
-        paginator.streamify('getQueryResultsAsStream_');
+        paginator.streamify<RowMetadata>('getQueryResultsAsStream_');
   }
 
   cancel(): Promise<CancelResponse>;

--- a/src/job.ts
+++ b/src/job.ts
@@ -28,16 +28,16 @@ import {teenyRequest} from 'teeny-request';
 
 import {BigQuery, JobRequest, PagedRequest, QueryRowsCallback, QueryRowsResponse, RequestCallback} from '../src';
 import {RowMetadata} from './table';
-import {bigquery} from './types';
+import bigquery from './types';
 
 export type JobMetadata = bigquery.IJob;
 export type JobOptions = JobRequest<JobMetadata>;
 
-export type CancelCallback = RequestCallback<bigquery.ICancelJobResponse>;
-export type CancelResponse = [bigquery.ICancelJobResponse];
+export type CancelCallback = RequestCallback<bigquery.IJobCancelResponse>;
+export type CancelResponse = [bigquery.IJobCancelResponse];
 
 export type QueryResultsOptions =
-    PagedRequest<bigquery.IGetQueryResultsRequest>;
+    PagedRequest<bigquery.jobs.IGetQueryResultsParams>;
 
 /**
  * @callback QueryResultsCallback

--- a/src/table.ts
+++ b/src/table.ts
@@ -34,7 +34,7 @@ import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
 import {Duplex, Readable, Writable} from 'stream';
 import {teenyRequest} from 'teeny-request';
 import {JobMetadata} from './job';
-import {bigquery} from './types';
+import bigquery from './types';
 
 // This is supposed to be a @google-cloud/storage `File` type. The storage npm
 // module includes these types, but is current installed as a devDependency.
@@ -56,7 +56,7 @@ export type JobMetadataResponse = [JobMetadata];
 // tslint:disable-next-line no-any
 export type RowMetadata = any;
 
-export type InsertRowsOptions = bigquery.IInsertAllTableDataRequest&{
+export type InsertRowsOptions = bigquery.ITableDataInsertAllRequest&{
   autoCreate?: boolean;
   raw?: boolean;
   schema: string|{};
@@ -64,22 +64,20 @@ export type InsertRowsOptions = bigquery.IInsertAllTableDataRequest&{
 
 // @TODO when breaking changes are cool, rename these to have suffix InsertRows
 export type ApiResponse =
-    [bigquery.IInsertAllTableDataResponse | bigquery.ITable];
+    [bigquery.ITableDataInsertAllResponse | bigquery.ITable];
 export type ApiResponseCallback =
-    RequestCallback<bigquery.IInsertAllTableDataResponse|bigquery.ITable>;
+    RequestCallback<bigquery.ITableDataInsertAllResponse|bigquery.ITable>;
 
 export type RowsResponse = PagedResponse<
-    RowMetadata, GetRowsOptions,
-    bigquery.IListTableDataResponse|bigquery.ITable>;
+    RowMetadata, GetRowsOptions, bigquery.ITableDataList|bigquery.ITable>;
 export type RowsCallback = PagedCallback<
-    RowMetadata, GetRowsOptions,
-    bigquery.IListTableDataResponse|bigquery.ITable>;
+    RowMetadata, GetRowsOptions, bigquery.ITableDataList|bigquery.ITable>;
 
 export type TableRow = bigquery.ITableRow;
 export type TableRowField = bigquery.ITableCell;
 export type TableRowValue = string|TableRow;
 
-export type GetRowsOptions = PagedRequest<bigquery.IListTableDataRequest>;
+export type GetRowsOptions = PagedRequest<bigquery.tabledata.IListParams>;
 
 export type JobLoadMetadata = JobRequest<bigquery.IJobConfigurationLoad>&{
   format?: string;
@@ -1573,7 +1571,7 @@ class Table extends common.ServiceObject {
         typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
     const onComplete =
         (err: Error|null, rows: TableRow[]|null, nextQuery: GetRowsOptions|null,
-         resp: bigquery.IListTableDataResponse) => {
+         resp: bigquery.ITableList) => {
           if (err) {
             callback!(err, null, null, resp);
             return;

--- a/src/table.ts
+++ b/src/table.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@google-cloud/common';
-import {paginator} from '@google-cloud/paginator';
+import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
 import Big from 'big.js';
@@ -29,11 +29,12 @@ import * as path from 'path';
 import * as r from 'request';
 import * as streamEvents from 'stream-events';
 import * as uuid from 'uuid';
-import {BigQuery, Job, Dataset, Query, SimpleQueryRowsResponse, SimpleQueryRowsCallback} from '../src';
+import {BigQuery, Job, Dataset, Query, SimpleQueryRowsResponse, SimpleQueryRowsCallback, ResourceCallback, RequestCallback, PagedResponse, PagedCallback, JobRequest, PagedRequest} from '../src';
 import {GoogleErrorBody} from '@google-cloud/common/build/src/util';
 import {Duplex, Readable, Writable} from 'stream';
 import {teenyRequest} from 'teeny-request';
 import {JobMetadata} from './job';
+import {bigquery} from './types';
 
 // This is supposed to be a @google-cloud/storage `File` type. The storage npm
 // module includes these types, but is current installed as a devDependency.
@@ -49,150 +50,65 @@ export interface File {
   generation?: number;
 }
 
-export interface JobMetadataCallback {
-  (err: Error|null, metadataOrResponse: JobMetadata|r.Response): void;
-}
-
+export type JobMetadataCallback = RequestCallback<JobMetadata>;
 export type JobMetadataResponse = [JobMetadata];
 
 // tslint:disable-next-line no-any
 export type RowMetadata = any;
 
-export interface InsertRowsOptions {
+export type InsertRowsOptions = bigquery.IInsertAllTableDataRequest&{
   autoCreate?: boolean;
-  ignoreUnknownValues?: boolean;
   raw?: boolean;
-  schema?: string|{};
-  skipInvalidRows?: boolean;
-  templateSuffix?: string;
-}
+  schema: string|{};
+};
 
-export type RowsResponse = [RowMetadata[], GetRowsOptions, r.Response];
-export interface RowsCallback {
-  (err: Error|null, rows?: RowMetadata[]|null, nextQuery?: GetRowsOptions|null,
-   apiResponse?: r.Response): void;
-}
+// @TODO when breaking changes are cool, rename these to have suffix InsertRows
+export type ApiResponse =
+    [bigquery.IInsertAllTableDataResponse | bigquery.ITable];
+export type ApiResponseCallback =
+    RequestCallback<bigquery.IInsertAllTableDataResponse|bigquery.ITable>;
 
-export interface TableRow {
-  f: TableRowField[];
-}
-export interface TableRowField {
-  v: string|TableRow|TableRowField[];
-}
+export type RowsResponse = PagedResponse<
+    RowMetadata, GetRowsOptions,
+    bigquery.IListTableDataResponse|bigquery.ITable>;
+export type RowsCallback = PagedCallback<
+    RowMetadata, GetRowsOptions,
+    bigquery.IListTableDataResponse|bigquery.ITable>;
+
+export type TableRow = bigquery.ITableRow;
+export type TableRowField = bigquery.ITableCell;
 export type TableRowValue = string|TableRow;
 
-export interface GetRowsOptions {
-  startIndex?: number;
-  selectedFields?: string;
-  autoPaginate?: boolean;
-  maxApiCalls?: number;
-  maxResults?: number;
-}
+export type GetRowsOptions = PagedRequest<bigquery.IListTableDataRequest>;
 
-export interface JobLoadMetadata {
-  jobId?: string;
-  jobPrefix?: string;
-  allowJaggedRows?: boolean;
-  allowQuotedNewlines?: boolean;
-  autodetect?: boolean;
-  clustering?: {fields: number[];};
-  createDisposition?: string;
-  destinationEncryptionConfiguration?: {kmsKeyName?: string;};
-  destinationTable?: {datasetId: string; projectId: string; tableId: string;};
-  destinationTableProperties?: {description?: string; friendlyName?: string;};
-  encoding?: string;
-  fieldDelimiter?: string;
-  ignoreUnknownValues?: boolean;
-  maxBadRecords?: number;
-  nullMarker?: string;
-  projectionFields?: string[];
-  quote?: string;
-  schema?: {fields: TableField[]};
-  schemaUpdateOptions?: string[];
-  skipLeadingRows?: number;
-  sourceFormat?: string;
+export type JobLoadMetadata = JobRequest<bigquery.IJobConfigurationLoad>&{
   format?: string;
-  location?: string;
-  sourceUris?: string[];
-  timePartitioning?: {
-    expirationMs?: number;
-    field?: string;
-    requirePartitionFilter?: boolean;
-    type?: string;
-  };
-  writeDisposition?: string;
-}
+};
 
-export interface CreateExtractJobOptions {
+export type CreateExtractJobOptions =
+    JobRequest<bigquery.IJobConfigurationExtract>&{
   format?: 'CSV'|'JSON'|'AVRO'|'PARQUET'|'ORC';
   gzip?: boolean;
-  jobId?: string;
-  jobPrefix?: string;
-  destinationFormat?: string;
-  compression?: string;
-}
+};
 
-export type JobResponse = [Job, r.Response];
-export interface JobCallback {
-  (err: Error|null, job?: Job|null, apiResponse?: r.Response): void;
-}
+export type JobResponse = [Job, bigquery.IJob];
+export type JobCallback = ResourceCallback<Job, bigquery.IJob>;
 
-export interface CreateCopyJobMetadata extends CopyTableMetadata {
-  destinationTable?: {datasetId: string; projectId: string; tableId: string;};
-  sourceTable?: {datasetId: string; projectId: string; tableId: string;};
-  sourceTables: Array<{datasetId: string; projectId: string; tableId: string;}>;
-}
+export type CreateCopyJobMetadata = CopyTableMetadata;
+export type SetTableMetadataOptions = TableMetadata;
+export type CopyTableMetadata = JobRequest<bigquery.IJobConfigurationTableCopy>;
 
-export interface SetTableMetadataOptions {
-  description?: string;
-  schema?: string|{};
-}
-
-export interface CopyTableMetadata {
-  jobId?: string;
-  jobPrefix?: string;
-  createDisposition?: 'CREATE_IF_NEEDED'|'CREATE_NEVER';
-  writeDisposition?: 'WRITE_TRUNCATE'|'WRITE_APPEND'|'WRITE_EMPTY';
-  destinationEncryptionConfiguration?: {kmsKeyName?: string;};
-}
-
-export interface TableMetadata {
+export type TableMetadata = bigquery.ITable&{
   name?: string;
-  friendlyName: string;
   schema?: string|TableField[];
   partitioning?: string;
   view?: string|ViewDefinition;
-}
+};
 
-export interface ViewDefinition {
-  query: string;
-  useLegacySql?: boolean;
-}
-
-export interface FormattedMetadata {
-  schema?: TableSchema;
-  friendlyName: string;
-  name?: string;
-  partitioning?: string;
-  timePartitioning?: {type: string};
-  view: ViewDefinition;
-}
-
-export interface TableSchema {
-  fields: TableField[];
-}
-
-export interface TableField {
-  name: string;
-  type: string;
-  mode?: string;
-  fields?: TableField[];
-}
-
-export type ApiResponse = [r.Response];
-export interface ApiResponseCallback {
-  (err: Error|null, apiResponse?: r.Response): void;
-}
+export type ViewDefinition = bigquery.IViewDefinition;
+export type FormattedMetadata = bigquery.ITable;
+export type TableSchema = bigquery.ITableSchema;
+export type TableField = bigquery.ITableFieldSchema;
 
 /**
  * The file formats accepted by BigQuery.
@@ -239,7 +155,7 @@ class Table extends common.ServiceObject {
   dataset: Dataset;
   bigQuery: BigQuery;
   location?: string;
-  createReadStream: (options?: GetRowsOptions) => Readable;
+  createReadStream: (options?: GetRowsOptions) => ResourceStream<RowMetadata>;
   constructor(dataset: Dataset, id: string, options?: TableOptions) {
     const methods = {
       /**
@@ -466,7 +382,7 @@ class Table extends common.ServiceObject {
      *     this.end();
      *   });
      */
-    this.createReadStream = paginator.streamify('getRows');
+    this.createReadStream = paginator.streamify<RowMetadata>('getRows');
   }
 
   /**
@@ -557,7 +473,7 @@ class Table extends common.ServiceObject {
 
     if (options.name) {
       body.friendlyName = options.name;
-      delete body.name;
+      delete (body as TableMetadata).name;
     }
 
     if (is.string(options.schema)) {
@@ -581,8 +497,9 @@ class Table extends common.ServiceObject {
 
     if (is.string(options.partitioning)) {
       body.timePartitioning = {
-        type: body.partitioning!.toUpperCase(),
+        type: options.partitioning!.toUpperCase(),
       };
+      delete (body as TableMetadata).partitioning;
     }
 
     if (is.string(options.view)) {
@@ -1656,7 +1573,7 @@ class Table extends common.ServiceObject {
         typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
     const onComplete =
         (err: Error|null, rows: TableRow[]|null, nextQuery: GetRowsOptions|null,
-         resp: r.Response) => {
+         resp: bigquery.IListTableDataResponse) => {
           if (err) {
             callback!(err, null, null, resp);
             return;
@@ -1687,7 +1604,7 @@ class Table extends common.ServiceObject {
             // We don't know the schema for this table yet. Do a quick stat.
             this.getMetadata(
                 (err: Error, metadata: common.Metadata,
-                 apiResponse: r.Response) => {
+                 apiResponse: bigquery.ITable) => {
                   if (err) {
                     onComplete(err, null, null, apiResponse!);
                     return;
@@ -1844,10 +1761,12 @@ class Table extends common.ServiceObject {
       rows: RowMetadata|RowMetadata[],
       optionsOrCallback?: InsertRowsOptions|ApiResponseCallback,
       cb?: ApiResponseCallback): void|Promise<ApiResponse> {
-    const options =
-        typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
-    const callback =
-        typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
+    const options = typeof optionsOrCallback === 'object' ?
+        optionsOrCallback :
+        {} as InsertRowsOptions;
+    const callback = typeof optionsOrCallback === 'function' ?
+        optionsOrCallback :
+        cb as ApiResponseCallback;
 
     rows = arrify(rows);
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -62,10 +62,9 @@ export type InsertRowsOptions = bigquery.ITableDataInsertAllRequest&{
   schema: string|{};
 };
 
-// @TODO when breaking changes are cool, rename these to have suffix InsertRows
-export type ApiResponse =
+export type InsertRowsResponse =
     [bigquery.ITableDataInsertAllResponse | bigquery.ITable];
-export type ApiResponseCallback =
+export type InsertRowsCallback =
     RequestCallback<bigquery.ITableDataInsertAllResponse|bigquery.ITable>;
 
 export type RowsResponse = PagedResponse<
@@ -1617,11 +1616,11 @@ class Table extends common.ServiceObject {
   }
 
   insert(rows: RowMetadata|RowMetadata[], options?: InsertRowsOptions):
-      Promise<ApiResponse>;
+      Promise<InsertRowsResponse>;
   insert(
       rows: RowMetadata|RowMetadata[], options: InsertRowsOptions,
-      callback: ApiResponseCallback): void;
-  insert(rows: RowMetadata|RowMetadata[], callback: ApiResponseCallback): void;
+      callback: InsertRowsCallback): void;
+  insert(rows: RowMetadata|RowMetadata[], callback: InsertRowsCallback): void;
   /**
    * Stream data into BigQuery one record at a time without running a load job.
    *
@@ -1757,14 +1756,14 @@ class Table extends common.ServiceObject {
    */
   insert(
       rows: RowMetadata|RowMetadata[],
-      optionsOrCallback?: InsertRowsOptions|ApiResponseCallback,
-      cb?: ApiResponseCallback): void|Promise<ApiResponse> {
+      optionsOrCallback?: InsertRowsOptions|InsertRowsCallback,
+      cb?: InsertRowsCallback): void|Promise<InsertRowsResponse> {
     const options = typeof optionsOrCallback === 'object' ?
         optionsOrCallback :
         {} as InsertRowsOptions;
     const callback = typeof optionsOrCallback === 'function' ?
         optionsOrCallback :
-        cb as ApiResponseCallback;
+        cb as InsertRowsCallback;
 
     rows = arrify(rows);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,463 +1,49 @@
-export namespace bigquery {
-
-  interface IEmpty {}
-
-  interface ICancelJobRequest {
-    /**
-     * The geographic location of the job to cancel. Required except for US and
-     * EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
-     */
-    location?: string;
-  }
-
-  interface ICancelJobResponse {
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-    /**
-     * The final state of the job.
-     */
-    job?: IJob;
-  }
-
-  interface IDeleteDatasetRequest {
-    /**
-     * If True, delete all the tables in the dataset. If False and the dataset
-     * contains tables, the request will fail. Default is False
-     */
-    deleteContents?: boolean;
-  }
-
-  interface IGetQueryResultsRequest {
-    /**
-     * The geographic location where the job should run. Required except for US
-     * and EU. See details at
-     * https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
-     */
-    location?: string;
-    /**
-     * Maximum number of results to read
-     */
-    maxResults?: number;
-    /**
-     * Page token, returned by a previous call, to request the next page of
-     * results
-     */
-    pageToken?: string;
-    /**
-     * [Required] Project ID of the query job
-     */
-    projectId?: string;
-    /**
-     * Zero-based index of the starting row
-     */
-    startIndex?: string;
-    /**
-     * How long to wait for the query to complete, in milliseconds, before
-     * returning. Default is 10 seconds. If the timeout passes before the job
-     * completes, the 'jobComplete' field in the response will be false
-     */
-    timeoutMs?: number;
-  }
-
-  interface IGetQueryResultsResponse {
-    /**
-     * Whether the query result was fetched from the query cache.
-     */
-    cacheHit?: boolean;
-    /**
-     * [Output-only] The first errors or warnings encountered during the running
-     * of the job. The final message includes the number of errors that caused
-     * the process to stop. Errors here do not necessarily mean that the job has
-     * completed or was unsuccessful.
-     */
-    errors?: IErrorProto[];
-    /**
-     * A hash of this response.
-     */
-    etag?: string;
-    /**
-     * Whether the query has completed or not. If rows or totalRows are present,
-     * this will always be true. If this is false, totalRows will not be
-     * available.
-     */
-    jobComplete?: boolean;
-    /**
-     * Reference to the BigQuery Job that was created to run the query. This
-     * field will be present even if the original request timed out, in which
-     * case GetQueryResults can be used to read the results once the query has
-     * completed. Since this API only returns the first page of results,
-     * subsequent pages can be fetched via the same mechanism (GetQueryResults).
-     */
-    jobReference?: IJobReference;
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-    /**
-     * [Output-only] The number of rows affected by a DML statement. Present
-     * only for DML statements INSERT, UPDATE or DELETE.
-     */
-    numDmlAffectedRows?: string;
-    /**
-     * A token used for paging results.
-     */
-    pageToken?: string;
-    /**
-     * An object with as many results as can be contained within the maximum
-     * permitted reply size. To get any additional rows, you can call
-     * GetQueryResults and specify the jobReference returned above. Present only
-     * when the query completes successfully.
-     */
-    rows?: ITableRow[];
-    /**
-     * The schema of the results. Present only when the query completes
-     * successfully.
-     */
-    schema?: ITableSchema;
-    /**
-     * The total number of bytes processed for this query.
-     */
-    totalBytesProcessed?: string;
-    /**
-     * The total number of rows in the complete query result set, which can be
-     * more than the number of rows in this single page of results. Present only
-     * when the query completes successfully.
-     */
-    totalRows?: string;
-  }
-
-  interface IInsertAllTableDataRequest {
-    /**
-     * [Optional] Accept rows that contain values that do not match the schema.
-     * The unknown values are ignored. Default is false, which treats unknown
-     * values as errors.
-     */
-    ignoreUnknownValues?: boolean;
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-    /**
-     * The rows to insert.
-     */
-    rows?: Array<{insertId?: string; json?: IJsonObject;}>;
-    /**
-     * [Optional] Insert all valid rows of a request, even if invalid rows
-     * exist. The default value is false, which causes the entire request to
-     * fail if any invalid rows exist.
-     */
-    skipInvalidRows?: boolean;
-    /**
-     * If specified, treats the destination table as a base template, and
-     * inserts the rows into an instance table named
-     * &quot;{destination}{templateSuffix}&quot;. BigQuery will manage creation
-     * of the instance table, using the schema of the base template table. See
-     * https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
-     * for considerations when working with templates tables.
-     */
-    templateSuffix?: string;
-  }
-
-  interface IInsertAllTableDataResponse {
-    /**
-     * An array of errors for rows that were not inserted.
-     */
-    insertErrors?: Array<{errors?: IErrorProto[]; index?: number;}>;
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-  }
-
-  interface IListDatasetsRequest {
-    /**
-     * Whether to list all datasets, including hidden ones
-     */
-    all?: boolean;
-    /**
-     * An expression for filtering the results of the request by label. The
-     * syntax is "labels.<name>[:<value>]". Multiple filters can be ANDed
-     * together by connecting with a space. Example:
-     * "labels.department:receiving labels.active". See Filtering datasets using
-     * labels for details.
-     */
-    filter?: string;
-    /**
-     * The maximum number of results to return
-     */
-    maxResults?: number;
-    /**
-     * Page token, returned by a previous call, to request the next page of
-     * results
-     */
-    pageToken?: string;
-  }
-
-  interface IListDatasetsResponse {
-    /**
-     * An array of the dataset resources in the project. Each resource contains
-     * basic information. For full information about a particular dataset
-     * resource, use the Datasets: get method. This property is omitted when
-     * there are no datasets in the project.
-     */
-    datasets?: Array<{
-      datasetReference?: IDatasetReference;
-      friendlyName?: string;
-      id?: string;
-      kind?: string;
-      labels?: {[key: string]: string;};
-      location?: string;
-    }>;
-    /**
-     * A hash value of the results page. You can use this property to determine
-     * if the page has changed since the last request.
-     */
-    etag?: string;
-    /**
-     * The list type. This property always returns the value
-     * &quot;bigquery#datasetList&quot;.
-     */
-    kind?: string;
-    /**
-     * A token that can be used to request the next results page. This property
-     * is omitted on the final results page.
-     */
-    nextPageToken?: string;
-  }
-
-  interface IListJobsRequest {
-    /**
-     * Whether to display jobs owned by all users in the project. Default false
-     */
-    allUsers?: boolean;
-    /**
-     * Max value for job creation time, in milliseconds since the POSIX epoch.
-     * If set, only jobs created before or at this timestamp are returned
-     */
-    maxCreationTime?: string;
-    /**
-     * Maximum number of results to return
-     */
-    maxResults?: number;
-    /**
-     * Min value for job creation time, in milliseconds since the POSIX epoch.
-     * If set, only jobs created after or at this timestamp are returned
-     */
-    minCreationTime?: string;
-    /**
-     * Page token, returned by a previous call, to request the next page of
-     * results
-     */
-    pageToken?: string;
-            /**
-     * Restrict information returned to a set of selected fields
-     */
-    projection?: string;
-    /**
-     * Filter for job state
-     */
-    stateFilter?: string[];
-  }
-
-  interface IListJobsResponse {
-    /**
-     * A hash of this page of results.
-     */
-    etag?: string;
-    /**
-     * List of jobs that were requested.
-     */
-    jobs?: Array<{
-      configuration?: IJobConfiguration;
-      errorResult?: IErrorProto;
-      id?: string;
-      jobReference?: IJobReference;
-      kind?: string;
-      state?: string;
-      statistics?: IJobStatistics;
-      status?: IJobStatus;
-      user_email?: string;
-    }>;
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-    /**
-     * A token to request the next page of results.
-     */
-    nextPageToken?: string;
-  }
-
-  interface IListTableDataRequest {
-    /**
-     * Maximum number of results to return
-     */
-    maxResults?: number;
-    /**
-     * Page token, returned by a previous call, identifying the result set
-     */
-    pageToken?: string;
-    /**
-     * List of fields to return (comma-separated). If unspecified, all fields
-     * are returned
-     */
-    selectedFields?: string;
-    /**
-     * Zero-based index of the starting row to read
-     */
-    startIndex?: string;
-  }
-
-  interface IListTableDataResponse {
-    /**
-     * A hash of this page of results.
-     */
-    etag?: string;
-    /**
-     * The resource type of the response.
-     */
-    kind?: string;
-    /**
-     * A token used for paging results. Providing this token instead of the
-     * startIndex parameter can help you retrieve stable results when an
-     * underlying table is changing.
-     */
-    pageToken?: string;
-    /**
-     * Rows of results.
-     */
-    rows?: ITableRow[];
-    /**
-     * The total number of rows in the complete table.
-     */
-    totalRows?: string;
-  }
-
-  interface IListTablesRequest {
-    /**
-     * Maximum number of results to return
-     */
-    maxResults?: number;
-    /**
-     * Page token, returned by a previous call, to request the next page of
-     * results
-     */
-    pageToken?: string;
-  }
-
-  interface IListTablesResponse {
-    /**
-     * A hash of this page of results.
-     */
-    etag?: string;
-    /**
-     * The type of list.
-     */
-    kind?: string;
-    /**
-     * A token to request the next page of results.
-     */
-    nextPageToken?: string;
-    /**
-     * Tables in the requested dataset.
-     */
-    tables?: Array<{
-      clustering?: IClustering;
-      creationTime?: string;
-      expirationTime?: string;
-      friendlyName?: string;
-      id?: string;
-      kind?: string;
-      labels?: {[key: string]: string;};
-      tableReference?: ITableReference;
-      timePartitioning?: ITimePartitioning;
-      type?: string;
-      view?: {useLegacySql?: boolean;};
-    }>;
-    /**
-     * The total number of tables in the dataset.
-     */
-    totalItems?: number;
-  }
-
-  interface IBigQueryModelTraining {
-    /**
-     * [Output-only, Beta] Index of current ML training iteration. Updated
-     * during create model query job to show job progress.
+/**
+ * BigQuery API
+ */
+declare namespace bigquery {
+  type IBigQueryModelTraining = {
+    /**
+     * [Output-only, Beta] Index of current ML training iteration. Updated during create model query job to show job progress.
      */
     currentIteration?: number;
     /**
-     * [Output-only, Beta] Expected number of iterations for the create model
-     * query job specified as num_iterations in the input query. The actual
-     * total number of iterations may be less than this number due to early
-     * stop.
+     * [Output-only, Beta] Expected number of iterations for the create model query job specified as num_iterations in the input query. The actual total number of iterations may be less than this number due to early stop.
      */
     expectedTotalIterations?: string;
-  }
+  };
 
-  interface IBigtableColumn {
+  type IBigtableColumn = {
     /**
-     * [Optional] The encoding of the values when the type is not STRING.
-     * Acceptable encoding values are: TEXT - indicates values are alphanumeric
-     * text strings. BINARY - indicates values are encoded using HBase
-     * Bytes.toBytes family of functions. &#39;encoding&#39; can also be set at
-     * the column family level. However, the setting at this level takes
-     * precedence if &#39;encoding&#39; is set at both levels.
+     * [Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
      */
     encoding?: string;
     /**
-     * [Optional] If the qualifier is not a valid BigQuery field identifier i.e.
-     * does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided
-     * as the column field name and is used as field name in queries.
+     * [Optional] If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries.
      */
     fieldName?: string;
     /**
-     * [Optional] If this is set, only the latest version of value in this
-     * column are exposed. &#39;onlyReadLatest&#39; can also be set at the
-     * column family level. However, the setting at this level takes precedence
-     * if &#39;onlyReadLatest&#39; is set at both levels.
+     * [Optional] If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.
      */
     onlyReadLatest?: boolean;
     /**
-     * [Required] Qualifier of the column. Columns in the parent column family
-     * that has this exact qualifier are exposed as . field. If the qualifier is
-     * valid UTF-8 string, it can be specified in the qualifier_string field.
-     * Otherwise, a base-64 encoded value must be set to qualifier_encoded. The
-     * column field name is the same as the column qualifier. However, if the
-     * qualifier is not a valid BigQuery field identifier i.e. does not match
-     * [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as field_name.
+     * [Required] Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifier_string field. Otherwise, a base-64 encoded value must be set to qualifier_encoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as field_name.
      */
     qualifierEncoded?: string;
     qualifierString?: string;
     /**
-     * [Optional] The type to convert the value in cells of this column. The
-     * values are expected to be encoded using HBase Bytes.toBytes function when
-     * using the BINARY encoding value. Following BigQuery types are allowed
-     * (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is
-     * BYTES. &#39;type&#39; can also be set at the column family level.
-     * However, the setting at this level takes precedence if &#39;type&#39; is
-     * set at both levels.
+     * [Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.
      */
     type?: string;
-  }
+  };
 
-  interface IBigtableColumnFamily {
+  type IBigtableColumnFamily = {
     /**
-     * [Optional] Lists of columns that should be exposed as individual fields
-     * as opposed to a list of (column name, value) pairs. All columns whose
-     * qualifier matches a qualifier in this list can be accessed as .. Other
-     * columns can be accessed as a list through .Column field.
+     * [Optional] Lists of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as .. Other columns can be accessed as a list through .Column field.
      */
-    columns?: IBigtableColumn[];
+    columns?: Array<IBigtableColumn>;
     /**
-     * [Optional] The encoding of the values when the type is not STRING.
-     * Acceptable encoding values are: TEXT - indicates values are alphanumeric
-     * text strings. BINARY - indicates values are encoded using HBase
-     * Bytes.toBytes family of functions. This can be overridden for a specific
-     * column by listing that column in &#39;columns&#39; and specifying an
-     * encoding for it.
+     * [Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
      */
     encoding?: string;
     /**
@@ -465,131 +51,152 @@ export namespace bigquery {
      */
     familyId?: string;
     /**
-     * [Optional] If this is set only the latest version of value are exposed
-     * for all columns in this column family. This can be overridden for a
-     * specific column by listing that column in &#39;columns&#39; and
-     * specifying a different setting for that column.
+     * [Optional] If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.
      */
     onlyReadLatest?: boolean;
     /**
-     * [Optional] The type to convert the value in cells of this column family.
-     * The values are expected to be encoded using HBase Bytes.toBytes function
-     * when using the BINARY encoding value. Following BigQuery types are
-     * allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default
-     * type is BYTES. This can be overridden for a specific column by listing
-     * that column in &#39;columns&#39; and specifying a type for it.
+     * [Optional] The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.
      */
     type?: string;
-  }
+  };
 
-  interface IBigtableOptions {
+  type IBigtableOptions = {
     /**
-     * [Optional] List of column families to expose in the table schema along
-     * with their types. This list restricts the column families that can be
-     * referenced in queries and specifies their value types. You can use this
-     * list to do type conversions - see the &#39;type&#39; field for more
-     * details. If you leave this list empty, all column families are present in
-     * the table schema and their values are read as BYTES. During a query only
-     * the column families referenced in that query are read from Bigtable.
+     * [Optional] List of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.
      */
-    columnFamilies?: IBigtableColumnFamily[];
+    columnFamilies?: Array<IBigtableColumnFamily>;
     /**
-     * [Optional] If field is true, then the column families that are not
-     * specified in columnFamilies list are not exposed in the table schema.
-     * Otherwise, they are read with BYTES type values. The default value is
-     * false.
+     * [Optional] If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.
      */
     ignoreUnspecifiedColumnFamilies?: boolean;
     /**
-     * [Optional] If field is true, then the rowkey column families will be read
-     * and converted to string. Otherwise they are read with BYTES type values
-     * and users need to manually cast them with CAST if necessary. The default
-     * value is false.
+     * [Optional] If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.
      */
     readRowkeyAsString?: boolean;
-  }
+  };
 
-  interface IClustering {
+  type IBqmlIterationResult = {
     /**
-     * [Repeated] One or more fields on which data should be clustered. Only
-     * top-level, non-repeated, simple-type fields are supported. When you
-     * cluster a table using multiple columns, the order of columns you specify
-     * is important. The order of the specified columns determines the sort
-     * order of the data.
+     * [Output-only, Beta] Time taken to run the training iteration in milliseconds.
      */
-    fields?: string[];
-  }
-
-  interface ICsvOptions {
+    durationMs?: string;
     /**
-     * [Optional] Indicates if BigQuery should accept rows that are missing
-     * trailing optional columns. If true, BigQuery treats missing trailing
-     * columns as null values. If false, records with missing trailing columns
-     * are treated as bad records, and if there are too many bad records, an
-     * invalid error is returned in the job result. The default value is false.
+     * [Output-only, Beta] Eval loss computed on the eval data at the end of the iteration. The eval loss is used for early stopping to avoid overfitting. No eval loss if eval_split_method option is specified as no_split or auto_split with input data size less than 500 rows.
+     */
+    evalLoss?: number;
+    /**
+     * [Output-only, Beta] Index of the ML training iteration, starting from zero for each training run.
+     */
+    index?: number;
+    /**
+     * [Output-only, Beta] Learning rate used for this iteration, it varies for different training iterations if learn_rate_strategy option is not constant.
+     */
+    learnRate?: number;
+    /**
+     * [Output-only, Beta] Training loss computed on the training data at the end of the iteration. The training loss function is defined by model type.
+     */
+    trainingLoss?: number;
+  };
+
+  type IBqmlTrainingRun = {
+    /**
+     * [Output-only, Beta] List of each iteration results.
+     */
+    iterationResults?: Array<IBqmlIterationResult>;
+    /**
+     * [Output-only, Beta] Training run start time in milliseconds since the epoch.
+     */
+    startTime?: string;
+    /**
+     * [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
+     */
+    state?: string;
+    /**
+     * [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
+     */
+    trainingOptions?: {
+      earlyStop?: boolean;
+      l1Reg?: number;
+      l2Reg?: number;
+      learnRate?: number;
+      learnRateStrategy?: string;
+      lineSearchInitLearnRate?: number;
+      maxIteration?: string;
+      minRelProgress?: number;
+      warmStart?: boolean;
+    };
+  };
+
+  type IClustering = {
+    /**
+     * [Repeated] One or more fields on which data should be clustered. Only top-level, non-repeated, simple-type fields are supported. When you cluster a table using multiple columns, the order of columns you specify is important. The order of the specified columns determines the sort order of the data.
+     */
+    fields?: Array<string>;
+  };
+
+  type ICsvOptions = {
+    /**
+     * [Optional] Indicates if BigQuery should accept rows that are missing trailing optional columns. If true, BigQuery treats missing trailing columns as null values. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.
      */
     allowJaggedRows?: boolean;
     /**
-     * [Optional] Indicates if BigQuery should allow quoted data sections that
-     * contain newline characters in a CSV file. The default value is false.
+     * [Optional] Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.
      */
     allowQuotedNewlines?: boolean;
     /**
-     * [Optional] The character encoding of the data. The supported values are
-     * UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the
-     * data after the raw, binary data has been split using the values of the
-     * quote and fieldDelimiter properties.
+     * [Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.
      */
     encoding?: string;
     /**
-     * [Optional] The separator for fields in a CSV file. BigQuery converts the
-     * string to ISO-8859-1 encoding, and then uses the first byte of the
-     * encoded string to split the data in its raw, binary state. BigQuery also
-     * supports the escape sequence &quot;\t&quot; to specify a tab separator.
-     * The default value is a comma (&#39;,&#39;).
+     * [Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence "\t" to specify a tab separator. The default value is a comma (',').
      */
     fieldDelimiter?: string;
     /**
-     * [Optional] The value that is used to quote data sections in a CSV file.
-     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
-     * first byte of the encoded string to split the data in its raw, binary
-     * state. The default value is a double-quote (&#39;&quot;&#39;). If your
-     * data does not contain quoted sections, set the property value to an empty
-     * string. If your data contains quoted newline characters, you must also
-     * set the allowQuotedNewlines property to true.
+     * [Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.
      */
     quote?: string;
     /**
-     * [Optional] The number of rows at the top of a CSV file that BigQuery will
-     * skip when reading the data. The default value is 0. This property is
-     * useful if you have header rows in the file that should be skipped.
+     * [Optional] The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.
      */
     skipLeadingRows?: string;
-  }
+  };
 
-  interface IDataset {
+  type IDataset = {
     /**
-     * [Optional] An array of objects that define dataset access for one or more
-     * entities. You can set this property when inserting or updating a dataset
-     * in order to control who is allowed to access the data. If unspecified at
-     * dataset creation time, BigQuery adds default dataset access for the
-     * following entities: access.specialGroup: projectReaders; access.role:
-     * READER; access.specialGroup: projectWriters; access.role: WRITER;
-     * access.specialGroup: projectOwners; access.role: OWNER;
-     * access.userByEmail: [dataset creator email]; access.role: OWNER;
+     * [Optional] An array of objects that define dataset access for one or more entities. You can set this property when inserting or updating a dataset in order to control who is allowed to access the data. If unspecified at dataset creation time, BigQuery adds default dataset access for the following entities: access.specialGroup: projectReaders; access.role: READER; access.specialGroup: projectWriters; access.role: WRITER; access.specialGroup: projectOwners; access.role: OWNER; access.userByEmail: [dataset creator email]; access.role: OWNER;
      */
     access?: Array<{
+      /**
+       * [Pick one] A domain to grant access to. Any users signed in with the domain specified will be granted the specified access. Example: "example.com". Maps to IAM policy member "domain:DOMAIN".
+       */
       domain?: string;
+      /**
+       * [Pick one] An email address of a Google Group to grant access to. Maps to IAM policy member "group:GROUP".
+       */
       groupByEmail?: string;
+      /**
+       * [Pick one] Some other type of member that appears in the IAM Policy but isn't a user, group, domain, or special group.
+       */
       iamMember?: string;
+      /**
+       * [Required] An IAM role ID that should be granted to the user, group, or domain specified in this access entry. The following legacy mappings will be applied: OWNER  roles/bigquery.dataOwner WRITER  roles/bigquery.dataEditor READER  roles/bigquery.dataViewer This field will accept any of the above formats, but will return only the legacy format. For example, if you set this field to "roles/bigquery.dataOwner", it will be returned back as "OWNER".
+       */
       role?: string;
+      /**
+       * [Pick one] A special group to grant access to. Possible values include: projectOwners: Owners of the enclosing project. projectReaders: Readers of the enclosing project. projectWriters: Writers of the enclosing project. allAuthenticatedUsers: All authenticated BigQuery users. Maps to similarly-named IAM members.
+       */
       specialGroup?: string;
+      /**
+       * [Pick one] An email address of a user to grant access to. For example: fred@example.com. Maps to IAM policy member "user:EMAIL" or "serviceAccount:EMAIL".
+       */
       userByEmail?: string;
+      /**
+       * [Pick one] A view from a different dataset to grant access to. Queries executed against that view will have read access to tables in this dataset. The role field is not required when this field is set. If that view is updated by any user, access to the view needs to be granted again via an update operation.
+       */
       view?: ITableReference;
     }>;
     /**
-     * [Output-only] The time when this dataset was created, in milliseconds
-     * since the epoch.
+     * [Output-only] The time when this dataset was created, in milliseconds since the epoch.
      */
     creationTime?: string;
     /**
@@ -597,32 +204,11 @@ export namespace bigquery {
      */
     datasetReference?: IDatasetReference;
     /**
-     * [Optional] The default partition expiration for all partitioned tables in
-     * the dataset, in milliseconds. Once this property is set, all
-     * newly-created partitioned tables in the dataset will have an expirationMs
-     * property in the timePartitioning settings set to this value, and changing
-     * the value will only affect new tables, not existing ones. The storage in
-     * a partition will have an expiration time of its partition time plus this
-     * value. Setting this property overrides the use of
-     * defaultTableExpirationMs for partitioned tables: only one of
-     * defaultTableExpirationMs and defaultPartitionExpirationMs will be used
-     * for any new partitioned table. If you provide an explicit
-     * timePartitioning.expirationMs when creating or updating a partitioned
-     * table, that value takes precedence over the default partition expiration
-     * time indicated by this property.
+     * [Optional] The default partition expiration for all partitioned tables in the dataset, in milliseconds. Once this property is set, all newly-created partitioned tables in the dataset will have an expirationMs property in the timePartitioning settings set to this value, and changing the value will only affect new tables, not existing ones. The storage in a partition will have an expiration time of its partition time plus this value. Setting this property overrides the use of defaultTableExpirationMs for partitioned tables: only one of defaultTableExpirationMs and defaultPartitionExpirationMs will be used for any new partitioned table. If you provide an explicit timePartitioning.expirationMs when creating or updating a partitioned table, that value takes precedence over the default partition expiration time indicated by this property.
      */
     defaultPartitionExpirationMs?: string;
     /**
-     * [Optional] The default lifetime of all tables in the dataset, in
-     * milliseconds. The minimum value is 3600000 milliseconds (one hour). Once
-     * this property is set, all newly-created tables in the dataset will have
-     * an expirationTime property set to the creation time plus the value in
-     * this property, and changing the value will only affect new tables, not
-     * existing ones. When the expirationTime for a given table is reached, that
-     * table will be deleted automatically. If a table&#39;s expirationTime is
-     * modified or removed before the table expires, or if you provide an
-     * explicit expirationTime when creating a table, that value takes
-     * precedence over the default expiration time indicated by this property.
+     * [Optional] The default lifetime of all tables in the dataset, in milliseconds. The minimum value is 3600000 milliseconds (one hour). Once this property is set, all newly-created tables in the dataset will have an expirationTime property set to the creation time plus the value in this property, and changing the value will only affect new tables, not existing ones. When the expirationTime for a given table is reached, that table will be deleted automatically. If a table's expirationTime is modified or removed before the table expires, or if you provide an explicit expirationTime when creating a table, that value takes precedence over the default expiration time indicated by this property.
      */
     defaultTableExpirationMs?: string;
     /**
@@ -638,10 +224,7 @@ export namespace bigquery {
      */
     friendlyName?: string;
     /**
-     * [Output-only] The fully-qualified unique name of the dataset in the
-     * format projectId:datasetId. The dataset name without the project name is
-     * given in the datasetId field. When creating a new dataset, leave this
-     * field blank, and instead specify the datasetId field.
+     * [Output-only] The fully-qualified unique name of the dataset in the format projectId:datasetId. The dataset name without the project name is given in the datasetId field. When creating a new dataset, leave this field blank, and instead specify the datasetId field.
      */
     id?: string;
     /**
@@ -649,80 +232,103 @@ export namespace bigquery {
      */
     kind?: string;
     /**
-     * The labels associated with this dataset. You can use these to organize
-     * and group your datasets. You can set this property when inserting or
-     * updating a dataset. See Creating and Updating Dataset Labels for more
-     * information.
+     * The labels associated with this dataset. You can use these to organize and group your datasets. You can set this property when inserting or updating a dataset. See Creating and Updating Dataset Labels for more information.
      */
-    labels?: {[key: string]: string;};
+    labels?: { [key: string]: string };
     /**
-     * [Output-only] The date when this dataset or any of its tables was last
-     * modified, in milliseconds since the epoch.
+     * [Output-only] The date when this dataset or any of its tables was last modified, in milliseconds since the epoch.
      */
     lastModifiedTime?: string;
     /**
-     * The geographic location where the dataset should reside. The default
-     * value is US. See details at
-     * https://cloud.google.com/bigquery/docs/locations.
+     * The geographic location where the dataset should reside. The default value is US. See details at https://cloud.google.com/bigquery/docs/locations.
      */
     location?: string;
     /**
-     * [Output-only] A URL that can be used to access the resource again. You
-     * can use this URL in Get or Update requests to the resource.
+     * [Output-only] A URL that can be used to access the resource again. You can use this URL in Get or Update requests to the resource.
      */
     selfLink?: string;
-  }
+  };
 
-  interface IDatasetReference {
+  type IDatasetList = {
     /**
-     * [Required] A unique ID for this dataset, without the project name. The ID
-     * must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_).
-     * The maximum length is 1,024 characters.
+     * An array of the dataset resources in the project. Each resource contains basic information. For full information about a particular dataset resource, use the Datasets: get method. This property is omitted when there are no datasets in the project.
+     */
+    datasets?: Array<{
+      /**
+       * The dataset reference. Use this property to access specific parts of the dataset's ID, such as project ID or dataset ID.
+       */
+      datasetReference?: IDatasetReference;
+      /**
+       * A descriptive name for the dataset, if one exists.
+       */
+      friendlyName?: string;
+      /**
+       * The fully-qualified, unique, opaque ID of the dataset.
+       */
+      id?: string;
+      /**
+       * The resource type. This property always returns the value "bigquery#dataset".
+       */
+      kind?: string;
+      /**
+       * The labels associated with this dataset. You can use these to organize and group your datasets.
+       */
+      labels?: { [key: string]: string };
+      /**
+       * The geographic location where the data resides.
+       */
+      location?: string;
+    }>;
+    /**
+     * A hash value of the results page. You can use this property to determine if the page has changed since the last request.
+     */
+    etag?: string;
+    /**
+     * The list type. This property always returns the value "bigquery#datasetList".
+     */
+    kind?: string;
+    /**
+     * A token that can be used to request the next results page. This property is omitted on the final results page.
+     */
+    nextPageToken?: string;
+  };
+
+  type IDatasetReference = {
+    /**
+     * [Required] A unique ID for this dataset, without the project name. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.
      */
     datasetId?: string;
     /**
      * [Optional] The ID of the project containing this dataset.
      */
     projectId?: string;
-  }
+  };
 
-  interface IDestinationTableProperties {
+  type IDestinationTableProperties = {
     /**
-     * [Optional] The description for the destination table. This will only be
-     * used if the destination table is newly created. If the table already
-     * exists and a value different than the current description is provided,
-     * the job will fail.
+     * [Optional] The description for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current description is provided, the job will fail.
      */
     description?: string;
     /**
-     * [Optional] The friendly name for the destination table. This will only be
-     * used if the destination table is newly created. If the table already
-     * exists and a value different than the current friendly name is provided,
-     * the job will fail.
+     * [Optional] The friendly name for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current friendly name is provided, the job will fail.
      */
     friendlyName?: string;
     /**
-     * [Optional] The labels associated with this table. You can use these to
-     * organize and group your tables. This will only be used if the destination
-     * table is newly created. If the table already exists and labels are
-     * different than the current labels are provided, the job will fail.
+     * [Optional] The labels associated with this table. You can use these to organize and group your tables. This will only be used if the destination table is newly created. If the table already exists and labels are different than the current labels are provided, the job will fail.
      */
-    labels?: {[key: string]: string;};
-  }
+    labels?: { [key: string]: string };
+  };
 
-  interface IEncryptionConfiguration {
+  type IEncryptionConfiguration = {
     /**
-     * [Optional] Describes the Cloud KMS encryption key that will be used to
-     * protect destination BigQuery table. The BigQuery Service Account
-     * associated with your project requires access to this encryption key.
+     * [Optional] Describes the Cloud KMS encryption key that will be used to protect destination BigQuery table. The BigQuery Service Account associated with your project requires access to this encryption key.
      */
     kmsKeyName?: string;
-  }
+  };
 
-  interface IErrorProto {
+  type IErrorProto = {
     /**
-     * Debugging information. This property is internal to Google and should not
-     * be used.
+     * Debugging information. This property is internal to Google and should not be used.
      */
     debugInfo?: string;
     /**
@@ -737,9 +343,9 @@ export namespace bigquery {
      * A short error code that summarizes the error.
      */
     reason?: string;
-  }
+  };
 
-  interface IExplainQueryStage {
+  type IExplainQueryStage = {
     /**
      * Number of parallel input segments completed.
      */
@@ -771,7 +377,7 @@ export namespace bigquery {
     /**
      * IDs for stages that are inputs to this stage.
      */
-    inputStages?: string[];
+    inputStages?: Array<string>;
     /**
      * Human-readable name for stage.
      */
@@ -821,10 +427,9 @@ export namespace bigquery {
      */
     status?: string;
     /**
-     * List of operations within the stage in dependency order (approximately
-     * chronological).
+     * List of operations within the stage in dependency order (approximately chronological).
      */
-    steps?: IExplainQueryStep[];
+    steps?: Array<IExplainQueryStep>;
     /**
      * Milliseconds the average shard spent waiting to be scheduled.
      */
@@ -857,9 +462,9 @@ export namespace bigquery {
      * Relative amount of time the slowest shard spent on writing output.
      */
     writeRatioMax?: number;
-  }
+  };
 
-  interface IExplainQueryStep {
+  type IExplainQueryStep = {
     /**
      * Machine-readable operation type.
      */
@@ -867,13 +472,12 @@ export namespace bigquery {
     /**
      * Human-readable stage descriptions.
      */
-    substeps?: string[];
-  }
+    substeps?: Array<string>;
+  };
 
-  interface IExternalDataConfiguration {
+  type IExternalDataConfiguration = {
     /**
-     * Try to detect schema and format options automatically. Any option
-     * specified explicitly will be honored.
+     * Try to detect schema and format options automatically. Any option specified explicitly will be honored.
      */
     autodetect?: boolean;
     /**
@@ -881,10 +485,7 @@ export namespace bigquery {
      */
     bigtableOptions?: IBigtableOptions;
     /**
-     * [Optional] The compression type of the data source. Possible values
-     * include GZIP and NONE. The default value is NONE. This setting is ignored
-     * for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
-     * formats.
+     * [Optional] The compression type of the data source. Possible values include GZIP and NONE. The default value is NONE. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups and Avro formats.
      */
     compression?: string;
     /**
@@ -896,121 +497,105 @@ export namespace bigquery {
      */
     googleSheetsOptions?: IGoogleSheetsOptions;
     /**
-     * [Optional, Experimental] If hive partitioning is enabled, which mode to
-     * use. Two modes are supported: - AUTO: automatically infer partition key
-     * name(s) and type(s). - STRINGS: automatic infer partition key name(s).
-     * All types are strings. Not all storage formats support hive partitioning
-     * -- requesting hive partitioning on an unsupported format will lead to an
-     * error.
+     * [Optional, Experimental] If hive partitioning is enabled, which mode to use. Two modes are supported: - AUTO: automatically infer partition key name(s) and type(s). - STRINGS: automatic infer partition key name(s). All types are strings. Not all storage formats support hive partitioning -- requesting hive partitioning on an unsupported format will lead to an error.
      */
     hivePartitioningMode?: string;
     /**
-     * [Optional] Indicates if BigQuery should allow extra values that are not
-     * represented in the table schema. If true, the extra values are ignored.
-     * If false, records with extra columns are treated as bad records, and if
-     * there are too many bad records, an invalid error is returned in the job
-     * result. The default value is false. The sourceFormat property determines
-     * what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named
-     * values that don&#39;t match any column names Google Cloud Bigtable: This
-     * setting is ignored. Google Cloud Datastore backups: This setting is
-     * ignored. Avro: This setting is ignored.
+     * [Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names Google Cloud Bigtable: This setting is ignored. Google Cloud Datastore backups: This setting is ignored. Avro: This setting is ignored.
      */
     ignoreUnknownValues?: boolean;
     /**
-     * [Optional] The maximum number of bad records that BigQuery can ignore
-     * when reading data. If the number of bad records exceeds this value, an
-     * invalid error is returned in the job result. This is only valid for CSV,
-     * JSON, and Google Sheets. The default value is 0, which requires that all
-     * records are valid. This setting is ignored for Google Cloud Bigtable,
-     * Google Cloud Datastore backups and Avro formats.
+     * [Optional] The maximum number of bad records that BigQuery can ignore when reading data. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV, JSON, and Google Sheets. The default value is 0, which requires that all records are valid. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups and Avro formats.
      */
     maxBadRecords?: number;
     /**
-     * [Optional] The schema for the data. Schema is required for CSV and JSON
-     * formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore
-     * backups, and Avro formats.
+     * [Optional] The schema for the data. Schema is required for CSV and JSON formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats.
      */
     schema?: ITableSchema;
     /**
-     * [Required] The data format. For CSV files, specify &quot;CSV&quot;. For
-     * Google sheets, specify &quot;GOOGLE_SHEETS&quot;. For newline-delimited
-     * JSON, specify &quot;NEWLINE_DELIMITED_JSON&quot;. For Avro files, specify
-     * &quot;AVRO&quot;. For Google Cloud Datastore backups, specify
-     * &quot;DATASTORE_BACKUP&quot;. [Beta] For Google Cloud Bigtable, specify
-     * &quot;BIGTABLE&quot;.
+     * [Required] The data format. For CSV files, specify "CSV". For Google sheets, specify "GOOGLE_SHEETS". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro files, specify "AVRO". For Google Cloud Datastore backups, specify "DATASTORE_BACKUP". [Beta] For Google Cloud Bigtable, specify "BIGTABLE".
      */
     sourceFormat?: string;
     /**
-     * [Required] The fully-qualified URIs that point to your data in Google
-     * Cloud. For Google Cloud Storage URIs: Each URI can contain one
-     * &#39;*&#39; wildcard character and it must come after the
-     * &#39;bucket&#39; name. Size limits related to load jobs apply to external
-     * data sources. For Google Cloud Bigtable URIs: Exactly one URI can be
-     * specified and it has be a fully specified and valid HTTPS URL for a
-     * Google Cloud Bigtable table. For Google Cloud Datastore backups, exactly
-     * one URI can be specified. Also, the &#39;*&#39; wildcard character is not
-     * allowed.
+     * [Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups, exactly one URI can be specified. Also, the '*' wildcard character is not allowed.
      */
-    sourceUris?: string[];
-  }
+    sourceUris?: Array<string>;
+  };
 
-  interface IGoogleSheetsOptions {
+  type IGetQueryResultsResponse = {
     /**
-     * [Beta] [Optional] Range of a sheet to query from. Only used when
-     * non-empty. Typical format:
-     * sheet_name!top_left_cell_id:bottom_right_cell_id For example:
-     * sheet1!A1:B20
+     * Whether the query result was fetched from the query cache.
+     */
+    cacheHit?: boolean;
+    /**
+     * [Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
+     */
+    errors?: Array<IErrorProto>;
+    /**
+     * A hash of this response.
+     */
+    etag?: string;
+    /**
+     * Whether the query has completed or not. If rows or totalRows are present, this will always be true. If this is false, totalRows will not be available.
+     */
+    jobComplete?: boolean;
+    /**
+     * Reference to the BigQuery Job that was created to run the query. This field will be present even if the original request timed out, in which case GetQueryResults can be used to read the results once the query has completed. Since this API only returns the first page of results, subsequent pages can be fetched via the same mechanism (GetQueryResults).
+     */
+    jobReference?: IJobReference;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * [Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
+     */
+    numDmlAffectedRows?: string;
+    /**
+     * A token used for paging results.
+     */
+    pageToken?: string;
+    /**
+     * An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above. Present only when the query completes successfully.
+     */
+    rows?: Array<ITableRow>;
+    /**
+     * The schema of the results. Present only when the query completes successfully.
+     */
+    schema?: ITableSchema;
+    /**
+     * The total number of bytes processed for this query.
+     */
+    totalBytesProcessed?: string;
+    /**
+     * The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.
+     */
+    totalRows?: string;
+  };
+
+  type IGetServiceAccountResponse = {
+    /**
+     * The service account email address.
+     */
+    email?: string;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+  };
+
+  type IGoogleSheetsOptions = {
+    /**
+     * [Beta] [Optional] Range of a sheet to query from. Only used when non-empty. Typical format: sheet_name!top_left_cell_id:bottom_right_cell_id For example: sheet1!A1:B20
      */
     range?: string;
     /**
-     * [Optional] The number of rows at the top of a sheet that BigQuery will
-     * skip when reading the data. The default value is 0. This property is
-     * useful if you have header rows that should be skipped. When autodetect is
-     * on, behavior is the following: * skipLeadingRows unspecified - Autodetect
-     * tries to detect headers in the first row. If they are not detected, the
-     * row is read as data. Otherwise data is read starting from the second row.
-     * * skipLeadingRows is 0 - Instructs autodetect that there are no headers
-     * and data should be read starting from the first row. * skipLeadingRows =
-     * N &gt; 0 - Autodetect skips N-1 rows and tries to detect headers in row
-     * N. If headers are not detected, row N is just skipped. Otherwise row N is
-     * used to extract column names for the detected schema.
+     * [Optional] The number of rows at the top of a sheet that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows that should be skipped. When autodetect is on, behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: string;
-  }
+  };
 
-  interface IIterationResult {
-    /**
-     * [Output-only, Beta] Time taken to run the training iteration in
-     * milliseconds.
-     */
-    durationMs?: string;
-    /**
-     * [Output-only, Beta] Eval loss computed on the eval data at the end of the
-     * iteration. The eval loss is used for early stopping to avoid overfitting.
-     * No eval loss if eval_split_method option is specified as no_split or
-     * auto_split with input data size less than 500 rows.
-     */
-    evalLoss?: number;
-    /**
-     * [Output-only, Beta] Index of the ML training iteration, starting from
-     * zero for each training run.
-     */
-    index?: number;
-    /**
-     * [Output-only, Beta] Learning rate used for this iteration, it varies for
-     * different training iterations if learn_rate_strategy option is not
-     * constant.
-     */
-    learnRate?: number;
-    /**
-     * [Output-only, Beta] Training loss computed on the training data at the
-     * end of the iteration. The training loss function is defined by model
-     * type.
-     */
-    trainingLoss?: number;
-  }
-
-  interface IJob {
+  type IJob = {
     /**
      * [Required] Describes the job configuration.
      */
@@ -1036,31 +621,37 @@ export namespace bigquery {
      */
     selfLink?: string;
     /**
-     * [Output-only] Information about the job, including starting time and
-     * ending time of the job.
+     * [Output-only] Information about the job, including starting time and ending time of the job.
      */
     statistics?: IJobStatistics;
     /**
-     * [Output-only] The status of this job. Examine this value when polling an
-     * asynchronous job to see if the job is complete.
+     * [Output-only] The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
      */
     status?: IJobStatus;
     /**
      * [Output-only] Email address of the user who ran the job.
      */
     user_email?: string;
-  }
+  };
 
-  interface IJobConfiguration {
+  type IJobCancelResponse = {
+    /**
+     * The final state of the job.
+     */
+    job?: IJob;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+  };
+
+  type IJobConfiguration = {
     /**
      * [Pick one] Copies a table.
      */
     copy?: IJobConfigurationTableCopy;
     /**
-     * [Optional] If set, don&#39;t actually run this job. A valid query will
-     * return a mostly empty response with some processing statistics, while an
-     * invalid query will return the same error it would if it wasn&#39;t a dry
-     * run. Behavior of non-query jobs is undefined.
+     * [Optional] If set, don't actually run this job. A valid query will return a mostly empty response with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run. Behavior of non-query jobs is undefined.
      */
     dryRun?: boolean;
     /**
@@ -1068,24 +659,17 @@ export namespace bigquery {
      */
     extract?: IJobConfigurationExtract;
     /**
-     * [Optional] Job timeout in milliseconds. If this time limit is exceeded,
-     * BigQuery may attempt to terminate the job.
+     * [Optional] Job timeout in milliseconds. If this time limit is exceeded, BigQuery may attempt to terminate the job.
      */
     jobTimeoutMs?: string;
     /**
-     * [Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or
-     * UNKNOWN.
+     * [Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or UNKNOWN.
      */
     jobType?: string;
     /**
-     * The labels associated with this job. You can use these to organize and
-     * group your jobs. Label keys and values can be no longer than 63
-     * characters, can only contain lowercase letters, numeric characters,
-     * underscores and dashes. International characters are allowed. Label
-     * values are optional. Label keys must start with a letter and each label
-     * in the list must have a different key.
+     * The labels associated with this job. You can use these to organize and group your jobs. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.
      */
-    labels?: {[key: string]: string;};
+    labels?: { [key: string]: string };
     /**
      * [Pick one] Configures a load job.
      */
@@ -1094,80 +678,58 @@ export namespace bigquery {
      * [Pick one] Configures a query job.
      */
     query?: IJobConfigurationQuery;
-  }
+  };
 
-  interface IJobConfigurationExtract {
+  type IJobConfigurationExtract = {
     /**
-     * [Optional] The compression type to use for exported files. Possible
-     * values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is
-     * NONE. DEFLATE and SNAPPY are only supported for Avro.
+     * [Optional] The compression type to use for exported files. Possible values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is NONE. DEFLATE and SNAPPY are only supported for Avro.
      */
     compression?: string;
     /**
-     * [Optional] The exported file format. Possible values include CSV,
-     * NEWLINE_DELIMITED_JSON and AVRO. The default value is CSV. Tables with
-     * nested or repeated fields cannot be exported as CSV.
+     * [Optional] The exported file format. Possible values include CSV, NEWLINE_DELIMITED_JSON and AVRO. The default value is CSV. Tables with nested or repeated fields cannot be exported as CSV.
      */
     destinationFormat?: string;
     /**
-     * [Pick one] DEPRECATED: Use destinationUris instead, passing only one URI
-     * as necessary. The fully-qualified Google Cloud Storage URI where the
-     * extracted table should be written.
+     * [Pick one] DEPRECATED: Use destinationUris instead, passing only one URI as necessary. The fully-qualified Google Cloud Storage URI where the extracted table should be written.
      */
     destinationUri?: string;
     /**
-     * [Pick one] A list of fully-qualified Google Cloud Storage URIs where the
-     * extracted table should be written.
+     * [Pick one] A list of fully-qualified Google Cloud Storage URIs where the extracted table should be written.
      */
-    destinationUris?: string[];
+    destinationUris?: Array<string>;
     /**
-     * [Optional] Delimiter to use between fields in the exported data. Default
-     * is &#39;,&#39;
+     * [Optional] Delimiter to use between fields in the exported data. Default is ','
      */
     fieldDelimiter?: string;
     /**
-     * [Optional] Whether to print out a header row in the results. Default is
-     * true.
+     * [Optional] Whether to print out a header row in the results. Default is true.
      */
     printHeader?: boolean;
     /**
      * [Required] A reference to the table being exported.
      */
     sourceTable?: ITableReference;
-  }
+  };
 
-  interface IJobConfigurationLoad {
+  type IJobConfigurationLoad = {
     /**
-     * [Optional] Accept rows that are missing trailing optional columns. The
-     * missing values are treated as nulls. If false, records with missing
-     * trailing columns are treated as bad records, and if there are too many
-     * bad records, an invalid error is returned in the job result. The default
-     * value is false. Only applicable to CSV, ignored for other formats.
+     * [Optional] Accept rows that are missing trailing optional columns. The missing values are treated as nulls. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. Only applicable to CSV, ignored for other formats.
      */
     allowJaggedRows?: boolean;
     /**
-     * Indicates if BigQuery should allow quoted data sections that contain
-     * newline characters in a CSV file. The default value is false.
+     * Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.
      */
     allowQuotedNewlines?: boolean;
     /**
-     * [Optional] Indicates if we should automatically infer the options and
-     * schema for CSV and JSON sources.
+     * [Optional] Indicates if we should automatically infer the options and schema for CSV and JSON sources.
      */
     autodetect?: boolean;
     /**
-     * [Beta] Clustering specification for the destination table. Must be
-     * specified with time-based partitioning, data in the table will be first
-     * partitioned and subsequently clustered.
+     * [Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.
      */
     clustering?: IClustering;
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The
-     * following values are supported: CREATE_IF_NEEDED: If the table does not
-     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
-     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
-     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
-     * append actions occur as one atomic update upon job completion.
+     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
@@ -1179,98 +741,51 @@ export namespace bigquery {
      */
     destinationTable?: ITableReference;
     /**
-     * [Beta] [Optional] Properties with which to create the destination table
-     * if it is new.
+     * [Beta] [Optional] Properties with which to create the destination table if it is new.
      */
     destinationTableProperties?: IDestinationTableProperties;
     /**
-     * [Optional] The character encoding of the data. The supported values are
-     * UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the
-     * data after the raw, binary data has been split using the values of the
-     * quote and fieldDelimiter properties.
+     * [Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.
      */
     encoding?: string;
     /**
-     * [Optional] The separator for fields in a CSV file. The separator can be
-     * any ISO-8859-1 single-byte character. To use a character in the range
-     * 128-255, you must encode the character as UTF8. BigQuery converts the
-     * string to ISO-8859-1 encoding, and then uses the first byte of the
-     * encoded string to split the data in its raw, binary state. BigQuery also
-     * supports the escape sequence &quot;\t&quot; to specify a tab separator.
-     * The default value is a comma (&#39;,&#39;).
+     * [Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence "\t" to specify a tab separator. The default value is a comma (',').
      */
     fieldDelimiter?: string;
     /**
-     * [Optional, Experimental] If hive partitioning is enabled, which mode to
-     * use. Two modes are supported: - AUTO: automatically infer partition key
-     * name(s) and type(s). - STRINGS: automatic infer partition key name(s).
-     * All types are strings. Not all storage formats support hive partitioning
-     * -- requesting hive partitioning on an unsupported format will lead to an
-     * error.
+     * [Optional, Experimental] If hive partitioning is enabled, which mode to use. Two modes are supported: - AUTO: automatically infer partition key name(s) and type(s). - STRINGS: automatic infer partition key name(s). All types are strings. Not all storage formats support hive partitioning -- requesting hive partitioning on an unsupported format will lead to an error.
      */
     hivePartitioningMode?: string;
     /**
-     * [Optional] Indicates if BigQuery should allow extra values that are not
-     * represented in the table schema. If true, the extra values are ignored.
-     * If false, records with extra columns are treated as bad records, and if
-     * there are too many bad records, an invalid error is returned in the job
-     * result. The default value is false. The sourceFormat property determines
-     * what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named
-     * values that don&#39;t match any column names
+     * [Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names
      */
     ignoreUnknownValues?: boolean;
     /**
-     * [Optional] The maximum number of bad records that BigQuery can ignore
-     * when running the job. If the number of bad records exceeds this value, an
-     * invalid error is returned in the job result. This is only valid for CSV
-     * and JSON. The default value is 0, which requires that all records are
-     * valid.
+     * [Optional] The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV and JSON. The default value is 0, which requires that all records are valid.
      */
     maxBadRecords?: number;
     /**
-     * [Optional] Specifies a string that represents a null value in a CSV file.
-     * For example, if you specify &quot;x/&quot;, BigQuery interprets
-     * &quot;x/&quot; as a null value when loading a CSV file. The default value
-     * is the empty string. If you set this property to a custom value, BigQuery
-     * throws an error if an empty string is present for all data types except
-     * for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the
-     * empty string as an empty value.
+     * [Optional] Specifies a string that represents a null value in a CSV file. For example, if you specify "\N", BigQuery interprets "\N" as a null value when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as an empty value.
      */
     nullMarker?: string;
     /**
-     * If sourceFormat is set to &quot;DATASTORE_BACKUP&quot;, indicates which
-     * entity properties to load into BigQuery from a Cloud Datastore backup.
-     * Property names are case sensitive and must be top-level properties. If no
-     * properties are specified, BigQuery loads all properties. If any named
-     * property isn&#39;t found in the Cloud Datastore backup, an invalid error
-     * is returned in the job result.
+     * If sourceFormat is set to "DATASTORE_BACKUP", indicates which entity properties to load into BigQuery from a Cloud Datastore backup. Property names are case sensitive and must be top-level properties. If no properties are specified, BigQuery loads all properties. If any named property isn't found in the Cloud Datastore backup, an invalid error is returned in the job result.
      */
-    projectionFields?: string[];
+    projectionFields?: Array<string>;
     /**
-     * [Optional] The value that is used to quote data sections in a CSV file.
-     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
-     * first byte of the encoded string to split the data in its raw, binary
-     * state. The default value is a double-quote (&#39;&quot;&#39;). If your
-     * data does not contain quoted sections, set the property value to an empty
-     * string. If your data contains quoted newline characters, you must also
-     * set the allowQuotedNewlines property to true.
+     * [Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.
      */
     quote?: string;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one
-     * of timePartitioning and rangePartitioning should be specified.
+     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * [Optional] The schema for the destination table. The schema can be
-     * omitted if the destination table already exists, or if you&#39;re loading
-     * data from Google Cloud Datastore.
+     * [Optional] The schema for the destination table. The schema can be omitted if the destination table already exists, or if you're loading data from Google Cloud Datastore.
      */
     schema?: ITableSchema;
     /**
-     * [Deprecated] The inline schema. For CSV schemas, specify as
-     * &quot;Field1:Type1[,Field2:Type2]*&quot;. For example, &quot;foo:STRING,
-     * bar:INTEGER, baz:FLOAT&quot;.
+     * [Deprecated] The inline schema. For CSV schemas, specify as "Field1:Type1[,Field2:Type2]*". For example, "foo:STRING, bar:INTEGER, baz:FLOAT".
      */
     schemaInline?: string;
     /**
@@ -1278,99 +793,50 @@ export namespace bigquery {
      */
     schemaInlineFormat?: string;
     /**
-     * Allows the schema of the destination table to be updated as a side effect
-     * of the load job if a schema is autodetected or supplied in the job
-     * configuration. Schema update options are supported in two cases: when
-     * writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE
-     * and the destination table is a partition of a table, specified by
-     * partition decorators. For normal tables, WRITE_TRUNCATE will always
-     * overwrite the schema. One or more of the following values are specified:
-     * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema.
-     * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original
-     * schema to nullable.
+     * Allows the schema of the destination table to be updated as a side effect of the load job if a schema is autodetected or supplied in the job configuration. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
      */
-    schemaUpdateOptions?: string[];
+    schemaUpdateOptions?: Array<string>;
     /**
-     * [Optional] The number of rows at the top of a CSV file that BigQuery will
-     * skip when loading the data. The default value is 0. This property is
-     * useful if you have header rows in the file that should be skipped.
+     * [Optional] The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.
      */
     skipLeadingRows?: number;
     /**
-     * [Optional] The format of the data files. For CSV files, specify
-     * &quot;CSV&quot;. For datastore backups, specify
-     * &quot;DATASTORE_BACKUP&quot;. For newline-delimited JSON, specify
-     * &quot;NEWLINE_DELIMITED_JSON&quot;. For Avro, specify &quot;AVRO&quot;.
-     * For parquet, specify &quot;PARQUET&quot;. For orc, specify
-     * &quot;ORC&quot;. The default value is CSV.
+     * [Optional] The format of the data files. For CSV files, specify "CSV". For datastore backups, specify "DATASTORE_BACKUP". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro, specify "AVRO". For parquet, specify "PARQUET". For orc, specify "ORC". The default value is CSV.
      */
     sourceFormat?: string;
     /**
-     * [Required] The fully-qualified URIs that point to your data in Google
-     * Cloud. For Google Cloud Storage URIs: Each URI can contain one
-     * &#39;*&#39; wildcard character and it must come after the
-     * &#39;bucket&#39; name. Size limits related to load jobs apply to external
-     * data sources. For Google Cloud Bigtable URIs: Exactly one URI can be
-     * specified and it has be a fully specified and valid HTTPS URL for a
-     * Google Cloud Bigtable table. For Google Cloud Datastore backups: Exactly
-     * one URI can be specified. Also, the &#39;*&#39; wildcard character is not
-     * allowed.
+     * [Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups: Exactly one URI can be specified. Also, the '*' wildcard character is not allowed.
      */
-    sourceUris?: string[];
+    sourceUris?: Array<string>;
     /**
-     * Time-based partitioning specification for the destination table. Only one
-     * of timePartitioning and rangePartitioning should be specified.
+     * Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * [Optional] If sourceFormat is set to &quot;AVRO&quot;, indicates whether
-     * to enable interpreting logical types into their corresponding types (ie.
-     * TIMESTAMP), instead of only using their raw types (ie. INTEGER).
+     * [Optional] If sourceFormat is set to "AVRO", indicates whether to enable interpreting logical types into their corresponding types (ie. TIMESTAMP), instead of only using their raw types (ie. INTEGER).
      */
     useAvroLogicalTypes?: boolean;
     /**
-     * [Optional] Specifies the action that occurs if the destination table
-     * already exists. The following values are supported: WRITE_TRUNCATE: If
-     * the table already exists, BigQuery overwrites the table data.
-     * WRITE_APPEND: If the table already exists, BigQuery appends the data to
-     * the table. WRITE_EMPTY: If the table already exists and contains data, a
-     * &#39;duplicate&#39; error is returned in the job result. The default
-     * value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery
-     * is able to complete the job successfully. Creation, truncation and append
-     * actions occur as one atomic update upon job completion.
+     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
-  }
+  };
 
-  interface IJobConfigurationQuery {
+  type IJobConfigurationQuery = {
     /**
-     * [Optional] If true and query uses legacy SQL dialect, allows the query to
-     * produce arbitrarily large result tables at a slight cost in performance.
-     * Requires destinationTable to be set. For standard SQL queries, this flag
-     * is ignored and large results are always allowed. However, you must still
-     * set destinationTable when result size exceeds the allowed maximum
-     * response size.
+     * [Optional] If true and query uses legacy SQL dialect, allows the query to produce arbitrarily large result tables at a slight cost in performance. Requires destinationTable to be set. For standard SQL queries, this flag is ignored and large results are always allowed. However, you must still set destinationTable when result size exceeds the allowed maximum response size.
      */
     allowLargeResults?: boolean;
     /**
-     * [Beta] Clustering specification for the destination table. Must be
-     * specified with time-based partitioning, data in the table will be first
-     * partitioned and subsequently clustered.
+     * [Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.
      */
     clustering?: IClustering;
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The
-     * following values are supported: CREATE_IF_NEEDED: If the table does not
-     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
-     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
-     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
-     * append actions occur as one atomic update upon job completion.
+     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
-     * [Optional] Specifies the default dataset to use for unqualified table
-     * names in the query. Note that this does not alter behavior of unqualified
-     * dataset names.
+     * [Optional] Specifies the default dataset to use for unqualified table names in the query. Note that this does not alter behavior of unqualified dataset names.
      */
     defaultDataset?: IDatasetReference;
     /**
@@ -1378,35 +844,23 @@ export namespace bigquery {
      */
     destinationEncryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Optional] Describes the table where the query results should be stored.
-     * If not present, a new table will be created to store the results. This
-     * property must be set for large results that exceed the maximum response
-     * size.
+     * [Optional] Describes the table where the query results should be stored. If not present, a new table will be created to store the results. This property must be set for large results that exceed the maximum response size.
      */
     destinationTable?: ITableReference;
     /**
-     * [Optional] If true and query uses legacy SQL dialect, flattens all nested
-     * and repeated fields in the query results. allowLargeResults must be true
-     * if this is set to false. For standard SQL queries, this flag is ignored
-     * and results are never flattened.
+     * [Optional] If true and query uses legacy SQL dialect, flattens all nested and repeated fields in the query results. allowLargeResults must be true if this is set to false. For standard SQL queries, this flag is ignored and results are never flattened.
      */
     flattenResults?: boolean;
     /**
-     * [Optional] Limits the billing tier for this job. Queries that have
-     * resource usage beyond this tier will fail (without incurring a charge).
-     * If unspecified, this will be set to your project default.
+     * [Optional] Limits the billing tier for this job. Queries that have resource usage beyond this tier will fail (without incurring a charge). If unspecified, this will be set to your project default.
      */
     maximumBillingTier?: number;
     /**
-     * [Optional] Limits the bytes billed for this job. Queries that will have
-     * bytes billed beyond this limit will fail (without incurring a charge). If
-     * unspecified, this will be set to your project default.
+     * [Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.
      */
     maximumBytesBilled?: string;
     /**
-     * Standard SQL only. Set to POSITIONAL to use positional (?) query
-     * parameters or to NAMED to use named (@myparam) query parameters in this
-     * query.
+     * Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
      */
     parameterMode?: string;
     /**
@@ -1414,92 +868,54 @@ export namespace bigquery {
      */
     preserveNulls?: boolean;
     /**
-     * [Optional] Specifies a priority for the query. Possible values include
-     * INTERACTIVE and BATCH. The default value is INTERACTIVE.
+     * [Optional] Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.
      */
     priority?: string;
     /**
-     * [Required] SQL query text to execute. The useLegacySql field can be used
-     * to indicate whether the query uses legacy SQL or standard SQL.
+     * [Required] SQL query text to execute. The useLegacySql field can be used to indicate whether the query uses legacy SQL or standard SQL.
      */
     query?: string;
     /**
      * Query parameters for standard SQL queries.
      */
-    queryParameters?: IQueryParameter[];
+    queryParameters?: Array<IQueryParameter>;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one
-     * of timePartitioning and rangePartitioning should be specified.
+     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * Allows the schema of the destination table to be updated as a side effect
-     * of the query job. Schema update options are supported in two cases: when
-     * writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE
-     * and the destination table is a partition of a table, specified by
-     * partition decorators. For normal tables, WRITE_TRUNCATE will always
-     * overwrite the schema. One or more of the following values are specified:
-     * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema.
-     * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original
-     * schema to nullable.
+     * Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
      */
-    schemaUpdateOptions?: string[];
+    schemaUpdateOptions?: Array<string>;
     /**
-     * [Optional] If querying an external data source outside of BigQuery,
-     * describes the data format, location and other properties of the data
-     * source. By defining these properties, the data source can then be queried
-     * as if it were a standard BigQuery table.
+     * [Optional] If querying an external data source outside of BigQuery, describes the data format, location and other properties of the data source. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.
      */
-    tableDefinitions?: {[key: string]: IExternalDataConfiguration;};
+    tableDefinitions?: { [key: string]: IExternalDataConfiguration };
     /**
-     * Time-based partitioning specification for the destination table. Only one
-     * of timePartitioning and rangePartitioning should be specified.
+     * Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * Specifies whether to use BigQuery&#39;s legacy SQL dialect for this
-     * query. The default value is true. If set to false, the query will use
-     * BigQuery&#39;s standard SQL:
-     * https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set
-     * to false, the value of flattenResults is ignored; query will be run as if
-     * flattenResults is false.
+     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
      */
     useLegacySql?: boolean;
     /**
-     * [Optional] Whether to look for the result in the query cache. The query
-     * cache is a best-effort cache that will be flushed whenever tables in the
-     * query are modified. Moreover, the query cache is only available when a
-     * query does not have a destination table specified. The default value is
-     * true.
+     * [Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. Moreover, the query cache is only available when a query does not have a destination table specified. The default value is true.
      */
     useQueryCache?: boolean;
     /**
      * Describes user-defined function resources used in the query.
      */
-    userDefinedFunctionResources?: IUserDefinedFunctionResource[];
+    userDefinedFunctionResources?: Array<IUserDefinedFunctionResource>;
     /**
-     * [Optional] Specifies the action that occurs if the destination table
-     * already exists. The following values are supported: WRITE_TRUNCATE: If
-     * the table already exists, BigQuery overwrites the table data and uses the
-     * schema from the query result. WRITE_APPEND: If the table already exists,
-     * BigQuery appends the data to the table. WRITE_EMPTY: If the table already
-     * exists and contains data, a &#39;duplicate&#39; error is returned in the
-     * job result. The default value is WRITE_EMPTY. Each action is atomic and
-     * only occurs if BigQuery is able to complete the job successfully.
-     * Creation, truncation and append actions occur as one atomic update upon
-     * job completion.
+     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
-  }
+  };
 
-  interface IJobConfigurationTableCopy {
+  type IJobConfigurationTableCopy = {
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The
-     * following values are supported: CREATE_IF_NEEDED: If the table does not
-     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
-     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
-     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
-     * append actions occur as one atomic update upon job completion.
+     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
@@ -1517,53 +933,95 @@ export namespace bigquery {
     /**
      * [Pick one] Source tables to copy.
      */
-    sourceTables?: ITableReference[];
+    sourceTables?: Array<ITableReference>;
     /**
-     * [Optional] Specifies the action that occurs if the destination table
-     * already exists. The following values are supported: WRITE_TRUNCATE: If
-     * the table already exists, BigQuery overwrites the table data.
-     * WRITE_APPEND: If the table already exists, BigQuery appends the data to
-     * the table. WRITE_EMPTY: If the table already exists and contains data, a
-     * &#39;duplicate&#39; error is returned in the job result. The default
-     * value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery
-     * is able to complete the job successfully. Creation, truncation and append
-     * actions occur as one atomic update upon job completion.
+     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
-  }
+  };
 
-  interface IJobReference {
+  type IJobList = {
     /**
-     * [Required] The ID of the job. The ID must contain only letters (a-z,
-     * A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length
-     * is 1,024 characters.
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * List of jobs that were requested.
+     */
+    jobs?: Array<{
+      /**
+       * [Full-projection-only] Specifies the job configuration.
+       */
+      configuration?: IJobConfiguration;
+      /**
+       * A result object that will be present only if the job has failed.
+       */
+      errorResult?: IErrorProto;
+      /**
+       * Unique opaque ID of the job.
+       */
+      id?: string;
+      /**
+       * Job reference uniquely identifying the job.
+       */
+      jobReference?: IJobReference;
+      /**
+       * The resource type.
+       */
+      kind?: string;
+      /**
+       * Running state of the job. When the state is DONE, errorResult can be checked to determine whether the job succeeded or failed.
+       */
+      state?: string;
+      /**
+       * [Output-only] Information about the job, including starting time and ending time of the job.
+       */
+      statistics?: IJobStatistics;
+      /**
+       * [Full-projection-only] Describes the state of the job.
+       */
+      status?: IJobStatus;
+      /**
+       * [Full-projection-only] Email address of the user who ran the job.
+       */
+      user_email?: string;
+    }>;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * A token to request the next page of results.
+     */
+    nextPageToken?: string;
+  };
+
+  type IJobReference = {
+    /**
+     * [Required] The ID of the job. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024 characters.
      */
     jobId?: string;
     /**
-     * The geographic location of the job. See details at
-     * https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     * The geographic location of the job. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
      */
     location?: string;
     /**
      * [Required] The ID of the project containing this job.
      */
     projectId?: string;
-  }
+  };
 
-  interface IJobStatistics {
+  type IJobStatistics = {
     /**
-     * [TrustedTester] [Output-only] Job progress (0.0 -&gt; 1.0) for LOAD and
-     * EXTRACT jobs.
+     * [TrustedTester] [Output-only] Job progress (0.0 -> 1.0) for LOAD and EXTRACT jobs.
      */
     completionRatio?: number;
     /**
-     * [Output-only] Creation time of this job, in milliseconds since the epoch.
-     * This field will be present on all jobs.
+     * [Output-only] Creation time of this job, in milliseconds since the epoch. This field will be present on all jobs.
      */
     creationTime?: string;
     /**
-     * [Output-only] End time of this job, in milliseconds since the epoch. This
-     * field will be present whenever a job is in the DONE state.
+     * [Output-only] End time of this job, in milliseconds since the epoch. This field will be present whenever a job is in the DONE state.
      */
     endTime?: string;
     /**
@@ -1587,31 +1045,37 @@ export namespace bigquery {
      */
     query?: IJobStatistics2;
     /**
-     * [Output-only] Quotas which delayed this job&#39;s start time.
+     * [Output-only] Quotas which delayed this job's start time.
      */
-    quotaDeferments?: string[];
+    quotaDeferments?: Array<string>;
     /**
      * [Output-only] Job resource usage breakdown by reservation.
      */
-    reservationUsage?: Array<{name?: string; slotMs?: string;}>;
+    reservationUsage?: Array<{
+      /**
+       * [Output-only] Reservation name or "unreserved" for on-demand resources usage.
+       */
+      name?: string;
+      /**
+       * [Output-only] Slot-milliseconds the job spent in the given reservation.
+       */
+      slotMs?: string;
+    }>;
     /**
-     * [Output-only] Start time of this job, in milliseconds since the epoch.
-     * This field will be present when the job transitions from the PENDING
-     * state to either RUNNING or DONE.
+     * [Output-only] Start time of this job, in milliseconds since the epoch. This field will be present when the job transitions from the PENDING state to either RUNNING or DONE.
      */
     startTime?: string;
     /**
-     * [Output-only] [Deprecated] Use the bytes processed in the query
-     * statistics instead.
+     * [Output-only] [Deprecated] Use the bytes processed in the query statistics instead.
      */
     totalBytesProcessed?: string;
     /**
      * [Output-only] Slot-milliseconds for the job.
      */
     totalSlotMs?: string;
-  }
+  };
 
-  interface IJobStatistics2 {
+  type IJobStatistics2 = {
     /**
      * [Output-only] Billing tier for the job.
      */
@@ -1621,17 +1085,13 @@ export namespace bigquery {
      */
     cacheHit?: boolean;
     /**
-     * The DDL operation performed, possibly dependent on the pre-existence of
-     * the DDL target. Possible values (new values might be added in the
-     * future): &quot;CREATE&quot;: The query created the DDL target.
-     * &quot;SKIP&quot;: No-op. Example cases: the query is CREATE TABLE IF NOT
-     * EXISTS while the table already exists, or the query is DROP TABLE IF
-     * EXISTS while the table does not exist. &quot;REPLACE&quot;: The query
-     * replaced the DDL target. Example case: the query is CREATE OR REPLACE
-     * TABLE, and the table already exists. &quot;DROP&quot;: The query deleted
-     * the DDL target.
+     * The DDL operation performed, possibly dependent on the pre-existence of the DDL target. Possible values (new values might be added in the future): "CREATE": The query created the DDL target. "SKIP": No-op. Example cases: the query is CREATE TABLE IF NOT EXISTS while the table already exists, or the query is DROP TABLE IF EXISTS while the table does not exist. "REPLACE": The query replaced the DDL target. Example case: the query is CREATE OR REPLACE TABLE, and the table already exists. "DROP": The query deleted the DDL target.
      */
     ddlOperationPerformed?: string;
+    /**
+     * The DDL target routine. Present only for CREATE/DROP FUNCTION/PROCEDURE queries.
+     */
+    ddlTargetRoutine?: IRoutineReference;
     /**
      * The DDL target table. Present only for CREATE/DROP TABLE/VIEW queries.
      */
@@ -1653,51 +1113,42 @@ export namespace bigquery {
      */
     modelTrainingExpectedTotalIteration?: string;
     /**
-     * [Output-only] The number of rows affected by a DML statement. Present
-     * only for DML statements INSERT, UPDATE or DELETE.
+     * [Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
      */
     numDmlAffectedRows?: string;
     /**
      * [Output-only] Describes execution plan for the query.
      */
-    queryPlan?: IExplainQueryStage[];
+    queryPlan?: Array<IExplainQueryStage>;
     /**
-     * [Output-only] Referenced tables for the job. Queries that reference more
-     * than 50 tables will not have a complete list.
+     * [Output-only] Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
      */
-    referencedTables?: ITableReference[];
+    referencedTables?: Array<ITableReference>;
     /**
      * [Output-only] Job resource usage breakdown by reservation.
      */
-    reservationUsage?: Array<{name?: string; slotMs?: string;}>;
+    reservationUsage?: Array<{
+      /**
+       * [Output-only] Reservation name or "unreserved" for on-demand resources usage.
+       */
+      name?: string;
+      /**
+       * [Output-only] Slot-milliseconds the job spent in the given reservation.
+       */
+      slotMs?: string;
+    }>;
     /**
-     * [Output-only] The schema of the results. Present only for successful dry
-     * run of non-legacy SQL queries.
+     * [Output-only] The schema of the results. Present only for successful dry run of non-legacy SQL queries.
      */
     schema?: ITableSchema;
     /**
-     * The type of query statement, if valid. Possible values (new values might
-     * be added in the future): &quot;SELECT&quot;: SELECT query.
-     * &quot;INSERT&quot;: INSERT query; see
-     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
-     * &quot;UPDATE&quot;: UPDATE query; see
-     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
-     * &quot;DELETE&quot;: DELETE query; see
-     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
-     * &quot;MERGE&quot;: MERGE query; see
-     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
-     * &quot;CREATE_TABLE&quot;: CREATE [OR REPLACE] TABLE without AS SELECT.
-     * &quot;CREATE_TABLE_AS_SELECT&quot;: CREATE [OR REPLACE] TABLE ... AS
-     * SELECT ... . &quot;DROP_TABLE&quot;: DROP TABLE query.
-     * &quot;CREATE_VIEW&quot;: CREATE [OR REPLACE] VIEW ... AS SELECT ... .
-     * &quot;DROP_VIEW&quot;: DROP VIEW query. &quot;ALTER_TABLE&quot;: ALTER
-     * TABLE query. &quot;ALTER_VIEW&quot;: ALTER VIEW query.
+     * The type of query statement, if valid. Possible values (new values might be added in the future): "SELECT": SELECT query. "INSERT": INSERT query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "UPDATE": UPDATE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "DELETE": DELETE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "MERGE": MERGE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "CREATE_TABLE": CREATE [OR REPLACE] TABLE without AS SELECT. "CREATE_TABLE_AS_SELECT": CREATE [OR REPLACE] TABLE ... AS SELECT ... . "DROP_TABLE": DROP TABLE query. "CREATE_VIEW": CREATE [OR REPLACE] VIEW ... AS SELECT ... . "DROP_VIEW": DROP VIEW query. "CREATE_FUNCTION": CREATE FUNCTION query. "DROP_FUNCTION" : DROP FUNCTION query. "ALTER_TABLE": ALTER TABLE query. "ALTER_VIEW": ALTER VIEW query.
      */
     statementType?: string;
     /**
      * [Output-only] [Beta] Describes a timeline of job execution.
      */
-    timeline?: IQueryTimelineSample[];
+    timeline?: Array<IQueryTimelineSample>;
     /**
      * [Output-only] Total bytes billed for the job.
      */
@@ -1707,16 +1158,11 @@ export namespace bigquery {
      */
     totalBytesProcessed?: string;
     /**
-     * [Output-only] For dry-run jobs, totalBytesProcessed is an estimate and
-     * this field specifies the accuracy of the estimate. Possible values can
-     * be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is
-     * precise. LOWER_BOUND: estimate is lower bound of what the query would
-     * cost. UPPER_BOUND: estimate is upper bound of what the query would cost.
+     * [Output-only] For dry-run jobs, totalBytesProcessed is an estimate and this field specifies the accuracy of the estimate. Possible values can be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is precise. LOWER_BOUND: estimate is lower bound of what the query would cost. UPPER_BOUND: estimate is upper bound of what the query would cost.
      */
     totalBytesProcessedAccuracy?: string;
     /**
-     * [Output-only] Total number of partitions processed from all partitioned
-     * tables referenced in the job.
+     * [Output-only] Total number of partitions processed from all partitioned tables referenced in the job.
      */
     totalPartitionsProcessed?: string;
     /**
@@ -1724,18 +1170,14 @@ export namespace bigquery {
      */
     totalSlotMs?: string;
     /**
-     * Standard SQL only: list of undeclared query parameters detected during a
-     * dry run validation.
+     * Standard SQL only: list of undeclared query parameters detected during a dry run validation.
      */
-    undeclaredQueryParameters?: IQueryParameter[];
-  }
+    undeclaredQueryParameters?: Array<IQueryParameter>;
+  };
 
-  interface IJobStatistics3 {
+  type IJobStatistics3 = {
     /**
-     * [Output-only] The number of bad records encountered. Note that if the job
-     * has failed because of more bad records encountered than the maximum
-     * allowed in the load job configuration, then this number can be less than
-     * the total number of bad records present in the input data.
+     * [Output-only] The number of bad records encountered. Note that if the job has failed because of more bad records encountered than the maximum allowed in the load job configuration, then this number can be less than the total number of bad records present in the input data.
      */
     badRecords?: string;
     /**
@@ -1747,89 +1189,128 @@ export namespace bigquery {
      */
     inputFiles?: string;
     /**
-     * [Output-only] Size of the loaded data in bytes. Note that while a load
-     * job is in the running state, this value may change.
+     * [Output-only] Size of the loaded data in bytes. Note that while a load job is in the running state, this value may change.
      */
     outputBytes?: string;
     /**
-     * [Output-only] Number of rows imported in a load job. Note that while an
-     * import job is in the running state, this value may change.
+     * [Output-only] Number of rows imported in a load job. Note that while an import job is in the running state, this value may change.
      */
     outputRows?: string;
-  }
+  };
 
-  interface IJobStatistics4 {
+  type IJobStatistics4 = {
     /**
-     * [Output-only] Number of files per destination URI or URI pattern
-     * specified in the extract configuration. These values will be in the same
-     * order as the URIs specified in the &#39;destinationUris&#39; field.
+     * [Output-only] Number of files per destination URI or URI pattern specified in the extract configuration. These values will be in the same order as the URIs specified in the 'destinationUris' field.
      */
-    destinationUriFileCounts?: string[];
+    destinationUriFileCounts?: Array<string>;
     /**
-     * [Output-only] Number of user bytes extracted into the result. This is the
-     * byte count as computed by BigQuery for billing purposes.
+     * [Output-only] Number of user bytes extracted into the result. This is the byte count as computed by BigQuery for billing purposes.
      */
     inputBytes?: string;
-  }
+  };
 
-  interface IJobStatus {
+  type IJobStatus = {
     /**
-     * [Output-only] Final error result of the job. If present, indicates that
-     * the job has completed and was unsuccessful.
+     * [Output-only] Final error result of the job. If present, indicates that the job has completed and was unsuccessful.
      */
     errorResult?: IErrorProto;
     /**
-     * [Output-only] The first errors encountered during the running of the job.
-     * The final message includes the number of errors that caused the process
-     * to stop. Errors here do not necessarily mean that the job has completed
-     * or was unsuccessful.
+     * [Output-only] The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
      */
-    errors?: IErrorProto[];
+    errors?: Array<IErrorProto>;
     /**
      * [Output-only] Running state of the job.
      */
     state?: string;
-  }
+  };
+
   /**
    * Represents a single JSON object.
    */
+  type IJsonObject = { [key: string]: IJsonValue };
 
-  interface IJsonObject {}
+  type IJsonValue = any;
 
-  interface IJsonValue {}
-
-  interface IMaterializedViewDefinition {
+  type IMaterializedViewDefinition = {
     /**
-     * [Output-only] [TrustedTester] The time when this materialized view was
-     * last modified, in milliseconds since the epoch.
+     * [Output-only] [TrustedTester] The time when this materialized view was last modified, in milliseconds since the epoch.
      */
     lastRefreshTime?: string;
     /**
      * [Required] A query whose result is persisted.
      */
     query?: string;
-  }
+  };
 
-  interface IModelDefinition {
+  type IModelDefinition = {
     /**
-     * [Output-only, Beta] Model options used for the first training run. These
-     * options are immutable for subsequent training runs. Default values are
-     * used for any options not specified in the input query.
+     * [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
      */
-    modelOptions?: {labels?: string[]; lossType?: string; modelType?: string;};
+    modelOptions?: {
+      labels?: Array<string>;
+      lossType?: string;
+      modelType?: string;
+    };
     /**
-     * [Output-only, Beta] Information about ml training runs, each training run
-     * comprises of multiple iterations and there may be multiple training runs
-     * for the model if warm start is used or if a user decides to continue a
-     * previously cancelled query.
+     * [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
      */
-    trainingRuns?: ITrainingRun[];
-  }
+    trainingRuns?: Array<IBqmlTrainingRun>;
+  };
 
-  interface IQueryParameter {
+  type IProjectList = {
     /**
-     * [Optional] If unset, this is a positional parameter. Otherwise, should be
-     * unique within a query.
+     * A hash of the page of results
+     */
+    etag?: string;
+    /**
+     * The type of list.
+     */
+    kind?: string;
+    /**
+     * A token to request the next page of results.
+     */
+    nextPageToken?: string;
+    /**
+     * Projects to which you have at least READ access.
+     */
+    projects?: Array<{
+      /**
+       * A descriptive name for this project.
+       */
+      friendlyName?: string;
+      /**
+       * An opaque ID of this project.
+       */
+      id?: string;
+      /**
+       * The resource type.
+       */
+      kind?: string;
+      /**
+       * The numeric ID of this project.
+       */
+      numericId?: string;
+      /**
+       * A unique reference to this project.
+       */
+      projectReference?: IProjectReference;
+    }>;
+    /**
+     * The total number of projects in the list.
+     */
+    totalItems?: number;
+  };
+
+  type IProjectReference = {
+    /**
+     * [Required] ID of the project. Can be either the numeric ID or the assigned ID of the project.
+     */
+    projectId?: string;
+  };
+
+  type IQueryParameter = {
+    /**
+     * [Optional] If unset, this is a positional parameter. Otherwise, should be unique within a query.
      */
     name?: string;
     /**
@@ -1840,49 +1321,152 @@ export namespace bigquery {
      * [Required] The value of this parameter.
      */
     parameterValue?: IQueryParameterValue;
-  }
+  };
 
-  interface IQueryParameterType {
+  type IQueryParameterType = {
     /**
-     * [Optional] The type of the array&#39;s elements, if this is an array.
+     * [Optional] The type of the array's elements, if this is an array.
      */
     arrayType?: IQueryParameterType;
     /**
-     * [Optional] The types of the fields of this struct, in order, if this is a
-     * struct.
+     * [Optional] The types of the fields of this struct, in order, if this is a struct.
      */
     structTypes?: Array<{
+      /**
+       * [Optional] Human-oriented description of the field.
+       */
       description?: string;
+      /**
+       * [Optional] The name of this field.
+       */
       name?: string;
+      /**
+       * [Required] The type of this field.
+       */
       type?: IQueryParameterType;
     }>;
     /**
      * [Required] The top level type of this field.
      */
     type?: string;
-  }
+  };
 
-  interface IQueryParameterValue {
+  type IQueryParameterValue = {
     /**
      * [Optional] The array values, if this is an array type.
      */
-    arrayValues?: IQueryParameterValue[];
+    arrayValues?: Array<IQueryParameterValue>;
     /**
-     * [Optional] The struct field values, in order of the struct type&#39;s
-     * declaration.
+     * [Optional] The struct field values, in order of the struct type's declaration.
      */
-    structValues?: {[key: string]: IQueryParameterValue;};
+    structValues?: { [key: string]: IQueryParameterValue };
     /**
      * [Optional] The value of this value, if a simple scalar type.
      */
     value?: string;
-  }
+  };
 
-  interface IQueryTimelineSample {
+  type IQueryRequest = {
     /**
-     * Total number of units currently being processed by workers. This does not
-     * correspond directly to slot usage. This is the largest value observed
-     * since the last sample.
+     * [Optional] Specifies the default datasetId and projectId to assume for any unqualified table names in the query. If not set, all table names in the query string must be qualified in the format 'datasetId.tableId'.
+     */
+    defaultDataset?: IDatasetReference;
+    /**
+     * [Optional] If set to true, BigQuery doesn't run the job. Instead, if the query is valid, BigQuery returns statistics about the job such as how many bytes would be processed. If the query is invalid, an error returns. The default value is false.
+     */
+    dryRun?: boolean;
+    /**
+     * The resource type of the request.
+     */
+    kind?: string;
+    /**
+     * The geographic location where the job should run. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     */
+    location?: string;
+    /**
+     * [Optional] The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.
+     */
+    maxResults?: number;
+    /**
+     * Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
+     */
+    parameterMode?: string;
+    /**
+     * [Deprecated] This property is deprecated.
+     */
+    preserveNulls?: boolean;
+    /**
+     * [Required] A query string, following the BigQuery query syntax, of the query to execute. Example: "SELECT count(f1) FROM [myProjectId:myDatasetId.myTableId]".
+     */
+    query?: string;
+    /**
+     * Query parameters for Standard SQL queries.
+     */
+    queryParameters?: Array<IQueryParameter>;
+    /**
+     * [Optional] How long to wait for the query to complete, in milliseconds, before the request times out and returns. Note that this is only a timeout for the request, not the query. If the query takes longer to run than the timeout value, the call returns without any results and with the 'jobComplete' flag set to false. You can call GetQueryResults() to wait for the query to complete and read the results. The default value is 10000 milliseconds (10 seconds).
+     */
+    timeoutMs?: number;
+    /**
+     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
+     */
+    useLegacySql?: boolean;
+    /**
+     * [Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. The default value is true.
+     */
+    useQueryCache?: boolean;
+  };
+
+  type IQueryResponse = {
+    /**
+     * Whether the query result was fetched from the query cache.
+     */
+    cacheHit?: boolean;
+    /**
+     * [Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
+     */
+    errors?: Array<IErrorProto>;
+    /**
+     * Whether the query has completed or not. If rows or totalRows are present, this will always be true. If this is false, totalRows will not be available.
+     */
+    jobComplete?: boolean;
+    /**
+     * Reference to the Job that was created to run the query. This field will be present even if the original request timed out, in which case GetQueryResults can be used to read the results once the query has completed. Since this API only returns the first page of results, subsequent pages can be fetched via the same mechanism (GetQueryResults).
+     */
+    jobReference?: IJobReference;
+    /**
+     * The resource type.
+     */
+    kind?: string;
+    /**
+     * [Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
+     */
+    numDmlAffectedRows?: string;
+    /**
+     * A token used for paging results.
+     */
+    pageToken?: string;
+    /**
+     * An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above.
+     */
+    rows?: Array<ITableRow>;
+    /**
+     * The schema of the results. Present only when the query completes successfully.
+     */
+    schema?: ITableSchema;
+    /**
+     * The total number of bytes processed for this query. If this query was a dry run, this is the number of bytes that would be processed if the query were run.
+     */
+    totalBytesProcessed?: string;
+    /**
+     * The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results.
+     */
+    totalRows?: string;
+  };
+
+  type IQueryTimelineSample = {
+    /**
+     * Total number of units currently being processed by workers. This does not correspond directly to slot usage. This is the largest value observed since the last sample.
      */
     activeUnits?: string;
     /**
@@ -1901,50 +1485,69 @@ export namespace bigquery {
      * Cumulative slot-ms consumed by the query.
      */
     totalSlotMs?: string;
-  }
+  };
 
-  interface IRangePartitioning {
+  type IRangePartitioning = {
     /**
-     * [TrustedTester] [Required] The table is partitioned by this field. The
-     * field must be a top-level NULLABLE/REQUIRED field. The only supported
-     * type is INTEGER/INT64.
+     * [TrustedTester] [Required] The table is partitioned by this field. The field must be a top-level NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.
      */
     field?: string;
     /**
      * [TrustedTester] [Required] Defines the ranges for range partitioning.
      */
-    range?: {end?: string; interval?: string; start?: string;};
-  }
+    range?: {
+      /**
+       * [TrustedTester] [Required] The end of range partitioning, exclusive.
+       */
+      end?: string;
+      /**
+       * [TrustedTester] [Required] The width of each interval.
+       */
+      interval?: string;
+      /**
+       * [TrustedTester] [Required] The start of range partitioning, inclusive.
+       */
+      start?: string;
+    };
+  };
 
-  interface IStreamingbuffer {
+  type IRoutineReference = {
     /**
-     * [Output-only] A lower-bound estimate of the number of bytes currently in
-     * the streaming buffer.
+     * [Required] The ID of the dataset containing this routine.
+     */
+    datasetId?: string;
+    /**
+     * [Required] The ID of the project containing this routine.
+     */
+    projectId?: string;
+    /**
+     * [Required] The ID of the routine. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 256 characters.
+     */
+    routineId?: string;
+  };
+
+  type IStreamingbuffer = {
+    /**
+     * [Output-only] A lower-bound estimate of the number of bytes currently in the streaming buffer.
      */
     estimatedBytes?: string;
     /**
-     * [Output-only] A lower-bound estimate of the number of rows currently in
-     * the streaming buffer.
+     * [Output-only] A lower-bound estimate of the number of rows currently in the streaming buffer.
      */
     estimatedRows?: string;
     /**
-     * [Output-only] Contains the timestamp of the oldest entry in the streaming
-     * buffer, in milliseconds since the epoch, if the streaming buffer is
-     * available.
+     * [Output-only] Contains the timestamp of the oldest entry in the streaming buffer, in milliseconds since the epoch, if the streaming buffer is available.
      */
     oldestEntryTime?: string;
-  }
+  };
 
-  interface ITable {
+  type ITable = {
     /**
-     * [Beta] Clustering specification for the table. Must be specified with
-     * partitioning, data in the table will be first partitioned and
-     * subsequently clustered.
+     * [Beta] Clustering specification for the table. Must be specified with partitioning, data in the table will be first partitioned and subsequently clustered.
      */
     clustering?: IClustering;
     /**
-     * [Output-only] The time when this table was created, in milliseconds since
-     * the epoch.
+     * [Output-only] The time when this table was created, in milliseconds since the epoch.
      */
     creationTime?: string;
     /**
@@ -1956,24 +1559,15 @@ export namespace bigquery {
      */
     encryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Output-only] A hash of the table metadata. Used to ensure there were no
-     * concurrent modifications to the resource when attempting an update. Not
-     * guaranteed to change when the table contents or the fields numRows,
-     * numBytes, numLongTermBytes or lastModifiedTime change.
+     * [Output-only] A hash of the table metadata. Used to ensure there were no concurrent modifications to the resource when attempting an update. Not guaranteed to change when the table contents or the fields numRows, numBytes, numLongTermBytes or lastModifiedTime change.
      */
     etag?: string;
     /**
-     * [Optional] The time when this table expires, in milliseconds since the
-     * epoch. If not present, the table will persist indefinitely. Expired
-     * tables will be deleted and their storage reclaimed. The
-     * defaultTableExpirationMs property of the encapsulating dataset can be
-     * used to set a default expirationTime on newly created tables.
+     * [Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed. The defaultTableExpirationMs property of the encapsulating dataset can be used to set a default expirationTime on newly created tables.
      */
     expirationTime?: string;
     /**
-     * [Optional] Describes the data format, location, and other properties of a
-     * table stored outside of BigQuery. By defining these properties, the data
-     * source can then be queried as if it were a standard BigQuery table.
+     * [Optional] Describes the data format, location, and other properties of a table stored outside of BigQuery. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.
      */
     externalDataConfiguration?: IExternalDataConfiguration;
     /**
@@ -1989,22 +1583,15 @@ export namespace bigquery {
      */
     kind?: string;
     /**
-     * The labels associated with this table. You can use these to organize and
-     * group your tables. Label keys and values can be no longer than 63
-     * characters, can only contain lowercase letters, numeric characters,
-     * underscores and dashes. International characters are allowed. Label
-     * values are optional. Label keys must start with a letter and each label
-     * in the list must have a different key.
+     * The labels associated with this table. You can use these to organize and group your tables. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.
      */
-    labels?: {[key: string]: string;};
+    labels?: { [key: string]: string };
     /**
-     * [Output-only] The time when this table was last modified, in milliseconds
-     * since the epoch.
+     * [Output-only] The time when this table was last modified, in milliseconds since the epoch.
      */
     lastModifiedTime?: string;
     /**
-     * [Output-only] The geographic location where the table resides. This value
-     * is inherited from the dataset.
+     * [Output-only] The geographic location where the table resides. This value is inherited from the dataset.
      */
     location?: string;
     /**
@@ -2012,41 +1599,31 @@ export namespace bigquery {
      */
     materializedView?: IMaterializedViewDefinition;
     /**
-     * [Output-only, Beta] Present iff this table represents a ML model.
-     * Describes the training information for the model, and it is required to
-     * run &#39;PREDICT&#39; queries.
+     * [Output-only, Beta] Present iff this table represents a ML model. Describes the training information for the model, and it is required to run 'PREDICT' queries.
      */
     model?: IModelDefinition;
     /**
-     * [Output-only] The size of this table in bytes, excluding any data in the
-     * streaming buffer.
+     * [Output-only] The size of this table in bytes, excluding any data in the streaming buffer.
      */
     numBytes?: string;
     /**
-     * [Output-only] The number of bytes in the table that are considered
-     * &quot;long-term storage&quot;.
+     * [Output-only] The number of bytes in the table that are considered "long-term storage".
      */
     numLongTermBytes?: string;
     /**
-     * [Output-only] [TrustedTester] The physical size of this table in bytes,
-     * excluding any data in the streaming buffer. This includes compression and
-     * storage used for time travel.
+     * [Output-only] [TrustedTester] The physical size of this table in bytes, excluding any data in the streaming buffer. This includes compression and storage used for time travel.
      */
     numPhysicalBytes?: string;
     /**
-     * [Output-only] The number of rows of data in this table, excluding any
-     * data in the streaming buffer.
+     * [Output-only] The number of rows of data in this table, excluding any data in the streaming buffer.
      */
     numRows?: string;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one
-     * of timePartitioning and rangePartitioning should be specified.
+     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * [Beta] [Optional] If set to true, queries over this table require a
-     * partition filter that can be used for partition elimination to be
-     * specified.
+     * [Beta] [Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.
      */
     requirePartitionFilter?: boolean;
     /**
@@ -2058,9 +1635,7 @@ export namespace bigquery {
      */
     selfLink?: string;
     /**
-     * [Output-only] Contains information regarding this table&#39;s streaming
-     * buffer, if one is present. This field will be absent if the table is not
-     * being streamed to or if there is no data in the streaming buffer.
+     * [Output-only] Contains information regarding this table's streaming buffer, if one is present. This field will be absent if the table is not being streamed to or if there is no data in the streaming buffer.
      */
     streamingBuffer?: IStreamingbuffer;
     /**
@@ -2068,66 +1643,202 @@ export namespace bigquery {
      */
     tableReference?: ITableReference;
     /**
-     * Time-based partitioning specification for this table. Only one of
-     * timePartitioning and rangePartitioning should be specified.
+     * Time-based partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * [Output-only] Describes the table type. The following values are
-     * supported: TABLE: A normal BigQuery table. VIEW: A virtual table defined
-     * by a SQL query. [TrustedTester] MATERIALIZED_VIEW: SQL query whose result
-     * is persisted. EXTERNAL: A table that references data stored in an
-     * external storage system, such as Google Cloud Storage. The default value
-     * is TABLE.
+     * [Output-only] Describes the table type. The following values are supported: TABLE: A normal BigQuery table. VIEW: A virtual table defined by a SQL query. [TrustedTester] MATERIALIZED_VIEW: SQL query whose result is persisted. EXTERNAL: A table that references data stored in an external storage system, such as Google Cloud Storage. The default value is TABLE.
      */
     type?: string;
     /**
      * [Optional] The view definition.
      */
     view?: IViewDefinition;
-  }
+  };
 
-  interface ITableCell {
-    v?: any;
-  }
+  type ITableCell = { v?: any };
 
-  interface ITableFieldSchema {
+  type ITableDataInsertAllRequest = {
     /**
-     * [Optional] The categories attached to this field, used for field-level
-     * access control.
+     * [Optional] Accept rows that contain values that do not match the schema. The unknown values are ignored. Default is false, which treats unknown values as errors.
      */
-    categories?: {names?: string[];};
+    ignoreUnknownValues?: boolean;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * The rows to insert.
+     */
+    rows?: Array<{
+      /**
+       * [Optional] A unique ID for each row. BigQuery uses this property to detect duplicate insertion requests on a best-effort basis.
+       */
+      insertId?: string;
+      /**
+       * [Required] A JSON object that contains a row of data. The object's properties and values must match the destination table's schema.
+       */
+      json?: IJsonObject;
+    }>;
+    /**
+     * [Optional] Insert all valid rows of a request, even if invalid rows exist. The default value is false, which causes the entire request to fail if any invalid rows exist.
+     */
+    skipInvalidRows?: boolean;
+    /**
+     * If specified, treats the destination table as a base template, and inserts the rows into an instance table named "{destination}{templateSuffix}". BigQuery will manage creation of the instance table, using the schema of the base template table. See https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables for considerations when working with templates tables.
+     */
+    templateSuffix?: string;
+  };
+
+  type ITableDataInsertAllResponse = {
+    /**
+     * An array of errors for rows that were not inserted.
+     */
+    insertErrors?: Array<{
+      /**
+       * Error information for the row indicated by the index property.
+       */
+      errors?: Array<IErrorProto>;
+      /**
+       * The index of the row that error applies to.
+       */
+      index?: number;
+    }>;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+  };
+
+  type ITableDataList = {
+    /**
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * A token used for paging results. Providing this token instead of the startIndex parameter can help you retrieve stable results when an underlying table is changing.
+     */
+    pageToken?: string;
+    /**
+     * Rows of results.
+     */
+    rows?: Array<ITableRow>;
+    /**
+     * The total number of rows in the complete table.
+     */
+    totalRows?: string;
+  };
+
+  type ITableFieldSchema = {
+    /**
+     * [Optional] The categories attached to this field, used for field-level access control.
+     */
+    categories?: {
+      /**
+       * A list of category resource names. For example, "projects/1/taxonomies/2/categories/3". At most 5 categories are allowed.
+       */
+      names?: Array<string>;
+    };
     /**
      * [Optional] The field description. The maximum length is 1,024 characters.
      */
     description?: string;
     /**
-     * [Optional] Describes the nested schema fields if the type property is set
-     * to RECORD.
+     * [Optional] Describes the nested schema fields if the type property is set to RECORD.
      */
-    fields?: ITableFieldSchema[];
+    fields?: Array<ITableFieldSchema>;
     /**
-     * [Optional] The field mode. Possible values include NULLABLE, REQUIRED and
-     * REPEATED. The default value is NULLABLE.
+     * [Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
      */
     mode?: string;
     /**
-     * [Required] The field name. The name must contain only letters (a-z, A-Z),
-     * numbers (0-9), or underscores (_), and must start with a letter or
-     * underscore. The maximum length is 128 characters.
+     * [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
      */
     name?: string;
     /**
-     * [Required] The field data type. Possible values include STRING, BYTES,
-     * INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT),
-     * BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, RECORD
-     * (where RECORD indicates that the field contains a nested schema) or
-     * STRUCT (same as RECORD).
+     * [Required] The field data type. Possible values include STRING, BYTES, INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT), BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, RECORD (where RECORD indicates that the field contains a nested schema) or STRUCT (same as RECORD).
      */
     type?: string;
-  }
+  };
 
-  interface ITableReference {
+  type ITableList = {
+    /**
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * The type of list.
+     */
+    kind?: string;
+    /**
+     * A token to request the next page of results.
+     */
+    nextPageToken?: string;
+    /**
+     * Tables in the requested dataset.
+     */
+    tables?: Array<{
+      /**
+       * [Beta] Clustering specification for this table, if configured.
+       */
+      clustering?: IClustering;
+      /**
+       * The time when this table was created, in milliseconds since the epoch.
+       */
+      creationTime?: string;
+      /**
+       * [Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed.
+       */
+      expirationTime?: string;
+      /**
+       * The user-friendly name for this table.
+       */
+      friendlyName?: string;
+      /**
+       * An opaque ID of the table
+       */
+      id?: string;
+      /**
+       * The resource type.
+       */
+      kind?: string;
+      /**
+       * The labels associated with this table. You can use these to organize and group your tables.
+       */
+      labels?: { [key: string]: string };
+      /**
+       * A reference uniquely identifying the table.
+       */
+      tableReference?: ITableReference;
+      /**
+       * The time-based partitioning specification for this table, if configured.
+       */
+      timePartitioning?: ITimePartitioning;
+      /**
+       * The type of table. Possible values are: TABLE, VIEW.
+       */
+      type?: string;
+      /**
+       * Additional details for a view.
+       */
+      view?: {
+        /**
+         * True if view is defined in legacy SQL dialect, false if in standard SQL.
+         */
+        useLegacySql?: boolean;
+      };
+    }>;
+    /**
+     * The total number of tables in the dataset.
+     */
+    totalItems?: number;
+  };
+
+  type ITableReference = {
     /**
      * [Required] The ID of the dataset containing this table.
      */
@@ -2137,119 +1848,249 @@ export namespace bigquery {
      */
     projectId?: string;
     /**
-     * [Required] The ID of the table. The ID must contain only letters (a-z,
-     * A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024
-     * characters.
+     * [Required] The ID of the table. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.
      */
     tableId?: string;
-  }
+  };
 
-  interface ITableRow {
+  type ITableRow = {
     /**
-     * Represents a single row in the result set, consisting of one or more
-     * fields.
+     * Represents a single row in the result set, consisting of one or more fields.
      */
-    f?: ITableCell[];
-  }
+    f?: Array<ITableCell>;
+  };
 
-  interface ITableSchema {
+  type ITableSchema = {
     /**
      * Describes the fields in a table.
      */
-    fields?: ITableFieldSchema[];
-  }
+    fields?: Array<ITableFieldSchema>;
+  };
 
-  interface ITimePartitioning {
+  type ITimePartitioning = {
     /**
-     * [Optional] Number of milliseconds for which to keep the storage for
-     * partitions in the table. The storage in a partition will have an
-     * expiration time of its partition time plus this value.
+     * [Optional] Number of milliseconds for which to keep the storage for partitions in the table. The storage in a partition will have an expiration time of its partition time plus this value.
      */
     expirationMs?: string;
     /**
-     * [Beta] [Optional] If not set, the table is partitioned by pseudo column,
-     * referenced via either &#39;_PARTITIONTIME&#39; as TIMESTAMP type, or
-     * &#39;_PARTITIONDATE&#39; as DATE type. If field is specified, the table
-     * is instead partitioned by this field. The field must be a top-level
-     * TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.
+     * [Beta] [Optional] If not set, the table is partitioned by pseudo column, referenced via either '_PARTITIONTIME' as TIMESTAMP type, or '_PARTITIONDATE' as DATE type. If field is specified, the table is instead partitioned by this field. The field must be a top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.
      */
     field?: string;
     requirePartitionFilter?: boolean;
     /**
-     * [Required] The only type supported is DAY, which will generate one
-     * partition per day.
+     * [Required] The only type supported is DAY, which will generate one partition per day.
      */
     type?: string;
-  }
+  };
 
-  interface ITrainingRun {
+  type IUserDefinedFunctionResource = {
     /**
-     * [Output-only, Beta] List of each iteration results.
-     */
-    iterationResults?: IIterationResult[];
-    /**
-     * [Output-only, Beta] Training run start time in milliseconds since the
-     * epoch.
-     */
-    startTime?: string;
-    /**
-     * [Output-only, Beta] Different state applicable for a training run. IN
-     * PROGRESS: Training run is in progress. FAILED: Training run ended due to
-     * a non-retryable failure. SUCCEEDED: Training run successfully completed.
-     * CANCELLED: Training run cancelled by the user.
-     */
-    state?: string;
-    /**
-     * [Output-only, Beta] Training options used by this training run. These
-     * options are mutable for subsequent training runs. Default values are
-     * explicitly stored for options not specified in the input query of the
-     * first training run. For subsequent training runs, any option not
-     * explicitly specified in the input query will be copied from the previous
-     * training run.
-     */
-    trainingOptions?: {
-      earlyStop?: boolean;
-      l1Reg?: number;
-      l2Reg?: number;
-      learnRate?: number;
-      learnRateStrategy?: string;
-      lineSearchInitLearnRate?: number;
-      maxIteration?: string;
-      minRelProgress?: number;
-      warmStart?: boolean;
-    };
-  }
-
-  interface IUserDefinedFunctionResource {
-    /**
-     * [Pick one] An inline resource that contains code for a user-defined
-     * function (UDF). Providing a inline code resource is equivalent to
-     * providing a URI for a file containing the same code.
+     * [Pick one] An inline resource that contains code for a user-defined function (UDF). Providing a inline code resource is equivalent to providing a URI for a file containing the same code.
      */
     inlineCode?: string;
     /**
-     * [Pick one] A code resource to load from a Google Cloud Storage URI
-     * (gs://bucket/path).
+     * [Pick one] A code resource to load from a Google Cloud Storage URI (gs://bucket/path).
      */
     resourceUri?: string;
-  }
+  };
 
-  interface IViewDefinition {
+  type IViewDefinition = {
     /**
      * [Required] A query that BigQuery executes when the view is referenced.
      */
     query?: string;
     /**
-     * Specifies whether to use BigQuery&#39;s legacy SQL for this view. The
-     * default value is true. If set to false, the view will use BigQuery&#39;s
-     * standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries
-     * and views that reference this view must use the same flag value.
+     * Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value.
      */
     useLegacySql?: boolean;
     /**
      * Describes user-defined function resources used in the query.
      */
-    userDefinedFunctionResources?: IUserDefinedFunctionResource[];
+    userDefinedFunctionResources?: Array<IUserDefinedFunctionResource>;
+  };
+
+  namespace datasets {
+    /**
+     * Deletes the dataset specified by the datasetId value. Before you can delete a dataset, you must delete all its tables, either manually or by specifying deleteContents. Immediately after deletion, you can create another dataset with the same name.
+     */
+    type IDeleteParams = {
+      /**
+       * If True, delete all the tables in the dataset. If False and the dataset contains tables, the request will fail. Default is False
+       */
+      deleteContents?: boolean;
+    };
+
+    /**
+     * Lists all datasets in the specified project to which you have been granted the READER dataset role.
+     */
+    type IListParams = {
+      /**
+       * Whether to list all datasets, including hidden ones
+       */
+      all?: boolean;
+      /**
+       * An expression for filtering the results of the request by label. The syntax is "labels.<name>[:<value>]". Multiple filters can be ANDed together by connecting with a space. Example: "labels.department:receiving labels.active". See Filtering datasets using labels for details.
+       */
+      filter?: string;
+      /**
+       * The maximum number of results to return
+       */
+      maxResults?: number;
+      /**
+       * Page token, returned by a previous call, to request the next page of results
+       */
+      pageToken?: string;
+    };
   }
 
+  namespace jobs {
+    /**
+     * Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs.
+     */
+    type ICancelParams = {
+      /**
+       * The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       */
+      location?: string;
+    };
+
+    /**
+     * Returns information about a specific job. Job information is available for a six month period after creation. Requires that you're the person who ran the job, or have the Is Owner project role.
+     */
+    type IGetParams = {
+      /**
+       * The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       */
+      location?: string;
+    };
+
+    /**
+     * Retrieves the results of a query job.
+     */
+    type IGetQueryResultsParams = {
+      /**
+       * The geographic location where the job should run. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       */
+      location?: string;
+      /**
+       * Maximum number of results to read
+       */
+      maxResults?: number;
+      /**
+       * Page token, returned by a previous call, to request the next page of results
+       */
+      pageToken?: string;
+      /**
+       * Zero-based index of the starting row
+       */
+      startIndex?: string;
+      /**
+       * How long to wait for the query to complete, in milliseconds, before returning. Default is 10 seconds. If the timeout passes before the job completes, the 'jobComplete' field in the response will be false
+       */
+      timeoutMs?: number;
+    };
+
+    /**
+     * Lists all jobs that you started in the specified project. Job information is available for a six month period after creation. The job list is sorted in reverse chronological order, by job creation time. Requires the Can View project role, or the Is Owner project role if you set the allUsers property.
+     */
+    type IListParams = {
+      /**
+       * Whether to display jobs owned by all users in the project. Default false
+       */
+      allUsers?: boolean;
+      /**
+       * Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned
+       */
+      maxCreationTime?: string;
+      /**
+       * Maximum number of results to return
+       */
+      maxResults?: number;
+      /**
+       * Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned
+       */
+      minCreationTime?: string;
+      /**
+       * Page token, returned by a previous call, to request the next page of results
+       */
+      pageToken?: string;
+      /**
+       * Restrict information returned to a set of selected fields
+       */
+      projection?: 'full' | 'minimal';
+      /**
+       * Filter for job state
+       */
+      stateFilter?: 'done' | 'pending' | 'running';
+    };
+  }
+
+  namespace projects {
+    /**
+     * Lists all projects to which you have been granted any project role.
+     */
+    type IListParams = {
+      /**
+       * Maximum number of results to return
+       */
+      maxResults?: number;
+      /**
+       * Page token, returned by a previous call, to request the next page of results
+       */
+      pageToken?: string;
+    };
+  }
+
+  namespace tabledata {
+    /**
+     * Retrieves table data from a specified set of rows. Requires the READER dataset role.
+     */
+    type IListParams = {
+      /**
+       * Maximum number of results to return
+       */
+      maxResults?: number;
+      /**
+       * Page token, returned by a previous call, identifying the result set
+       */
+      pageToken?: string;
+      /**
+       * List of fields to return (comma-separated). If unspecified, all fields are returned
+       */
+      selectedFields?: string;
+      /**
+       * Zero-based index of the starting row to read
+       */
+      startIndex?: string;
+    };
+  }
+
+  namespace tables {
+    /**
+     * Gets the specified table resource by table ID. This method does not return the data in the table, it only returns the table resource, which describes the structure of this table.
+     */
+    type IGetParams = {
+      /**
+       * List of fields to return (comma-separated). If unspecified, all fields are returned
+       */
+      selectedFields?: string;
+    };
+
+    /**
+     * Lists all tables in the specified dataset. Requires the READER dataset role.
+     */
+    type IListParams = {
+      /**
+       * Maximum number of results to return
+       */
+      maxResults?: number;
+      /**
+       * Page token, returned by a previous call, to request the next page of results
+       */
+      pageToken?: string;
+    };
+  }
 }
+
+export default bigquery;
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2255 @@
+export namespace bigquery {
+
+  interface IEmpty {}
+
+  interface ICancelJobRequest {
+    /**
+     * The geographic location of the job to cancel. Required except for US and
+     * EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     */
+    location?: string;
+  }
+
+  interface ICancelJobResponse {
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * The final state of the job.
+     */
+    job?: IJob;
+  }
+
+  interface IDeleteDatasetRequest {
+    /**
+     * If True, delete all the tables in the dataset. If False and the dataset
+     * contains tables, the request will fail. Default is False
+     */
+    deleteContents?: boolean;
+  }
+
+  interface IGetQueryResultsRequest {
+    /**
+     * The geographic location where the job should run. Required except for US
+     * and EU. See details at
+     * https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     */
+    location?: string;
+    /**
+     * Maximum number of results to read
+     */
+    maxResults?: number;
+    /**
+     * Page token, returned by a previous call, to request the next page of
+     * results
+     */
+    pageToken?: string;
+    /**
+     * [Required] Project ID of the query job
+     */
+    projectId?: string;
+    /**
+     * Zero-based index of the starting row
+     */
+    startIndex?: string;
+    /**
+     * How long to wait for the query to complete, in milliseconds, before
+     * returning. Default is 10 seconds. If the timeout passes before the job
+     * completes, the 'jobComplete' field in the response will be false
+     */
+    timeoutMs?: number;
+  }
+
+  interface IGetQueryResultsResponse {
+    /**
+     * Whether the query result was fetched from the query cache.
+     */
+    cacheHit?: boolean;
+    /**
+     * [Output-only] The first errors or warnings encountered during the running
+     * of the job. The final message includes the number of errors that caused
+     * the process to stop. Errors here do not necessarily mean that the job has
+     * completed or was unsuccessful.
+     */
+    errors?: IErrorProto[];
+    /**
+     * A hash of this response.
+     */
+    etag?: string;
+    /**
+     * Whether the query has completed or not. If rows or totalRows are present,
+     * this will always be true. If this is false, totalRows will not be
+     * available.
+     */
+    jobComplete?: boolean;
+    /**
+     * Reference to the BigQuery Job that was created to run the query. This
+     * field will be present even if the original request timed out, in which
+     * case GetQueryResults can be used to read the results once the query has
+     * completed. Since this API only returns the first page of results,
+     * subsequent pages can be fetched via the same mechanism (GetQueryResults).
+     */
+    jobReference?: IJobReference;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * [Output-only] The number of rows affected by a DML statement. Present
+     * only for DML statements INSERT, UPDATE or DELETE.
+     */
+    numDmlAffectedRows?: string;
+    /**
+     * A token used for paging results.
+     */
+    pageToken?: string;
+    /**
+     * An object with as many results as can be contained within the maximum
+     * permitted reply size. To get any additional rows, you can call
+     * GetQueryResults and specify the jobReference returned above. Present only
+     * when the query completes successfully.
+     */
+    rows?: ITableRow[];
+    /**
+     * The schema of the results. Present only when the query completes
+     * successfully.
+     */
+    schema?: ITableSchema;
+    /**
+     * The total number of bytes processed for this query.
+     */
+    totalBytesProcessed?: string;
+    /**
+     * The total number of rows in the complete query result set, which can be
+     * more than the number of rows in this single page of results. Present only
+     * when the query completes successfully.
+     */
+    totalRows?: string;
+  }
+
+  interface IInsertAllTableDataRequest {
+    /**
+     * [Optional] Accept rows that contain values that do not match the schema.
+     * The unknown values are ignored. Default is false, which treats unknown
+     * values as errors.
+     */
+    ignoreUnknownValues?: boolean;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * The rows to insert.
+     */
+    rows?: Array<{insertId?: string; json?: IJsonObject;}>;
+    /**
+     * [Optional] Insert all valid rows of a request, even if invalid rows
+     * exist. The default value is false, which causes the entire request to
+     * fail if any invalid rows exist.
+     */
+    skipInvalidRows?: boolean;
+    /**
+     * If specified, treats the destination table as a base template, and
+     * inserts the rows into an instance table named
+     * &quot;{destination}{templateSuffix}&quot;. BigQuery will manage creation
+     * of the instance table, using the schema of the base template table. See
+     * https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
+     * for considerations when working with templates tables.
+     */
+    templateSuffix?: string;
+  }
+
+  interface IInsertAllTableDataResponse {
+    /**
+     * An array of errors for rows that were not inserted.
+     */
+    insertErrors?: Array<{errors?: IErrorProto[]; index?: number;}>;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+  }
+
+  interface IListDatasetsRequest {
+    /**
+     * Whether to list all datasets, including hidden ones
+     */
+    all?: boolean;
+    /**
+     * An expression for filtering the results of the request by label. The
+     * syntax is "labels.<name>[:<value>]". Multiple filters can be ANDed
+     * together by connecting with a space. Example:
+     * "labels.department:receiving labels.active". See Filtering datasets using
+     * labels for details.
+     */
+    filter?: string;
+    /**
+     * The maximum number of results to return
+     */
+    maxResults?: number;
+    /**
+     * Page token, returned by a previous call, to request the next page of
+     * results
+     */
+    pageToken?: string;
+  }
+
+  interface IListDatasetsResponse {
+    /**
+     * An array of the dataset resources in the project. Each resource contains
+     * basic information. For full information about a particular dataset
+     * resource, use the Datasets: get method. This property is omitted when
+     * there are no datasets in the project.
+     */
+    datasets?: Array<{
+      datasetReference?: IDatasetReference;
+      friendlyName?: string;
+      id?: string;
+      kind?: string;
+      labels?: {[key: string]: string;};
+      location?: string;
+    }>;
+    /**
+     * A hash value of the results page. You can use this property to determine
+     * if the page has changed since the last request.
+     */
+    etag?: string;
+    /**
+     * The list type. This property always returns the value
+     * &quot;bigquery#datasetList&quot;.
+     */
+    kind?: string;
+    /**
+     * A token that can be used to request the next results page. This property
+     * is omitted on the final results page.
+     */
+    nextPageToken?: string;
+  }
+
+  interface IListJobsRequest {
+    /**
+     * Whether to display jobs owned by all users in the project. Default false
+     */
+    allUsers?: boolean;
+    /**
+     * Max value for job creation time, in milliseconds since the POSIX epoch.
+     * If set, only jobs created before or at this timestamp are returned
+     */
+    maxCreationTime?: string;
+    /**
+     * Maximum number of results to return
+     */
+    maxResults?: number;
+    /**
+     * Min value for job creation time, in milliseconds since the POSIX epoch.
+     * If set, only jobs created after or at this timestamp are returned
+     */
+    minCreationTime?: string;
+    /**
+     * Page token, returned by a previous call, to request the next page of
+     * results
+     */
+    pageToken?: string;
+            /**
+     * Restrict information returned to a set of selected fields
+     */
+    projection?: string;
+    /**
+     * Filter for job state
+     */
+    stateFilter?: string[];
+  }
+
+  interface IListJobsResponse {
+    /**
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * List of jobs that were requested.
+     */
+    jobs?: Array<{
+      configuration?: IJobConfiguration;
+      errorResult?: IErrorProto;
+      id?: string;
+      jobReference?: IJobReference;
+      kind?: string;
+      state?: string;
+      statistics?: IJobStatistics;
+      status?: IJobStatus;
+      user_email?: string;
+    }>;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * A token to request the next page of results.
+     */
+    nextPageToken?: string;
+  }
+
+  interface IListTableDataRequest {
+    /**
+     * Maximum number of results to return
+     */
+    maxResults?: number;
+    /**
+     * Page token, returned by a previous call, identifying the result set
+     */
+    pageToken?: string;
+    /**
+     * List of fields to return (comma-separated). If unspecified, all fields
+     * are returned
+     */
+    selectedFields?: string;
+    /**
+     * Zero-based index of the starting row to read
+     */
+    startIndex?: string;
+  }
+
+  interface IListTableDataResponse {
+    /**
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * The resource type of the response.
+     */
+    kind?: string;
+    /**
+     * A token used for paging results. Providing this token instead of the
+     * startIndex parameter can help you retrieve stable results when an
+     * underlying table is changing.
+     */
+    pageToken?: string;
+    /**
+     * Rows of results.
+     */
+    rows?: ITableRow[];
+    /**
+     * The total number of rows in the complete table.
+     */
+    totalRows?: string;
+  }
+
+  interface IListTablesRequest {
+    /**
+     * Maximum number of results to return
+     */
+    maxResults?: number;
+    /**
+     * Page token, returned by a previous call, to request the next page of
+     * results
+     */
+    pageToken?: string;
+  }
+
+  interface IListTablesResponse {
+    /**
+     * A hash of this page of results.
+     */
+    etag?: string;
+    /**
+     * The type of list.
+     */
+    kind?: string;
+    /**
+     * A token to request the next page of results.
+     */
+    nextPageToken?: string;
+    /**
+     * Tables in the requested dataset.
+     */
+    tables?: Array<{
+      clustering?: IClustering;
+      creationTime?: string;
+      expirationTime?: string;
+      friendlyName?: string;
+      id?: string;
+      kind?: string;
+      labels?: {[key: string]: string;};
+      tableReference?: ITableReference;
+      timePartitioning?: ITimePartitioning;
+      type?: string;
+      view?: {useLegacySql?: boolean;};
+    }>;
+    /**
+     * The total number of tables in the dataset.
+     */
+    totalItems?: number;
+  }
+
+  interface IBigQueryModelTraining {
+    /**
+     * [Output-only, Beta] Index of current ML training iteration. Updated
+     * during create model query job to show job progress.
+     */
+    currentIteration?: number;
+    /**
+     * [Output-only, Beta] Expected number of iterations for the create model
+     * query job specified as num_iterations in the input query. The actual
+     * total number of iterations may be less than this number due to early
+     * stop.
+     */
+    expectedTotalIterations?: string;
+  }
+
+  interface IBigtableColumn {
+    /**
+     * [Optional] The encoding of the values when the type is not STRING.
+     * Acceptable encoding values are: TEXT - indicates values are alphanumeric
+     * text strings. BINARY - indicates values are encoded using HBase
+     * Bytes.toBytes family of functions. &#39;encoding&#39; can also be set at
+     * the column family level. However, the setting at this level takes
+     * precedence if &#39;encoding&#39; is set at both levels.
+     */
+    encoding?: string;
+    /**
+     * [Optional] If the qualifier is not a valid BigQuery field identifier i.e.
+     * does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided
+     * as the column field name and is used as field name in queries.
+     */
+    fieldName?: string;
+    /**
+     * [Optional] If this is set, only the latest version of value in this
+     * column are exposed. &#39;onlyReadLatest&#39; can also be set at the
+     * column family level. However, the setting at this level takes precedence
+     * if &#39;onlyReadLatest&#39; is set at both levels.
+     */
+    onlyReadLatest?: boolean;
+    /**
+     * [Required] Qualifier of the column. Columns in the parent column family
+     * that has this exact qualifier are exposed as . field. If the qualifier is
+     * valid UTF-8 string, it can be specified in the qualifier_string field.
+     * Otherwise, a base-64 encoded value must be set to qualifier_encoded. The
+     * column field name is the same as the column qualifier. However, if the
+     * qualifier is not a valid BigQuery field identifier i.e. does not match
+     * [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as field_name.
+     */
+    qualifierEncoded?: string;
+    qualifierString?: string;
+    /**
+     * [Optional] The type to convert the value in cells of this column. The
+     * values are expected to be encoded using HBase Bytes.toBytes function when
+     * using the BINARY encoding value. Following BigQuery types are allowed
+     * (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is
+     * BYTES. &#39;type&#39; can also be set at the column family level.
+     * However, the setting at this level takes precedence if &#39;type&#39; is
+     * set at both levels.
+     */
+    type?: string;
+  }
+
+  interface IBigtableColumnFamily {
+    /**
+     * [Optional] Lists of columns that should be exposed as individual fields
+     * as opposed to a list of (column name, value) pairs. All columns whose
+     * qualifier matches a qualifier in this list can be accessed as .. Other
+     * columns can be accessed as a list through .Column field.
+     */
+    columns?: IBigtableColumn[];
+    /**
+     * [Optional] The encoding of the values when the type is not STRING.
+     * Acceptable encoding values are: TEXT - indicates values are alphanumeric
+     * text strings. BINARY - indicates values are encoded using HBase
+     * Bytes.toBytes family of functions. This can be overridden for a specific
+     * column by listing that column in &#39;columns&#39; and specifying an
+     * encoding for it.
+     */
+    encoding?: string;
+    /**
+     * Identifier of the column family.
+     */
+    familyId?: string;
+    /**
+     * [Optional] If this is set only the latest version of value are exposed
+     * for all columns in this column family. This can be overridden for a
+     * specific column by listing that column in &#39;columns&#39; and
+     * specifying a different setting for that column.
+     */
+    onlyReadLatest?: boolean;
+    /**
+     * [Optional] The type to convert the value in cells of this column family.
+     * The values are expected to be encoded using HBase Bytes.toBytes function
+     * when using the BINARY encoding value. Following BigQuery types are
+     * allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default
+     * type is BYTES. This can be overridden for a specific column by listing
+     * that column in &#39;columns&#39; and specifying a type for it.
+     */
+    type?: string;
+  }
+
+  interface IBigtableOptions {
+    /**
+     * [Optional] List of column families to expose in the table schema along
+     * with their types. This list restricts the column families that can be
+     * referenced in queries and specifies their value types. You can use this
+     * list to do type conversions - see the &#39;type&#39; field for more
+     * details. If you leave this list empty, all column families are present in
+     * the table schema and their values are read as BYTES. During a query only
+     * the column families referenced in that query are read from Bigtable.
+     */
+    columnFamilies?: IBigtableColumnFamily[];
+    /**
+     * [Optional] If field is true, then the column families that are not
+     * specified in columnFamilies list are not exposed in the table schema.
+     * Otherwise, they are read with BYTES type values. The default value is
+     * false.
+     */
+    ignoreUnspecifiedColumnFamilies?: boolean;
+    /**
+     * [Optional] If field is true, then the rowkey column families will be read
+     * and converted to string. Otherwise they are read with BYTES type values
+     * and users need to manually cast them with CAST if necessary. The default
+     * value is false.
+     */
+    readRowkeyAsString?: boolean;
+  }
+
+  interface IClustering {
+    /**
+     * [Repeated] One or more fields on which data should be clustered. Only
+     * top-level, non-repeated, simple-type fields are supported. When you
+     * cluster a table using multiple columns, the order of columns you specify
+     * is important. The order of the specified columns determines the sort
+     * order of the data.
+     */
+    fields?: string[];
+  }
+
+  interface ICsvOptions {
+    /**
+     * [Optional] Indicates if BigQuery should accept rows that are missing
+     * trailing optional columns. If true, BigQuery treats missing trailing
+     * columns as null values. If false, records with missing trailing columns
+     * are treated as bad records, and if there are too many bad records, an
+     * invalid error is returned in the job result. The default value is false.
+     */
+    allowJaggedRows?: boolean;
+    /**
+     * [Optional] Indicates if BigQuery should allow quoted data sections that
+     * contain newline characters in a CSV file. The default value is false.
+     */
+    allowQuotedNewlines?: boolean;
+    /**
+     * [Optional] The character encoding of the data. The supported values are
+     * UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the
+     * data after the raw, binary data has been split using the values of the
+     * quote and fieldDelimiter properties.
+     */
+    encoding?: string;
+    /**
+     * [Optional] The separator for fields in a CSV file. BigQuery converts the
+     * string to ISO-8859-1 encoding, and then uses the first byte of the
+     * encoded string to split the data in its raw, binary state. BigQuery also
+     * supports the escape sequence &quot;\t&quot; to specify a tab separator.
+     * The default value is a comma (&#39;,&#39;).
+     */
+    fieldDelimiter?: string;
+    /**
+     * [Optional] The value that is used to quote data sections in a CSV file.
+     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
+     * first byte of the encoded string to split the data in its raw, binary
+     * state. The default value is a double-quote (&#39;&quot;&#39;). If your
+     * data does not contain quoted sections, set the property value to an empty
+     * string. If your data contains quoted newline characters, you must also
+     * set the allowQuotedNewlines property to true.
+     */
+    quote?: string;
+    /**
+     * [Optional] The number of rows at the top of a CSV file that BigQuery will
+     * skip when reading the data. The default value is 0. This property is
+     * useful if you have header rows in the file that should be skipped.
+     */
+    skipLeadingRows?: string;
+  }
+
+  interface IDataset {
+    /**
+     * [Optional] An array of objects that define dataset access for one or more
+     * entities. You can set this property when inserting or updating a dataset
+     * in order to control who is allowed to access the data. If unspecified at
+     * dataset creation time, BigQuery adds default dataset access for the
+     * following entities: access.specialGroup: projectReaders; access.role:
+     * READER; access.specialGroup: projectWriters; access.role: WRITER;
+     * access.specialGroup: projectOwners; access.role: OWNER;
+     * access.userByEmail: [dataset creator email]; access.role: OWNER;
+     */
+    access?: Array<{
+      domain?: string;
+      groupByEmail?: string;
+      iamMember?: string;
+      role?: string;
+      specialGroup?: string;
+      userByEmail?: string;
+      view?: ITableReference;
+    }>;
+    /**
+     * [Output-only] The time when this dataset was created, in milliseconds
+     * since the epoch.
+     */
+    creationTime?: string;
+    /**
+     * [Required] A reference that identifies the dataset.
+     */
+    datasetReference?: IDatasetReference;
+    /**
+     * [Optional] The default partition expiration for all partitioned tables in
+     * the dataset, in milliseconds. Once this property is set, all
+     * newly-created partitioned tables in the dataset will have an expirationMs
+     * property in the timePartitioning settings set to this value, and changing
+     * the value will only affect new tables, not existing ones. The storage in
+     * a partition will have an expiration time of its partition time plus this
+     * value. Setting this property overrides the use of
+     * defaultTableExpirationMs for partitioned tables: only one of
+     * defaultTableExpirationMs and defaultPartitionExpirationMs will be used
+     * for any new partitioned table. If you provide an explicit
+     * timePartitioning.expirationMs when creating or updating a partitioned
+     * table, that value takes precedence over the default partition expiration
+     * time indicated by this property.
+     */
+    defaultPartitionExpirationMs?: string;
+    /**
+     * [Optional] The default lifetime of all tables in the dataset, in
+     * milliseconds. The minimum value is 3600000 milliseconds (one hour). Once
+     * this property is set, all newly-created tables in the dataset will have
+     * an expirationTime property set to the creation time plus the value in
+     * this property, and changing the value will only affect new tables, not
+     * existing ones. When the expirationTime for a given table is reached, that
+     * table will be deleted automatically. If a table&#39;s expirationTime is
+     * modified or removed before the table expires, or if you provide an
+     * explicit expirationTime when creating a table, that value takes
+     * precedence over the default expiration time indicated by this property.
+     */
+    defaultTableExpirationMs?: string;
+    /**
+     * [Optional] A user-friendly description of the dataset.
+     */
+    description?: string;
+    /**
+     * [Output-only] A hash of the resource.
+     */
+    etag?: string;
+    /**
+     * [Optional] A descriptive name for the dataset.
+     */
+    friendlyName?: string;
+    /**
+     * [Output-only] The fully-qualified unique name of the dataset in the
+     * format projectId:datasetId. The dataset name without the project name is
+     * given in the datasetId field. When creating a new dataset, leave this
+     * field blank, and instead specify the datasetId field.
+     */
+    id?: string;
+    /**
+     * [Output-only] The resource type.
+     */
+    kind?: string;
+    /**
+     * The labels associated with this dataset. You can use these to organize
+     * and group your datasets. You can set this property when inserting or
+     * updating a dataset. See Creating and Updating Dataset Labels for more
+     * information.
+     */
+    labels?: {[key: string]: string;};
+    /**
+     * [Output-only] The date when this dataset or any of its tables was last
+     * modified, in milliseconds since the epoch.
+     */
+    lastModifiedTime?: string;
+    /**
+     * The geographic location where the dataset should reside. The default
+     * value is US. See details at
+     * https://cloud.google.com/bigquery/docs/locations.
+     */
+    location?: string;
+    /**
+     * [Output-only] A URL that can be used to access the resource again. You
+     * can use this URL in Get or Update requests to the resource.
+     */
+    selfLink?: string;
+  }
+
+  interface IDatasetReference {
+    /**
+     * [Required] A unique ID for this dataset, without the project name. The ID
+     * must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_).
+     * The maximum length is 1,024 characters.
+     */
+    datasetId?: string;
+    /**
+     * [Optional] The ID of the project containing this dataset.
+     */
+    projectId?: string;
+  }
+
+  interface IDestinationTableProperties {
+    /**
+     * [Optional] The description for the destination table. This will only be
+     * used if the destination table is newly created. If the table already
+     * exists and a value different than the current description is provided,
+     * the job will fail.
+     */
+    description?: string;
+    /**
+     * [Optional] The friendly name for the destination table. This will only be
+     * used if the destination table is newly created. If the table already
+     * exists and a value different than the current friendly name is provided,
+     * the job will fail.
+     */
+    friendlyName?: string;
+    /**
+     * [Optional] The labels associated with this table. You can use these to
+     * organize and group your tables. This will only be used if the destination
+     * table is newly created. If the table already exists and labels are
+     * different than the current labels are provided, the job will fail.
+     */
+    labels?: {[key: string]: string;};
+  }
+
+  interface IEncryptionConfiguration {
+    /**
+     * [Optional] Describes the Cloud KMS encryption key that will be used to
+     * protect destination BigQuery table. The BigQuery Service Account
+     * associated with your project requires access to this encryption key.
+     */
+    kmsKeyName?: string;
+  }
+
+  interface IErrorProto {
+    /**
+     * Debugging information. This property is internal to Google and should not
+     * be used.
+     */
+    debugInfo?: string;
+    /**
+     * Specifies where the error occurred, if present.
+     */
+    location?: string;
+    /**
+     * A human-readable description of the error.
+     */
+    message?: string;
+    /**
+     * A short error code that summarizes the error.
+     */
+    reason?: string;
+  }
+
+  interface IExplainQueryStage {
+    /**
+     * Number of parallel input segments completed.
+     */
+    completedParallelInputs?: string;
+    /**
+     * Milliseconds the average shard spent on CPU-bound tasks.
+     */
+    computeMsAvg?: string;
+    /**
+     * Milliseconds the slowest shard spent on CPU-bound tasks.
+     */
+    computeMsMax?: string;
+    /**
+     * Relative amount of time the average shard spent on CPU-bound tasks.
+     */
+    computeRatioAvg?: number;
+    /**
+     * Relative amount of time the slowest shard spent on CPU-bound tasks.
+     */
+    computeRatioMax?: number;
+    /**
+     * Stage end time represented as milliseconds since epoch.
+     */
+    endMs?: string;
+    /**
+     * Unique ID for stage within plan.
+     */
+    id?: string;
+    /**
+     * IDs for stages that are inputs to this stage.
+     */
+    inputStages?: string[];
+    /**
+     * Human-readable name for stage.
+     */
+    name?: string;
+    /**
+     * Number of parallel input segments to be processed.
+     */
+    parallelInputs?: string;
+    /**
+     * Milliseconds the average shard spent reading input.
+     */
+    readMsAvg?: string;
+    /**
+     * Milliseconds the slowest shard spent reading input.
+     */
+    readMsMax?: string;
+    /**
+     * Relative amount of time the average shard spent reading input.
+     */
+    readRatioAvg?: number;
+    /**
+     * Relative amount of time the slowest shard spent reading input.
+     */
+    readRatioMax?: number;
+    /**
+     * Number of records read into the stage.
+     */
+    recordsRead?: string;
+    /**
+     * Number of records written by the stage.
+     */
+    recordsWritten?: string;
+    /**
+     * Total number of bytes written to shuffle.
+     */
+    shuffleOutputBytes?: string;
+    /**
+     * Total number of bytes written to shuffle and spilled to disk.
+     */
+    shuffleOutputBytesSpilled?: string;
+    /**
+     * Stage start time represented as milliseconds since epoch.
+     */
+    startMs?: string;
+    /**
+     * Current status for the stage.
+     */
+    status?: string;
+    /**
+     * List of operations within the stage in dependency order (approximately
+     * chronological).
+     */
+    steps?: IExplainQueryStep[];
+    /**
+     * Milliseconds the average shard spent waiting to be scheduled.
+     */
+    waitMsAvg?: string;
+    /**
+     * Milliseconds the slowest shard spent waiting to be scheduled.
+     */
+    waitMsMax?: string;
+    /**
+     * Relative amount of time the average shard spent waiting to be scheduled.
+     */
+    waitRatioAvg?: number;
+    /**
+     * Relative amount of time the slowest shard spent waiting to be scheduled.
+     */
+    waitRatioMax?: number;
+    /**
+     * Milliseconds the average shard spent on writing output.
+     */
+    writeMsAvg?: string;
+    /**
+     * Milliseconds the slowest shard spent on writing output.
+     */
+    writeMsMax?: string;
+    /**
+     * Relative amount of time the average shard spent on writing output.
+     */
+    writeRatioAvg?: number;
+    /**
+     * Relative amount of time the slowest shard spent on writing output.
+     */
+    writeRatioMax?: number;
+  }
+
+  interface IExplainQueryStep {
+    /**
+     * Machine-readable operation type.
+     */
+    kind?: string;
+    /**
+     * Human-readable stage descriptions.
+     */
+    substeps?: string[];
+  }
+
+  interface IExternalDataConfiguration {
+    /**
+     * Try to detect schema and format options automatically. Any option
+     * specified explicitly will be honored.
+     */
+    autodetect?: boolean;
+    /**
+     * [Optional] Additional options if sourceFormat is set to BIGTABLE.
+     */
+    bigtableOptions?: IBigtableOptions;
+    /**
+     * [Optional] The compression type of the data source. Possible values
+     * include GZIP and NONE. The default value is NONE. This setting is ignored
+     * for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
+     * formats.
+     */
+    compression?: string;
+    /**
+     * Additional properties to set if sourceFormat is set to CSV.
+     */
+    csvOptions?: ICsvOptions;
+    /**
+     * [Optional] Additional options if sourceFormat is set to GOOGLE_SHEETS.
+     */
+    googleSheetsOptions?: IGoogleSheetsOptions;
+    /**
+     * [Optional, Experimental] If hive partitioning is enabled, which mode to
+     * use. Two modes are supported: - AUTO: automatically infer partition key
+     * name(s) and type(s). - STRINGS: automatic infer partition key name(s).
+     * All types are strings. Not all storage formats support hive partitioning
+     * -- requesting hive partitioning on an unsupported format will lead to an
+     * error.
+     */
+    hivePartitioningMode?: string;
+    /**
+     * [Optional] Indicates if BigQuery should allow extra values that are not
+     * represented in the table schema. If true, the extra values are ignored.
+     * If false, records with extra columns are treated as bad records, and if
+     * there are too many bad records, an invalid error is returned in the job
+     * result. The default value is false. The sourceFormat property determines
+     * what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named
+     * values that don&#39;t match any column names Google Cloud Bigtable: This
+     * setting is ignored. Google Cloud Datastore backups: This setting is
+     * ignored. Avro: This setting is ignored.
+     */
+    ignoreUnknownValues?: boolean;
+    /**
+     * [Optional] The maximum number of bad records that BigQuery can ignore
+     * when reading data. If the number of bad records exceeds this value, an
+     * invalid error is returned in the job result. This is only valid for CSV,
+     * JSON, and Google Sheets. The default value is 0, which requires that all
+     * records are valid. This setting is ignored for Google Cloud Bigtable,
+     * Google Cloud Datastore backups and Avro formats.
+     */
+    maxBadRecords?: number;
+    /**
+     * [Optional] The schema for the data. Schema is required for CSV and JSON
+     * formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore
+     * backups, and Avro formats.
+     */
+    schema?: ITableSchema;
+    /**
+     * [Required] The data format. For CSV files, specify &quot;CSV&quot;. For
+     * Google sheets, specify &quot;GOOGLE_SHEETS&quot;. For newline-delimited
+     * JSON, specify &quot;NEWLINE_DELIMITED_JSON&quot;. For Avro files, specify
+     * &quot;AVRO&quot;. For Google Cloud Datastore backups, specify
+     * &quot;DATASTORE_BACKUP&quot;. [Beta] For Google Cloud Bigtable, specify
+     * &quot;BIGTABLE&quot;.
+     */
+    sourceFormat?: string;
+    /**
+     * [Required] The fully-qualified URIs that point to your data in Google
+     * Cloud. For Google Cloud Storage URIs: Each URI can contain one
+     * &#39;*&#39; wildcard character and it must come after the
+     * &#39;bucket&#39; name. Size limits related to load jobs apply to external
+     * data sources. For Google Cloud Bigtable URIs: Exactly one URI can be
+     * specified and it has be a fully specified and valid HTTPS URL for a
+     * Google Cloud Bigtable table. For Google Cloud Datastore backups, exactly
+     * one URI can be specified. Also, the &#39;*&#39; wildcard character is not
+     * allowed.
+     */
+    sourceUris?: string[];
+  }
+
+  interface IGoogleSheetsOptions {
+    /**
+     * [Beta] [Optional] Range of a sheet to query from. Only used when
+     * non-empty. Typical format:
+     * sheet_name!top_left_cell_id:bottom_right_cell_id For example:
+     * sheet1!A1:B20
+     */
+    range?: string;
+    /**
+     * [Optional] The number of rows at the top of a sheet that BigQuery will
+     * skip when reading the data. The default value is 0. This property is
+     * useful if you have header rows that should be skipped. When autodetect is
+     * on, behavior is the following: * skipLeadingRows unspecified - Autodetect
+     * tries to detect headers in the first row. If they are not detected, the
+     * row is read as data. Otherwise data is read starting from the second row.
+     * * skipLeadingRows is 0 - Instructs autodetect that there are no headers
+     * and data should be read starting from the first row. * skipLeadingRows =
+     * N &gt; 0 - Autodetect skips N-1 rows and tries to detect headers in row
+     * N. If headers are not detected, row N is just skipped. Otherwise row N is
+     * used to extract column names for the detected schema.
+     */
+    skipLeadingRows?: string;
+  }
+
+  interface IIterationResult {
+    /**
+     * [Output-only, Beta] Time taken to run the training iteration in
+     * milliseconds.
+     */
+    durationMs?: string;
+    /**
+     * [Output-only, Beta] Eval loss computed on the eval data at the end of the
+     * iteration. The eval loss is used for early stopping to avoid overfitting.
+     * No eval loss if eval_split_method option is specified as no_split or
+     * auto_split with input data size less than 500 rows.
+     */
+    evalLoss?: number;
+    /**
+     * [Output-only, Beta] Index of the ML training iteration, starting from
+     * zero for each training run.
+     */
+    index?: number;
+    /**
+     * [Output-only, Beta] Learning rate used for this iteration, it varies for
+     * different training iterations if learn_rate_strategy option is not
+     * constant.
+     */
+    learnRate?: number;
+    /**
+     * [Output-only, Beta] Training loss computed on the training data at the
+     * end of the iteration. The training loss function is defined by model
+     * type.
+     */
+    trainingLoss?: number;
+  }
+
+  interface IJob {
+    /**
+     * [Required] Describes the job configuration.
+     */
+    configuration?: IJobConfiguration;
+    /**
+     * [Output-only] A hash of this resource.
+     */
+    etag?: string;
+    /**
+     * [Output-only] Opaque ID field of the job
+     */
+    id?: string;
+    /**
+     * [Optional] Reference describing the unique-per-user name of the job.
+     */
+    jobReference?: IJobReference;
+    /**
+     * [Output-only] The type of the resource.
+     */
+    kind?: string;
+    /**
+     * [Output-only] A URL that can be used to access this resource again.
+     */
+    selfLink?: string;
+    /**
+     * [Output-only] Information about the job, including starting time and
+     * ending time of the job.
+     */
+    statistics?: IJobStatistics;
+    /**
+     * [Output-only] The status of this job. Examine this value when polling an
+     * asynchronous job to see if the job is complete.
+     */
+    status?: IJobStatus;
+    /**
+     * [Output-only] Email address of the user who ran the job.
+     */
+    user_email?: string;
+  }
+
+  interface IJobConfiguration {
+    /**
+     * [Pick one] Copies a table.
+     */
+    copy?: IJobConfigurationTableCopy;
+    /**
+     * [Optional] If set, don&#39;t actually run this job. A valid query will
+     * return a mostly empty response with some processing statistics, while an
+     * invalid query will return the same error it would if it wasn&#39;t a dry
+     * run. Behavior of non-query jobs is undefined.
+     */
+    dryRun?: boolean;
+    /**
+     * [Pick one] Configures an extract job.
+     */
+    extract?: IJobConfigurationExtract;
+    /**
+     * [Optional] Job timeout in milliseconds. If this time limit is exceeded,
+     * BigQuery may attempt to terminate the job.
+     */
+    jobTimeoutMs?: string;
+    /**
+     * [Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or
+     * UNKNOWN.
+     */
+    jobType?: string;
+    /**
+     * The labels associated with this job. You can use these to organize and
+     * group your jobs. Label keys and values can be no longer than 63
+     * characters, can only contain lowercase letters, numeric characters,
+     * underscores and dashes. International characters are allowed. Label
+     * values are optional. Label keys must start with a letter and each label
+     * in the list must have a different key.
+     */
+    labels?: {[key: string]: string;};
+    /**
+     * [Pick one] Configures a load job.
+     */
+    load?: IJobConfigurationLoad;
+    /**
+     * [Pick one] Configures a query job.
+     */
+    query?: IJobConfigurationQuery;
+  }
+
+  interface IJobConfigurationExtract {
+    /**
+     * [Optional] The compression type to use for exported files. Possible
+     * values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is
+     * NONE. DEFLATE and SNAPPY are only supported for Avro.
+     */
+    compression?: string;
+    /**
+     * [Optional] The exported file format. Possible values include CSV,
+     * NEWLINE_DELIMITED_JSON and AVRO. The default value is CSV. Tables with
+     * nested or repeated fields cannot be exported as CSV.
+     */
+    destinationFormat?: string;
+    /**
+     * [Pick one] DEPRECATED: Use destinationUris instead, passing only one URI
+     * as necessary. The fully-qualified Google Cloud Storage URI where the
+     * extracted table should be written.
+     */
+    destinationUri?: string;
+    /**
+     * [Pick one] A list of fully-qualified Google Cloud Storage URIs where the
+     * extracted table should be written.
+     */
+    destinationUris?: string[];
+    /**
+     * [Optional] Delimiter to use between fields in the exported data. Default
+     * is &#39;,&#39;
+     */
+    fieldDelimiter?: string;
+    /**
+     * [Optional] Whether to print out a header row in the results. Default is
+     * true.
+     */
+    printHeader?: boolean;
+    /**
+     * [Required] A reference to the table being exported.
+     */
+    sourceTable?: ITableReference;
+  }
+
+  interface IJobConfigurationLoad {
+    /**
+     * [Optional] Accept rows that are missing trailing optional columns. The
+     * missing values are treated as nulls. If false, records with missing
+     * trailing columns are treated as bad records, and if there are too many
+     * bad records, an invalid error is returned in the job result. The default
+     * value is false. Only applicable to CSV, ignored for other formats.
+     */
+    allowJaggedRows?: boolean;
+    /**
+     * Indicates if BigQuery should allow quoted data sections that contain
+     * newline characters in a CSV file. The default value is false.
+     */
+    allowQuotedNewlines?: boolean;
+    /**
+     * [Optional] Indicates if we should automatically infer the options and
+     * schema for CSV and JSON sources.
+     */
+    autodetect?: boolean;
+    /**
+     * [Beta] Clustering specification for the destination table. Must be
+     * specified with time-based partitioning, data in the table will be first
+     * partitioned and subsequently clustered.
+     */
+    clustering?: IClustering;
+    /**
+     * [Optional] Specifies whether the job is allowed to create new tables. The
+     * following values are supported: CREATE_IF_NEEDED: If the table does not
+     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
+     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
+     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
+     * append actions occur as one atomic update upon job completion.
+     */
+    createDisposition?: string;
+    /**
+     * Custom encryption configuration (e.g., Cloud KMS keys).
+     */
+    destinationEncryptionConfiguration?: IEncryptionConfiguration;
+    /**
+     * [Required] The destination table to load the data into.
+     */
+    destinationTable?: ITableReference;
+    /**
+     * [Beta] [Optional] Properties with which to create the destination table
+     * if it is new.
+     */
+    destinationTableProperties?: IDestinationTableProperties;
+    /**
+     * [Optional] The character encoding of the data. The supported values are
+     * UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the
+     * data after the raw, binary data has been split using the values of the
+     * quote and fieldDelimiter properties.
+     */
+    encoding?: string;
+    /**
+     * [Optional] The separator for fields in a CSV file. The separator can be
+     * any ISO-8859-1 single-byte character. To use a character in the range
+     * 128-255, you must encode the character as UTF8. BigQuery converts the
+     * string to ISO-8859-1 encoding, and then uses the first byte of the
+     * encoded string to split the data in its raw, binary state. BigQuery also
+     * supports the escape sequence &quot;\t&quot; to specify a tab separator.
+     * The default value is a comma (&#39;,&#39;).
+     */
+    fieldDelimiter?: string;
+    /**
+     * [Optional, Experimental] If hive partitioning is enabled, which mode to
+     * use. Two modes are supported: - AUTO: automatically infer partition key
+     * name(s) and type(s). - STRINGS: automatic infer partition key name(s).
+     * All types are strings. Not all storage formats support hive partitioning
+     * -- requesting hive partitioning on an unsupported format will lead to an
+     * error.
+     */
+    hivePartitioningMode?: string;
+    /**
+     * [Optional] Indicates if BigQuery should allow extra values that are not
+     * represented in the table schema. If true, the extra values are ignored.
+     * If false, records with extra columns are treated as bad records, and if
+     * there are too many bad records, an invalid error is returned in the job
+     * result. The default value is false. The sourceFormat property determines
+     * what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named
+     * values that don&#39;t match any column names
+     */
+    ignoreUnknownValues?: boolean;
+    /**
+     * [Optional] The maximum number of bad records that BigQuery can ignore
+     * when running the job. If the number of bad records exceeds this value, an
+     * invalid error is returned in the job result. This is only valid for CSV
+     * and JSON. The default value is 0, which requires that all records are
+     * valid.
+     */
+    maxBadRecords?: number;
+    /**
+     * [Optional] Specifies a string that represents a null value in a CSV file.
+     * For example, if you specify &quot;x/&quot;, BigQuery interprets
+     * &quot;x/&quot; as a null value when loading a CSV file. The default value
+     * is the empty string. If you set this property to a custom value, BigQuery
+     * throws an error if an empty string is present for all data types except
+     * for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the
+     * empty string as an empty value.
+     */
+    nullMarker?: string;
+    /**
+     * If sourceFormat is set to &quot;DATASTORE_BACKUP&quot;, indicates which
+     * entity properties to load into BigQuery from a Cloud Datastore backup.
+     * Property names are case sensitive and must be top-level properties. If no
+     * properties are specified, BigQuery loads all properties. If any named
+     * property isn&#39;t found in the Cloud Datastore backup, an invalid error
+     * is returned in the job result.
+     */
+    projectionFields?: string[];
+    /**
+     * [Optional] The value that is used to quote data sections in a CSV file.
+     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
+     * first byte of the encoded string to split the data in its raw, binary
+     * state. The default value is a double-quote (&#39;&quot;&#39;). If your
+     * data does not contain quoted sections, set the property value to an empty
+     * string. If your data contains quoted newline characters, you must also
+     * set the allowQuotedNewlines property to true.
+     */
+    quote?: string;
+    /**
+     * [TrustedTester] Range partitioning specification for this table. Only one
+     * of timePartitioning and rangePartitioning should be specified.
+     */
+    rangePartitioning?: IRangePartitioning;
+    /**
+     * [Optional] The schema for the destination table. The schema can be
+     * omitted if the destination table already exists, or if you&#39;re loading
+     * data from Google Cloud Datastore.
+     */
+    schema?: ITableSchema;
+    /**
+     * [Deprecated] The inline schema. For CSV schemas, specify as
+     * &quot;Field1:Type1[,Field2:Type2]*&quot;. For example, &quot;foo:STRING,
+     * bar:INTEGER, baz:FLOAT&quot;.
+     */
+    schemaInline?: string;
+    /**
+     * [Deprecated] The format of the schemaInline property.
+     */
+    schemaInlineFormat?: string;
+    /**
+     * Allows the schema of the destination table to be updated as a side effect
+     * of the load job if a schema is autodetected or supplied in the job
+     * configuration. Schema update options are supported in two cases: when
+     * writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE
+     * and the destination table is a partition of a table, specified by
+     * partition decorators. For normal tables, WRITE_TRUNCATE will always
+     * overwrite the schema. One or more of the following values are specified:
+     * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema.
+     * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original
+     * schema to nullable.
+     */
+    schemaUpdateOptions?: string[];
+    /**
+     * [Optional] The number of rows at the top of a CSV file that BigQuery will
+     * skip when loading the data. The default value is 0. This property is
+     * useful if you have header rows in the file that should be skipped.
+     */
+    skipLeadingRows?: number;
+    /**
+     * [Optional] The format of the data files. For CSV files, specify
+     * &quot;CSV&quot;. For datastore backups, specify
+     * &quot;DATASTORE_BACKUP&quot;. For newline-delimited JSON, specify
+     * &quot;NEWLINE_DELIMITED_JSON&quot;. For Avro, specify &quot;AVRO&quot;.
+     * For parquet, specify &quot;PARQUET&quot;. For orc, specify
+     * &quot;ORC&quot;. The default value is CSV.
+     */
+    sourceFormat?: string;
+    /**
+     * [Required] The fully-qualified URIs that point to your data in Google
+     * Cloud. For Google Cloud Storage URIs: Each URI can contain one
+     * &#39;*&#39; wildcard character and it must come after the
+     * &#39;bucket&#39; name. Size limits related to load jobs apply to external
+     * data sources. For Google Cloud Bigtable URIs: Exactly one URI can be
+     * specified and it has be a fully specified and valid HTTPS URL for a
+     * Google Cloud Bigtable table. For Google Cloud Datastore backups: Exactly
+     * one URI can be specified. Also, the &#39;*&#39; wildcard character is not
+     * allowed.
+     */
+    sourceUris?: string[];
+    /**
+     * Time-based partitioning specification for the destination table. Only one
+     * of timePartitioning and rangePartitioning should be specified.
+     */
+    timePartitioning?: ITimePartitioning;
+    /**
+     * [Optional] If sourceFormat is set to &quot;AVRO&quot;, indicates whether
+     * to enable interpreting logical types into their corresponding types (ie.
+     * TIMESTAMP), instead of only using their raw types (ie. INTEGER).
+     */
+    useAvroLogicalTypes?: boolean;
+    /**
+     * [Optional] Specifies the action that occurs if the destination table
+     * already exists. The following values are supported: WRITE_TRUNCATE: If
+     * the table already exists, BigQuery overwrites the table data.
+     * WRITE_APPEND: If the table already exists, BigQuery appends the data to
+     * the table. WRITE_EMPTY: If the table already exists and contains data, a
+     * &#39;duplicate&#39; error is returned in the job result. The default
+     * value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery
+     * is able to complete the job successfully. Creation, truncation and append
+     * actions occur as one atomic update upon job completion.
+     */
+    writeDisposition?: string;
+  }
+
+  interface IJobConfigurationQuery {
+    /**
+     * [Optional] If true and query uses legacy SQL dialect, allows the query to
+     * produce arbitrarily large result tables at a slight cost in performance.
+     * Requires destinationTable to be set. For standard SQL queries, this flag
+     * is ignored and large results are always allowed. However, you must still
+     * set destinationTable when result size exceeds the allowed maximum
+     * response size.
+     */
+    allowLargeResults?: boolean;
+    /**
+     * [Beta] Clustering specification for the destination table. Must be
+     * specified with time-based partitioning, data in the table will be first
+     * partitioned and subsequently clustered.
+     */
+    clustering?: IClustering;
+    /**
+     * [Optional] Specifies whether the job is allowed to create new tables. The
+     * following values are supported: CREATE_IF_NEEDED: If the table does not
+     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
+     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
+     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
+     * append actions occur as one atomic update upon job completion.
+     */
+    createDisposition?: string;
+    /**
+     * [Optional] Specifies the default dataset to use for unqualified table
+     * names in the query. Note that this does not alter behavior of unqualified
+     * dataset names.
+     */
+    defaultDataset?: IDatasetReference;
+    /**
+     * Custom encryption configuration (e.g., Cloud KMS keys).
+     */
+    destinationEncryptionConfiguration?: IEncryptionConfiguration;
+    /**
+     * [Optional] Describes the table where the query results should be stored.
+     * If not present, a new table will be created to store the results. This
+     * property must be set for large results that exceed the maximum response
+     * size.
+     */
+    destinationTable?: ITableReference;
+    /**
+     * [Optional] If true and query uses legacy SQL dialect, flattens all nested
+     * and repeated fields in the query results. allowLargeResults must be true
+     * if this is set to false. For standard SQL queries, this flag is ignored
+     * and results are never flattened.
+     */
+    flattenResults?: boolean;
+    /**
+     * [Optional] Limits the billing tier for this job. Queries that have
+     * resource usage beyond this tier will fail (without incurring a charge).
+     * If unspecified, this will be set to your project default.
+     */
+    maximumBillingTier?: number;
+    /**
+     * [Optional] Limits the bytes billed for this job. Queries that will have
+     * bytes billed beyond this limit will fail (without incurring a charge). If
+     * unspecified, this will be set to your project default.
+     */
+    maximumBytesBilled?: string;
+    /**
+     * Standard SQL only. Set to POSITIONAL to use positional (?) query
+     * parameters or to NAMED to use named (@myparam) query parameters in this
+     * query.
+     */
+    parameterMode?: string;
+    /**
+     * [Deprecated] This property is deprecated.
+     */
+    preserveNulls?: boolean;
+    /**
+     * [Optional] Specifies a priority for the query. Possible values include
+     * INTERACTIVE and BATCH. The default value is INTERACTIVE.
+     */
+    priority?: string;
+    /**
+     * [Required] SQL query text to execute. The useLegacySql field can be used
+     * to indicate whether the query uses legacy SQL or standard SQL.
+     */
+    query?: string;
+    /**
+     * Query parameters for standard SQL queries.
+     */
+    queryParameters?: IQueryParameter[];
+    /**
+     * [TrustedTester] Range partitioning specification for this table. Only one
+     * of timePartitioning and rangePartitioning should be specified.
+     */
+    rangePartitioning?: IRangePartitioning;
+    /**
+     * Allows the schema of the destination table to be updated as a side effect
+     * of the query job. Schema update options are supported in two cases: when
+     * writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE
+     * and the destination table is a partition of a table, specified by
+     * partition decorators. For normal tables, WRITE_TRUNCATE will always
+     * overwrite the schema. One or more of the following values are specified:
+     * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema.
+     * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original
+     * schema to nullable.
+     */
+    schemaUpdateOptions?: string[];
+    /**
+     * [Optional] If querying an external data source outside of BigQuery,
+     * describes the data format, location and other properties of the data
+     * source. By defining these properties, the data source can then be queried
+     * as if it were a standard BigQuery table.
+     */
+    tableDefinitions?: {[key: string]: IExternalDataConfiguration;};
+    /**
+     * Time-based partitioning specification for the destination table. Only one
+     * of timePartitioning and rangePartitioning should be specified.
+     */
+    timePartitioning?: ITimePartitioning;
+    /**
+     * Specifies whether to use BigQuery&#39;s legacy SQL dialect for this
+     * query. The default value is true. If set to false, the query will use
+     * BigQuery&#39;s standard SQL:
+     * https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set
+     * to false, the value of flattenResults is ignored; query will be run as if
+     * flattenResults is false.
+     */
+    useLegacySql?: boolean;
+    /**
+     * [Optional] Whether to look for the result in the query cache. The query
+     * cache is a best-effort cache that will be flushed whenever tables in the
+     * query are modified. Moreover, the query cache is only available when a
+     * query does not have a destination table specified. The default value is
+     * true.
+     */
+    useQueryCache?: boolean;
+    /**
+     * Describes user-defined function resources used in the query.
+     */
+    userDefinedFunctionResources?: IUserDefinedFunctionResource[];
+    /**
+     * [Optional] Specifies the action that occurs if the destination table
+     * already exists. The following values are supported: WRITE_TRUNCATE: If
+     * the table already exists, BigQuery overwrites the table data and uses the
+     * schema from the query result. WRITE_APPEND: If the table already exists,
+     * BigQuery appends the data to the table. WRITE_EMPTY: If the table already
+     * exists and contains data, a &#39;duplicate&#39; error is returned in the
+     * job result. The default value is WRITE_EMPTY. Each action is atomic and
+     * only occurs if BigQuery is able to complete the job successfully.
+     * Creation, truncation and append actions occur as one atomic update upon
+     * job completion.
+     */
+    writeDisposition?: string;
+  }
+
+  interface IJobConfigurationTableCopy {
+    /**
+     * [Optional] Specifies whether the job is allowed to create new tables. The
+     * following values are supported: CREATE_IF_NEEDED: If the table does not
+     * exist, BigQuery creates the table. CREATE_NEVER: The table must already
+     * exist. If it does not, a &#39;notFound&#39; error is returned in the job
+     * result. The default value is CREATE_IF_NEEDED. Creation, truncation and
+     * append actions occur as one atomic update upon job completion.
+     */
+    createDisposition?: string;
+    /**
+     * Custom encryption configuration (e.g., Cloud KMS keys).
+     */
+    destinationEncryptionConfiguration?: IEncryptionConfiguration;
+    /**
+     * [Required] The destination table
+     */
+    destinationTable?: ITableReference;
+    /**
+     * [Pick one] Source table to copy.
+     */
+    sourceTable?: ITableReference;
+    /**
+     * [Pick one] Source tables to copy.
+     */
+    sourceTables?: ITableReference[];
+    /**
+     * [Optional] Specifies the action that occurs if the destination table
+     * already exists. The following values are supported: WRITE_TRUNCATE: If
+     * the table already exists, BigQuery overwrites the table data.
+     * WRITE_APPEND: If the table already exists, BigQuery appends the data to
+     * the table. WRITE_EMPTY: If the table already exists and contains data, a
+     * &#39;duplicate&#39; error is returned in the job result. The default
+     * value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery
+     * is able to complete the job successfully. Creation, truncation and append
+     * actions occur as one atomic update upon job completion.
+     */
+    writeDisposition?: string;
+  }
+
+  interface IJobReference {
+    /**
+     * [Required] The ID of the job. The ID must contain only letters (a-z,
+     * A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length
+     * is 1,024 characters.
+     */
+    jobId?: string;
+    /**
+     * The geographic location of the job. See details at
+     * https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     */
+    location?: string;
+    /**
+     * [Required] The ID of the project containing this job.
+     */
+    projectId?: string;
+  }
+
+  interface IJobStatistics {
+    /**
+     * [TrustedTester] [Output-only] Job progress (0.0 -&gt; 1.0) for LOAD and
+     * EXTRACT jobs.
+     */
+    completionRatio?: number;
+    /**
+     * [Output-only] Creation time of this job, in milliseconds since the epoch.
+     * This field will be present on all jobs.
+     */
+    creationTime?: string;
+    /**
+     * [Output-only] End time of this job, in milliseconds since the epoch. This
+     * field will be present whenever a job is in the DONE state.
+     */
+    endTime?: string;
+    /**
+     * [Output-only] Statistics for an extract job.
+     */
+    extract?: IJobStatistics4;
+    /**
+     * [Output-only] Statistics for a load job.
+     */
+    load?: IJobStatistics3;
+    /**
+     * [Output-only] Number of child jobs executed.
+     */
+    numChildJobs?: string;
+    /**
+     * [Output-only] If this is a child job, the id of the parent.
+     */
+    parentJobId?: string;
+    /**
+     * [Output-only] Statistics for a query job.
+     */
+    query?: IJobStatistics2;
+    /**
+     * [Output-only] Quotas which delayed this job&#39;s start time.
+     */
+    quotaDeferments?: string[];
+    /**
+     * [Output-only] Job resource usage breakdown by reservation.
+     */
+    reservationUsage?: Array<{name?: string; slotMs?: string;}>;
+    /**
+     * [Output-only] Start time of this job, in milliseconds since the epoch.
+     * This field will be present when the job transitions from the PENDING
+     * state to either RUNNING or DONE.
+     */
+    startTime?: string;
+    /**
+     * [Output-only] [Deprecated] Use the bytes processed in the query
+     * statistics instead.
+     */
+    totalBytesProcessed?: string;
+    /**
+     * [Output-only] Slot-milliseconds for the job.
+     */
+    totalSlotMs?: string;
+  }
+
+  interface IJobStatistics2 {
+    /**
+     * [Output-only] Billing tier for the job.
+     */
+    billingTier?: number;
+    /**
+     * [Output-only] Whether the query result was fetched from the query cache.
+     */
+    cacheHit?: boolean;
+    /**
+     * The DDL operation performed, possibly dependent on the pre-existence of
+     * the DDL target. Possible values (new values might be added in the
+     * future): &quot;CREATE&quot;: The query created the DDL target.
+     * &quot;SKIP&quot;: No-op. Example cases: the query is CREATE TABLE IF NOT
+     * EXISTS while the table already exists, or the query is DROP TABLE IF
+     * EXISTS while the table does not exist. &quot;REPLACE&quot;: The query
+     * replaced the DDL target. Example case: the query is CREATE OR REPLACE
+     * TABLE, and the table already exists. &quot;DROP&quot;: The query deleted
+     * the DDL target.
+     */
+    ddlOperationPerformed?: string;
+    /**
+     * The DDL target table. Present only for CREATE/DROP TABLE/VIEW queries.
+     */
+    ddlTargetTable?: ITableReference;
+    /**
+     * [Output-only] The original estimate of bytes processed for the job.
+     */
+    estimatedBytesProcessed?: string;
+    /**
+     * [Output-only, Beta] Information about create model query job progress.
+     */
+    modelTraining?: IBigQueryModelTraining;
+    /**
+     * [Output-only, Beta] Deprecated; do not use.
+     */
+    modelTrainingCurrentIteration?: number;
+    /**
+     * [Output-only, Beta] Deprecated; do not use.
+     */
+    modelTrainingExpectedTotalIteration?: string;
+    /**
+     * [Output-only] The number of rows affected by a DML statement. Present
+     * only for DML statements INSERT, UPDATE or DELETE.
+     */
+    numDmlAffectedRows?: string;
+    /**
+     * [Output-only] Describes execution plan for the query.
+     */
+    queryPlan?: IExplainQueryStage[];
+    /**
+     * [Output-only] Referenced tables for the job. Queries that reference more
+     * than 50 tables will not have a complete list.
+     */
+    referencedTables?: ITableReference[];
+    /**
+     * [Output-only] Job resource usage breakdown by reservation.
+     */
+    reservationUsage?: Array<{name?: string; slotMs?: string;}>;
+    /**
+     * [Output-only] The schema of the results. Present only for successful dry
+     * run of non-legacy SQL queries.
+     */
+    schema?: ITableSchema;
+    /**
+     * The type of query statement, if valid. Possible values (new values might
+     * be added in the future): &quot;SELECT&quot;: SELECT query.
+     * &quot;INSERT&quot;: INSERT query; see
+     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
+     * &quot;UPDATE&quot;: UPDATE query; see
+     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
+     * &quot;DELETE&quot;: DELETE query; see
+     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
+     * &quot;MERGE&quot;: MERGE query; see
+     * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language.
+     * &quot;CREATE_TABLE&quot;: CREATE [OR REPLACE] TABLE without AS SELECT.
+     * &quot;CREATE_TABLE_AS_SELECT&quot;: CREATE [OR REPLACE] TABLE ... AS
+     * SELECT ... . &quot;DROP_TABLE&quot;: DROP TABLE query.
+     * &quot;CREATE_VIEW&quot;: CREATE [OR REPLACE] VIEW ... AS SELECT ... .
+     * &quot;DROP_VIEW&quot;: DROP VIEW query. &quot;ALTER_TABLE&quot;: ALTER
+     * TABLE query. &quot;ALTER_VIEW&quot;: ALTER VIEW query.
+     */
+    statementType?: string;
+    /**
+     * [Output-only] [Beta] Describes a timeline of job execution.
+     */
+    timeline?: IQueryTimelineSample[];
+    /**
+     * [Output-only] Total bytes billed for the job.
+     */
+    totalBytesBilled?: string;
+    /**
+     * [Output-only] Total bytes processed for the job.
+     */
+    totalBytesProcessed?: string;
+    /**
+     * [Output-only] For dry-run jobs, totalBytesProcessed is an estimate and
+     * this field specifies the accuracy of the estimate. Possible values can
+     * be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is
+     * precise. LOWER_BOUND: estimate is lower bound of what the query would
+     * cost. UPPER_BOUND: estimate is upper bound of what the query would cost.
+     */
+    totalBytesProcessedAccuracy?: string;
+    /**
+     * [Output-only] Total number of partitions processed from all partitioned
+     * tables referenced in the job.
+     */
+    totalPartitionsProcessed?: string;
+    /**
+     * [Output-only] Slot-milliseconds for the job.
+     */
+    totalSlotMs?: string;
+    /**
+     * Standard SQL only: list of undeclared query parameters detected during a
+     * dry run validation.
+     */
+    undeclaredQueryParameters?: IQueryParameter[];
+  }
+
+  interface IJobStatistics3 {
+    /**
+     * [Output-only] The number of bad records encountered. Note that if the job
+     * has failed because of more bad records encountered than the maximum
+     * allowed in the load job configuration, then this number can be less than
+     * the total number of bad records present in the input data.
+     */
+    badRecords?: string;
+    /**
+     * [Output-only] Number of bytes of source data in a load job.
+     */
+    inputFileBytes?: string;
+    /**
+     * [Output-only] Number of source files in a load job.
+     */
+    inputFiles?: string;
+    /**
+     * [Output-only] Size of the loaded data in bytes. Note that while a load
+     * job is in the running state, this value may change.
+     */
+    outputBytes?: string;
+    /**
+     * [Output-only] Number of rows imported in a load job. Note that while an
+     * import job is in the running state, this value may change.
+     */
+    outputRows?: string;
+  }
+
+  interface IJobStatistics4 {
+    /**
+     * [Output-only] Number of files per destination URI or URI pattern
+     * specified in the extract configuration. These values will be in the same
+     * order as the URIs specified in the &#39;destinationUris&#39; field.
+     */
+    destinationUriFileCounts?: string[];
+    /**
+     * [Output-only] Number of user bytes extracted into the result. This is the
+     * byte count as computed by BigQuery for billing purposes.
+     */
+    inputBytes?: string;
+  }
+
+  interface IJobStatus {
+    /**
+     * [Output-only] Final error result of the job. If present, indicates that
+     * the job has completed and was unsuccessful.
+     */
+    errorResult?: IErrorProto;
+    /**
+     * [Output-only] The first errors encountered during the running of the job.
+     * The final message includes the number of errors that caused the process
+     * to stop. Errors here do not necessarily mean that the job has completed
+     * or was unsuccessful.
+     */
+    errors?: IErrorProto[];
+    /**
+     * [Output-only] Running state of the job.
+     */
+    state?: string;
+  }
+  /**
+   * Represents a single JSON object.
+   */
+
+  interface IJsonObject {}
+
+  interface IJsonValue {}
+
+  interface IMaterializedViewDefinition {
+    /**
+     * [Output-only] [TrustedTester] The time when this materialized view was
+     * last modified, in milliseconds since the epoch.
+     */
+    lastRefreshTime?: string;
+    /**
+     * [Required] A query whose result is persisted.
+     */
+    query?: string;
+  }
+
+  interface IModelDefinition {
+    /**
+     * [Output-only, Beta] Model options used for the first training run. These
+     * options are immutable for subsequent training runs. Default values are
+     * used for any options not specified in the input query.
+     */
+    modelOptions?: {labels?: string[]; lossType?: string; modelType?: string;};
+    /**
+     * [Output-only, Beta] Information about ml training runs, each training run
+     * comprises of multiple iterations and there may be multiple training runs
+     * for the model if warm start is used or if a user decides to continue a
+     * previously cancelled query.
+     */
+    trainingRuns?: ITrainingRun[];
+  }
+
+  interface IQueryParameter {
+    /**
+     * [Optional] If unset, this is a positional parameter. Otherwise, should be
+     * unique within a query.
+     */
+    name?: string;
+    /**
+     * [Required] The type of this parameter.
+     */
+    parameterType?: IQueryParameterType;
+    /**
+     * [Required] The value of this parameter.
+     */
+    parameterValue?: IQueryParameterValue;
+  }
+
+  interface IQueryParameterType {
+    /**
+     * [Optional] The type of the array&#39;s elements, if this is an array.
+     */
+    arrayType?: IQueryParameterType;
+    /**
+     * [Optional] The types of the fields of this struct, in order, if this is a
+     * struct.
+     */
+    structTypes?: Array<{
+      description?: string;
+      name?: string;
+      type?: IQueryParameterType;
+    }>;
+    /**
+     * [Required] The top level type of this field.
+     */
+    type?: string;
+  }
+
+  interface IQueryParameterValue {
+    /**
+     * [Optional] The array values, if this is an array type.
+     */
+    arrayValues?: IQueryParameterValue[];
+    /**
+     * [Optional] The struct field values, in order of the struct type&#39;s
+     * declaration.
+     */
+    structValues?: {[key: string]: IQueryParameterValue;};
+    /**
+     * [Optional] The value of this value, if a simple scalar type.
+     */
+    value?: string;
+  }
+
+  interface IQueryTimelineSample {
+    /**
+     * Total number of units currently being processed by workers. This does not
+     * correspond directly to slot usage. This is the largest value observed
+     * since the last sample.
+     */
+    activeUnits?: string;
+    /**
+     * Total parallel units of work completed by this query.
+     */
+    completedUnits?: string;
+    /**
+     * Milliseconds elapsed since the start of query execution.
+     */
+    elapsedMs?: string;
+    /**
+     * Total parallel units of work remaining for the active stages.
+     */
+    pendingUnits?: string;
+    /**
+     * Cumulative slot-ms consumed by the query.
+     */
+    totalSlotMs?: string;
+  }
+
+  interface IRangePartitioning {
+    /**
+     * [TrustedTester] [Required] The table is partitioned by this field. The
+     * field must be a top-level NULLABLE/REQUIRED field. The only supported
+     * type is INTEGER/INT64.
+     */
+    field?: string;
+    /**
+     * [TrustedTester] [Required] Defines the ranges for range partitioning.
+     */
+    range?: {end?: string; interval?: string; start?: string;};
+  }
+
+  interface IStreamingbuffer {
+    /**
+     * [Output-only] A lower-bound estimate of the number of bytes currently in
+     * the streaming buffer.
+     */
+    estimatedBytes?: string;
+    /**
+     * [Output-only] A lower-bound estimate of the number of rows currently in
+     * the streaming buffer.
+     */
+    estimatedRows?: string;
+    /**
+     * [Output-only] Contains the timestamp of the oldest entry in the streaming
+     * buffer, in milliseconds since the epoch, if the streaming buffer is
+     * available.
+     */
+    oldestEntryTime?: string;
+  }
+
+  interface ITable {
+    /**
+     * [Beta] Clustering specification for the table. Must be specified with
+     * partitioning, data in the table will be first partitioned and
+     * subsequently clustered.
+     */
+    clustering?: IClustering;
+    /**
+     * [Output-only] The time when this table was created, in milliseconds since
+     * the epoch.
+     */
+    creationTime?: string;
+    /**
+     * [Optional] A user-friendly description of this table.
+     */
+    description?: string;
+    /**
+     * Custom encryption configuration (e.g., Cloud KMS keys).
+     */
+    encryptionConfiguration?: IEncryptionConfiguration;
+    /**
+     * [Output-only] A hash of the table metadata. Used to ensure there were no
+     * concurrent modifications to the resource when attempting an update. Not
+     * guaranteed to change when the table contents or the fields numRows,
+     * numBytes, numLongTermBytes or lastModifiedTime change.
+     */
+    etag?: string;
+    /**
+     * [Optional] The time when this table expires, in milliseconds since the
+     * epoch. If not present, the table will persist indefinitely. Expired
+     * tables will be deleted and their storage reclaimed. The
+     * defaultTableExpirationMs property of the encapsulating dataset can be
+     * used to set a default expirationTime on newly created tables.
+     */
+    expirationTime?: string;
+    /**
+     * [Optional] Describes the data format, location, and other properties of a
+     * table stored outside of BigQuery. By defining these properties, the data
+     * source can then be queried as if it were a standard BigQuery table.
+     */
+    externalDataConfiguration?: IExternalDataConfiguration;
+    /**
+     * [Optional] A descriptive name for this table.
+     */
+    friendlyName?: string;
+    /**
+     * [Output-only] An opaque ID uniquely identifying the table.
+     */
+    id?: string;
+    /**
+     * [Output-only] The type of the resource.
+     */
+    kind?: string;
+    /**
+     * The labels associated with this table. You can use these to organize and
+     * group your tables. Label keys and values can be no longer than 63
+     * characters, can only contain lowercase letters, numeric characters,
+     * underscores and dashes. International characters are allowed. Label
+     * values are optional. Label keys must start with a letter and each label
+     * in the list must have a different key.
+     */
+    labels?: {[key: string]: string;};
+    /**
+     * [Output-only] The time when this table was last modified, in milliseconds
+     * since the epoch.
+     */
+    lastModifiedTime?: string;
+    /**
+     * [Output-only] The geographic location where the table resides. This value
+     * is inherited from the dataset.
+     */
+    location?: string;
+    /**
+     * [Optional] Materialized view definition.
+     */
+    materializedView?: IMaterializedViewDefinition;
+    /**
+     * [Output-only, Beta] Present iff this table represents a ML model.
+     * Describes the training information for the model, and it is required to
+     * run &#39;PREDICT&#39; queries.
+     */
+    model?: IModelDefinition;
+    /**
+     * [Output-only] The size of this table in bytes, excluding any data in the
+     * streaming buffer.
+     */
+    numBytes?: string;
+    /**
+     * [Output-only] The number of bytes in the table that are considered
+     * &quot;long-term storage&quot;.
+     */
+    numLongTermBytes?: string;
+    /**
+     * [Output-only] [TrustedTester] The physical size of this table in bytes,
+     * excluding any data in the streaming buffer. This includes compression and
+     * storage used for time travel.
+     */
+    numPhysicalBytes?: string;
+    /**
+     * [Output-only] The number of rows of data in this table, excluding any
+     * data in the streaming buffer.
+     */
+    numRows?: string;
+    /**
+     * [TrustedTester] Range partitioning specification for this table. Only one
+     * of timePartitioning and rangePartitioning should be specified.
+     */
+    rangePartitioning?: IRangePartitioning;
+    /**
+     * [Beta] [Optional] If set to true, queries over this table require a
+     * partition filter that can be used for partition elimination to be
+     * specified.
+     */
+    requirePartitionFilter?: boolean;
+    /**
+     * [Optional] Describes the schema of this table.
+     */
+    schema?: ITableSchema;
+    /**
+     * [Output-only] A URL that can be used to access this resource again.
+     */
+    selfLink?: string;
+    /**
+     * [Output-only] Contains information regarding this table&#39;s streaming
+     * buffer, if one is present. This field will be absent if the table is not
+     * being streamed to or if there is no data in the streaming buffer.
+     */
+    streamingBuffer?: IStreamingbuffer;
+    /**
+     * [Required] Reference describing the ID of this table.
+     */
+    tableReference?: ITableReference;
+    /**
+     * Time-based partitioning specification for this table. Only one of
+     * timePartitioning and rangePartitioning should be specified.
+     */
+    timePartitioning?: ITimePartitioning;
+    /**
+     * [Output-only] Describes the table type. The following values are
+     * supported: TABLE: A normal BigQuery table. VIEW: A virtual table defined
+     * by a SQL query. [TrustedTester] MATERIALIZED_VIEW: SQL query whose result
+     * is persisted. EXTERNAL: A table that references data stored in an
+     * external storage system, such as Google Cloud Storage. The default value
+     * is TABLE.
+     */
+    type?: string;
+    /**
+     * [Optional] The view definition.
+     */
+    view?: IViewDefinition;
+  }
+
+  interface ITableCell {
+    v?: any;
+  }
+
+  interface ITableFieldSchema {
+    /**
+     * [Optional] The categories attached to this field, used for field-level
+     * access control.
+     */
+    categories?: {names?: string[];};
+    /**
+     * [Optional] The field description. The maximum length is 1,024 characters.
+     */
+    description?: string;
+    /**
+     * [Optional] Describes the nested schema fields if the type property is set
+     * to RECORD.
+     */
+    fields?: ITableFieldSchema[];
+    /**
+     * [Optional] The field mode. Possible values include NULLABLE, REQUIRED and
+     * REPEATED. The default value is NULLABLE.
+     */
+    mode?: string;
+    /**
+     * [Required] The field name. The name must contain only letters (a-z, A-Z),
+     * numbers (0-9), or underscores (_), and must start with a letter or
+     * underscore. The maximum length is 128 characters.
+     */
+    name?: string;
+    /**
+     * [Required] The field data type. Possible values include STRING, BYTES,
+     * INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT),
+     * BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, RECORD
+     * (where RECORD indicates that the field contains a nested schema) or
+     * STRUCT (same as RECORD).
+     */
+    type?: string;
+  }
+
+  interface ITableReference {
+    /**
+     * [Required] The ID of the dataset containing this table.
+     */
+    datasetId?: string;
+    /**
+     * [Required] The ID of the project containing this table.
+     */
+    projectId?: string;
+    /**
+     * [Required] The ID of the table. The ID must contain only letters (a-z,
+     * A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024
+     * characters.
+     */
+    tableId?: string;
+  }
+
+  interface ITableRow {
+    /**
+     * Represents a single row in the result set, consisting of one or more
+     * fields.
+     */
+    f?: ITableCell[];
+  }
+
+  interface ITableSchema {
+    /**
+     * Describes the fields in a table.
+     */
+    fields?: ITableFieldSchema[];
+  }
+
+  interface ITimePartitioning {
+    /**
+     * [Optional] Number of milliseconds for which to keep the storage for
+     * partitions in the table. The storage in a partition will have an
+     * expiration time of its partition time plus this value.
+     */
+    expirationMs?: string;
+    /**
+     * [Beta] [Optional] If not set, the table is partitioned by pseudo column,
+     * referenced via either &#39;_PARTITIONTIME&#39; as TIMESTAMP type, or
+     * &#39;_PARTITIONDATE&#39; as DATE type. If field is specified, the table
+     * is instead partitioned by this field. The field must be a top-level
+     * TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.
+     */
+    field?: string;
+    requirePartitionFilter?: boolean;
+    /**
+     * [Required] The only type supported is DAY, which will generate one
+     * partition per day.
+     */
+    type?: string;
+  }
+
+  interface ITrainingRun {
+    /**
+     * [Output-only, Beta] List of each iteration results.
+     */
+    iterationResults?: IIterationResult[];
+    /**
+     * [Output-only, Beta] Training run start time in milliseconds since the
+     * epoch.
+     */
+    startTime?: string;
+    /**
+     * [Output-only, Beta] Different state applicable for a training run. IN
+     * PROGRESS: Training run is in progress. FAILED: Training run ended due to
+     * a non-retryable failure. SUCCEEDED: Training run successfully completed.
+     * CANCELLED: Training run cancelled by the user.
+     */
+    state?: string;
+    /**
+     * [Output-only, Beta] Training options used by this training run. These
+     * options are mutable for subsequent training runs. Default values are
+     * explicitly stored for options not specified in the input query of the
+     * first training run. For subsequent training runs, any option not
+     * explicitly specified in the input query will be copied from the previous
+     * training run.
+     */
+    trainingOptions?: {
+      earlyStop?: boolean;
+      l1Reg?: number;
+      l2Reg?: number;
+      learnRate?: number;
+      learnRateStrategy?: string;
+      lineSearchInitLearnRate?: number;
+      maxIteration?: string;
+      minRelProgress?: number;
+      warmStart?: boolean;
+    };
+  }
+
+  interface IUserDefinedFunctionResource {
+    /**
+     * [Pick one] An inline resource that contains code for a user-defined
+     * function (UDF). Providing a inline code resource is equivalent to
+     * providing a URI for a file containing the same code.
+     */
+    inlineCode?: string;
+    /**
+     * [Pick one] A code resource to load from a Google Cloud Storage URI
+     * (gs://bucket/path).
+     */
+    resourceUri?: string;
+  }
+
+  interface IViewDefinition {
+    /**
+     * [Required] A query that BigQuery executes when the view is referenced.
+     */
+    query?: string;
+    /**
+     * Specifies whether to use BigQuery&#39;s legacy SQL for this view. The
+     * default value is true. If set to false, the view will use BigQuery&#39;s
+     * standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries
+     * and views that reference this view must use the same flag value.
+     */
+    useLegacySql?: boolean;
+    /**
+     * Describes user-defined function resources used in the query.
+     */
+    userDefinedFunctionResources?: IUserDefinedFunctionResource[];
+  }
+
+}

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -702,7 +702,7 @@ describe('BigQuery', () => {
 
         table1Instance.copy(table2Instance, (err, resp) => {
           assert.ifError(err);
-          assert.strictEqual(resp.status.state, 'DONE');
+          assert.strictEqual(resp!.status!.state, 'DONE');
           done();
         });
       });
@@ -735,7 +735,7 @@ describe('BigQuery', () => {
 
         table2Instance.copyFrom(table1Instance, (err, resp) => {
           assert.ifError(err);
-          assert.strictEqual(resp.status.state, 'DONE');
+          assert.strictEqual(resp!.status!.state, 'DONE');
           done();
         });
       });
@@ -767,7 +767,7 @@ describe('BigQuery', () => {
       it('should load data from a storage file', done => {
         table.load(file, (err, resp) => {
           assert.ifError(err);
-          assert.strictEqual(resp.status.state, 'DONE');
+          assert.strictEqual(resp!.status!.state, 'DONE');
           done();
         });
       });
@@ -775,7 +775,7 @@ describe('BigQuery', () => {
       it('should load data from a file via promises', () => {
         return table.load(file).then(results => {
           const metadata = results[0];
-          assert.strictEqual(metadata.status.state, 'DONE');
+          assert.strictEqual(metadata!.status!.state, 'DONE');
         });
       });
 
@@ -1284,7 +1284,7 @@ describe('BigQuery', () => {
         const file = bucket.file('kitten-test-data-backup.json');
         table.extract(file, (err, resp) => {
           assert.ifError(err);
-          assert.strictEqual(resp.status.state, 'DONE');
+          assert.strictEqual(resp!.status!.state, 'DONE');
           done();
         });
       });

--- a/test/dataset.ts
+++ b/test/dataset.ts
@@ -22,7 +22,7 @@ import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 
 import * as _root from '../src';
-import {DataSetOptions} from '../src/dataset';
+import {DatasetOptions} from '../src/dataset';
 import {FormattedMetadata, TableOptions} from '../src/table';
 
 let promisified = false;
@@ -165,7 +165,7 @@ describe('BigQuery/Dataset', () => {
 
       it('should pass the location', done => {
         bq.createDataset =
-            (id: string, options: DataSetOptions, callback: Function) => {
+            (id: string, options: DatasetOptions, callback: Function) => {
               assert.strictEqual(options.location, LOCATION);
               callback();  // the done fn
             };

--- a/test/index.ts
+++ b/test/index.ts
@@ -1117,7 +1117,8 @@ describe('BigQuery', () => {
 
       it('should delete the params option', done => {
         bq.createJob = (reqOpts: JobOptions) => {
-          assert.strictEqual(reqOpts.params, undefined);
+          // tslint:disable-next-line no-any
+          assert.strictEqual((reqOpts as any).params, undefined);
           done();
         };
 
@@ -1132,7 +1133,7 @@ describe('BigQuery', () => {
       describe('named', () => {
         it('should set the correct parameter mode', done => {
           bq.createJob = (reqOpts: JobOptions) => {
-            const query = reqOpts.configuration.query;
+            const query = reqOpts.configuration!.query!;
             assert.strictEqual(query.parameterMode, 'named');
             done();
           };
@@ -1154,9 +1155,9 @@ describe('BigQuery', () => {
           };
 
           bq.createJob = (reqOpts: JobOptions) => {
-            const query = reqOpts.configuration.query;
-            assert.strictEqual(query.queryParameters[0], queryParameter);
-            assert.strictEqual(query.queryParameters[0].name, 'key');
+            const query = reqOpts.configuration!.query!;
+            assert.strictEqual(query.queryParameters![0], queryParameter);
+            assert.strictEqual(query.queryParameters![0].name, 'key');
             done();
           };
 
@@ -1172,7 +1173,7 @@ describe('BigQuery', () => {
       describe('positional', () => {
         it('should set the correct parameter mode', done => {
           bq.createJob = (reqOpts: JobOptions) => {
-            const query = reqOpts.configuration.query;
+            const query = reqOpts.configuration!.query!;
             assert.strictEqual(query.parameterMode, 'positional');
             done();
           };
@@ -1194,8 +1195,8 @@ describe('BigQuery', () => {
           };
 
           bq.createJob = (reqOpts: JobOptions) => {
-            const query = reqOpts.configuration.query;
-            assert.strictEqual(query.queryParameters[0], queryParameter);
+            const query = reqOpts.configuration!.query!;
+            assert.strictEqual(query.queryParameters![0], queryParameter);
             done();
           };
 
@@ -1216,8 +1217,10 @@ describe('BigQuery', () => {
       };
 
       bq.createJob = (reqOpts: JobOptions) => {
-        assert.strictEqual(reqOpts.configuration.query.dryRun, undefined);
-        assert.strictEqual(reqOpts.configuration.dryRun, options.dryRun);
+        assert.strictEqual(
+            // tslint:disable-next-line no-any
+            (reqOpts.configuration!.query as any).dryRun, undefined);
+        assert.strictEqual(reqOpts.configuration!.dryRun, options.dryRun);
         done();
       };
 
@@ -1231,7 +1234,9 @@ describe('BigQuery', () => {
       };
 
       bq.createJob = (reqOpts: JobOptions) => {
-        assert.strictEqual(reqOpts.configuration.query.jobPrefix, undefined);
+        assert.strictEqual(
+            // tslint:disable-next-line no-any
+            (reqOpts.configuration!.query as any).jobPrefix, undefined);
         assert.strictEqual(reqOpts.jobPrefix, options.jobPrefix);
         done();
       };
@@ -1246,7 +1251,9 @@ describe('BigQuery', () => {
       };
 
       bq.createJob = (reqOpts: JobOptions) => {
-        assert.strictEqual(reqOpts.configuration.query.location, undefined);
+        assert.strictEqual(
+            // tslint:disable-next-line no-any
+            (reqOpts.configuration!.query as any).location, undefined);
         assert.strictEqual(reqOpts.location, LOCATION);
         done();
       };
@@ -1261,7 +1268,9 @@ describe('BigQuery', () => {
       };
 
       bq.createJob = (reqOpts: JobOptions) => {
-        assert.strictEqual(reqOpts.configuration.query.jobId, undefined);
+        assert.strictEqual(
+            // tslint:disable-next-line no-any
+            (reqOpts.configuration!.query as any).jobId, undefined);
         assert.strictEqual(reqOpts.jobId, options.jobId);
         done();
       };

--- a/test/table.ts
+++ b/test/table.ts
@@ -31,7 +31,7 @@ import * as uuid from 'uuid';
 import {BigQuery, Query} from '../src';
 import {Job, JobOptions} from '../src/job';
 import {CopyTableMetadata, JobLoadMetadata, Table, TableMetadata, TableOptions, ViewDefinition} from '../src/table';
-import {bigquery} from '../src/types';
+import bigquery from '../src/types';
 
 let promisified = false;
 let makeWritableStreamOverride: Function|null;


### PR DESCRIPTION
Fixes #332

This basically rewrites all the types. Pretty much every request/response interface was missing fields and every callback/response returned `request.Response` which we don't return anywhere.
~In an effort to **not** make breaking changes, I've kept all type names and duplicate types in tact.~

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
