### PR TITLE
feat(table): support all sourceFormat types

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1376,13 +1376,6 @@ class Table extends common.ServiceObject {
       delete metadata.jobPrefix;
     }
 
-    if (
-      metadata.hasOwnProperty('sourceFormat') &&
-      fileTypes.indexOf(metadata.sourceFormat!) < 0
-    ) {
-      throw new Error(`Source format not recognized: ${metadata.sourceFormat}`);
-    }
-
     const dup = streamEvents(duplexify());
 
     dup.once('writing', () => {

--- a/test/table.ts
+++ b/test/table.ts
@@ -1490,23 +1490,6 @@ describe('BigQuery/Table', () => {
       table.createWriteStream_({schema: SCHEMA_STRING}).emit('writing');
     });
 
-    it('should throw if a given source format is not recognized', () => {
-      assert.throws(() => {
-        table.createWriteStream_('zip');
-      }, /Source format not recognized/);
-
-      assert.throws(() => {
-        table.createWriteStream_({
-          sourceFormat: 'zip',
-        });
-      }, /Source format not recognized/);
-
-      assert.doesNotThrow(() => {
-        table.createWriteStream_();
-        table.createWriteStream_({});
-      });
-    });
-
     it('should return a stream', () => {
       assert(table.createWriteStream_() instanceof stream.Stream);
     });


### PR DESCRIPTION
Fixes #450 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
