### PR TITLE
fix: update root url to `bigquery.googleapis.com`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ export interface BigQueryOptions extends common.GoogleAuthOptions {
   location?: string;
   /**
    * The API endpoint of the service used to make requests.
-   * Defaults to `www.googleapis.com`.
+   * Defaults to `bigquery.googleapis.com`.
    */
   apiEndpoint?: string;
 }
@@ -200,7 +200,7 @@ export interface BigQueryOptions extends common.GoogleAuthOptions {
  * @property {string[]} [scopes] Additional OAuth scopes to use in requests. For
  *     example, to access an external data source, you may need the
  *     `https://www.googleapis.com/auth/drive.readonly` scope.
- * @property {string=} apiEndpoint The API endpoint of the service used to make requests. Defaults to `www.googleapis.com`.
+ * @property {string=} apiEndpoint The API endpoint of the service used to make requests. Defaults to `bigquery.googleapis.com`.
  */
 
 /**
@@ -244,7 +244,7 @@ export class BigQuery extends common.Service {
   getJobsStream: (options?: GetJobsOptions) => ResourceStream<Job>;
 
   constructor(options: BigQueryOptions = {}) {
-    options.apiEndpoint = options.apiEndpoint || 'www.googleapis.com';
+    options.apiEndpoint = options.apiEndpoint || 'bigquery.googleapis.com';
     const config = {
       apiEndpoint: options.apiEndpoint,
       baseUrl: `https://${options.apiEndpoint}/bigquery/v2`,

--- a/test/index.ts
+++ b/test/index.ts
@@ -175,7 +175,7 @@ describe('BigQuery', () => {
 
       const calledWith = bq.calledWith_[0];
 
-      const baseUrl = 'https://www.googleapis.com/bigquery/v2';
+      const baseUrl = 'https://bigquery.googleapis.com/bigquery/v2';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
       assert.deepStrictEqual(calledWith.scopes, [
         'https://www.googleapis.com/auth/bigquery',

--- a/test/table.ts
+++ b/test/table.ts
@@ -112,7 +112,7 @@ describe('BigQuery/Table', () => {
       job: (id: string) => {
         return {id};
       },
-      apiEndpoint: 'www.googleapis.com',
+      apiEndpoint: 'bigquery.googleapis.com',
       request: util.noop,
     },
   };
@@ -1555,7 +1555,7 @@ describe('BigQuery/Table', () => {
           options: MakeWritableStreamOptions
         ) => {
           const uri =
-            'https://www.googleapis.com/upload/bigquery/v2/projects/' +
+            'https://bigquery.googleapis.com/upload/bigquery/v2/projects/' +
             table.bigQuery.projectId +
             '/jobs';
           assert.strictEqual(options.request.uri, uri);


### PR DESCRIPTION
This change updates the root url for requests from `www.googleapis.com` to `bigquery.googleapis.com`.