### PR TITLE
build: generate discovery types via synthtool

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -6,3 +6,6 @@ logging.basicConfig(level=logging.DEBUG)
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
 s.copy(templates)
+
+# Node.js specific cleanup
+subprocess.run(['npm', 'run', 'types'])


### PR DESCRIPTION
Quite a few changes have been pushed to the discovery API lately, thought it would be a good idea to automate generating the TypeScript types.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
