### PR TITLE
feat: accept apiEndpoint override

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "types": "dtsd bigquery v2 > ./src/types.d.ts"
   },
   "dependencies": {
-    "@google-cloud/common": "^1.0.0",
+    "@google-cloud/common": "^2.0.0",
     "@google-cloud/paginator": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
     "arrify": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,11 @@ export interface BigQueryOptions extends common.GoogleAuthOptions {
   autoRetry?: boolean;
   maxRetries?: number;
   location?: string;
+  /**
+   * The API endpoint of the service used to make requests.
+   * Defaults to `www.googleapis.com`.
+   */
+  apiEndpoint?: string;
 }
 
 /**
@@ -238,10 +243,11 @@ export class BigQuery extends common.Service {
   getDatasetsStream: (options?: GetDatasetsOptions) => ResourceStream<Dataset>;
   getJobsStream: (options?: GetJobsOptions) => ResourceStream<Job>;
 
-  constructor(options?: BigQueryOptions) {
-    options = options || {};
+  constructor(options: BigQueryOptions = {}) {
+    options.apiEndpoint = options.apiEndpoint || 'www.googleapis.com';
     const config = {
-      baseUrl: 'https://www.googleapis.com/bigquery/v2',
+      apiEndpoint: options.apiEndpoint,
+      baseUrl: `https://${options.apiEndpoint}/bigquery/v2`,
       scopes: ['https://www.googleapis.com/auth/bigquery'],
       packageJson: require('../../package.json'),
     };

--- a/src/table.ts
+++ b/src/table.ts
@@ -1402,7 +1402,9 @@ class Table extends common.ServiceObject {
           } as {},
           request: {
             uri: format('{base}/{projectId}/jobs', {
-              base: 'https://www.googleapis.com/upload/bigquery/v2/projects',
+              base: `https://${
+                this.bigQuery.apiEndpoint
+              }/upload/bigquery/v2/projects`,
               projectId: this.bigQuery.projectId,
             }),
           },

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,7 +30,7 @@ import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import * as uuid from 'uuid';
 
-import {BigQueryDate, Dataset, Job, Query, Table} from '../src';
+import {BigQueryDate, Dataset, Job, Table} from '../src';
 import {JobOptions} from '../src/job';
 import {TableField} from '../src/table';
 
@@ -186,12 +186,23 @@ describe('BigQuery', () => {
       );
     });
 
+    it('should allow overriding the apiEndpoint', () => {
+      const apiEndpoint = 'not.real.local';
+      bq = new BigQuery({
+        apiEndpoint,
+      });
+      const calledWith = bq.calledWith_[0];
+      assert.strictEqual(
+        calledWith.baseUrl,
+        `https://${apiEndpoint}/bigquery/v2`
+      );
+    });
+
     it('should capture any user specified location', () => {
       const bq = new BigQuery({
         projectId: PROJECT_ID,
         location: LOCATION,
       });
-
       assert.strictEqual(bq.location, LOCATION);
     });
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -40,7 +40,6 @@ import {
   JobLoadMetadata,
   Table,
   TableMetadata,
-  TableOptions,
   ViewDefinition,
 } from '../src/table';
 import bigquery from '../src/types';
@@ -113,6 +112,7 @@ describe('BigQuery/Table', () => {
       job: (id: string) => {
         return {id};
       },
+      apiEndpoint: 'www.googleapis.com',
       request: util.noop,
     },
   };


### PR DESCRIPTION
This lets developers provide an api endpoint to override the backend service Url.  