### PR TITLE
fix(job): check for `errorResult` when polling jobs

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -454,28 +454,23 @@ class Job extends Operation {
    * @param {function} callback
    */
   poll_(callback: MetadataCallback): void {
-    this.getMetadata(
-        (err: Error, metadata: Metadata, apiResponse: r.Response) => {
-          // tslint:disable-next-line no-any
-          if (!err && (apiResponse as any).status &&
-              // tslint:disable-next-line no-any
-              (apiResponse as any).status.errors) {
-            // tslint:disable-next-line no-any
-            err = new util.ApiError((apiResponse as any).status);
-          }
+    this.getMetadata((err: Error, metadata: Metadata) => {
+      if (!err && metadata.status && metadata.status.errorResult) {
+        err = new util.ApiError(metadata.status);
+      }
 
-          if (err) {
-            callback(err);
-            return;
-          }
+      if (err) {
+        callback(err);
+        return;
+      }
 
-          if (metadata.status.state !== 'DONE') {
-            callback(null);
-            return;
-          }
+      if (metadata.status.state !== 'DONE') {
+        callback(null);
+        return;
+      }
 
-          callback(null, metadata);
-        });
+      callback(null, metadata);
+    });
   }
 }
 

--- a/test/job.ts
+++ b/test/job.ts
@@ -357,7 +357,8 @@ describe('BigQuery/Job', () => {
       const error = new Error('Error.');
       const apiResponse = {
         status: {
-          errors: error,
+          errorResult: error,
+          errors: [error],
         },
       };
 
@@ -365,7 +366,7 @@ describe('BigQuery/Job', () => {
 
       beforeEach(() => {
         job.getMetadata = (callback: Function) => {
-          callback(null, apiResponse, apiResponse);
+          callback(null, apiResponse);
         };
       });
 


### PR DESCRIPTION
Fixes #329

Would like some confirmation from a BQ team member on this one.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
