### PR TITLE
refactor(ts): cast arrified rows

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1764,7 +1764,7 @@ class Table extends common.ServiceObject {
         optionsOrCallback :
         cb as InsertRowsCallback;
 
-    rows = arrify(rows);
+    rows = arrify(rows) as RowMetadata[];
 
     if (!rows.length) {
       throw new Error('You must provide at least 1 row to be inserted.');
@@ -1775,7 +1775,7 @@ class Table extends common.ServiceObject {
     });
 
     if (!options.raw) {
-      json.rows = arrify(rows).map((row) => {
+      json.rows = rows.map((row: RowMetadata) => {
         return {
           insertId: uuid.v4(),
           json: Table.encodeValue_(row),


### PR DESCRIPTION
Looks like the latest `arrify` types are causing an issue for us.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
