### PR TITLE
fix(tests): update TIMESTAMP param tests

### DIFF
--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -978,12 +978,7 @@ describe('BigQuery', () => {
           it('should work with TIMESTAMP types', done => {
             bigquery.query(
                 {
-                  query: [
-                    'SELECT subject',
-                    'FROM `bigquery-public-data.github_repos.commits`',
-                    'WHERE author.date < ?',
-                    'LIMIT 1',
-                  ].join(' '),
+                  query: 'SELECT ? timestamp',
                   params: [new Date()],
                 },
                 (err, rows) => {
@@ -1192,12 +1187,7 @@ describe('BigQuery', () => {
           it('should work with TIMESTAMP types', done => {
             bigquery.query(
                 {
-                  query: [
-                    'SELECT subject',
-                    'FROM `bigquery-public-data.github_repos.commits`',
-                    'WHERE author.date < @time',
-                    'LIMIT 1',
-                  ].join(' '),
+                  query: 'SELECT @time timestamp',
                   params: {
                     time: new Date(),
                   },


### PR DESCRIPTION
The timestamps we were using to test against were recently converted to structs (essentially protobuf timestamps), so this just updates said tests to query in the same fashion as the `DATE`/`TIME`/`DATETIME` tests

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
