### PR TITLE
test: set minCreationTime for getJobs

### DIFF
--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -370,7 +370,7 @@ describe('BigQuery', () => {
     let jobEmitted = false;
 
     bigquery
-      .getJobsStream()
+      .getJobsStream({minCreationTime})
       .on('error', done)
       .on('data', job => {
         jobEmitted = job instanceof Job;

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -40,6 +40,7 @@ const storage = new Storage();
 
 describe('BigQuery', () => {
   const GCLOUD_TESTS_PREFIX = 'nodejs_bq_test';
+  const minCreationTime = Date.now().toString();
 
   const dataset = bigquery.dataset(generateName('dataset'));
   const table = dataset.table(generateName('table'));
@@ -358,7 +359,7 @@ describe('BigQuery', () => {
   });
 
   it('should get a list of jobs', done => {
-    bigquery.getJobs((err, jobs) => {
+    bigquery.getJobs({minCreationTime}, (err, jobs) => {
       assert.ifError(err);
       assert(jobs![0] instanceof Job);
       done();


### PR DESCRIPTION
Noticing this test was timing out, turns out `getJobs` returns any job created in the last 6 months (so quite a few). Setting the `minCreationTime` should help speed up that test.

- [ ] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
