### PR TITLE
test(samples): deflake table sample tests

### DIFF
--- a/samples/test/tables.test.js
+++ b/samples/test/tables.test.js
@@ -57,6 +57,9 @@ describe('Tables', () => {
     ]);
   });
 
+  // to avoid getting rate limited
+  beforeEach(done => setTimeout(done, 500));
+
   after(async () => {
     await bigquery
       .dataset(srcDatasetId)


### PR DESCRIPTION
Fixes #500

Looks like we are getting rate limited on a test that uploads a CSV file, which in turn causes a series of tests that depend on said file to fail.

