### PR TITLE
refactor!: don't return Stream from createLoadJob

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
     "is": "^3.3.0",
+    "p-event": "^4.1.0",
     "stream-events": "^1.0.5",
     "string-format-obj": "^1.1.1",
     "uuid": "^7.0.0"

--- a/src/table.ts
+++ b/src/table.ts
@@ -1103,114 +1103,10 @@ class Table extends common.ServiceObject {
     this.bigQuery.createJob(body, callback!);
   }
 
-  /**
-   * Add `location` if available. Replaces `format` with `sourceFormat` from
-   * lookup table if format is present. Does not mutate.
-   * @param {JobLoadMetadata} metadata
-   * @returns {JobLoadMetadata}
-   * @private
-   */
-  _prepareLoadJobMetadata(metadata?: JobLoadMetadata): JobLoadMetadata {
-    if (!metadata) {
-      return {};
-    }
-
-    const {format, ...restMetadata} = metadata || {};
-    const {location} = this;
-    const sourceFormat = format ? FORMATS[format.toLowerCase()] : undefined;
-
-    return {
-      ...restMetadata,
-      ...(location ? {location} : {}),
-      ...(format ? {sourceFormat} : {format}),
-    };
-  }
-
-  /**
-   * Load data from a local file, receiving
-   *
-   * By loading data this way, you create a load job that will run your data
-   * load asynchronously. If you would like instantaneous access to your data,
-   * insert it using {@liink Table#insert}.
-   *
-   * Note: The file type will be inferred by the given file's extension. If you
-   * wish to override this, you must provide `metadata.format`.
-   *
-   * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
-   *
-   * @param {string} source The path to the local source file to load.
-   * @param {object} [metadata] Metadata to set with the load operation. The
-   *     metadata object should be in the format of the
-   *     [`configuration.load`](http://goo.gl/BVcXk4) property of a Jobs
-   * resource.
-   * @param {string} [metadata.format] The format the data being loaded is in.
-   *     Allowed options are "AVRO", "CSV", "JSON", "ORC", or "PARQUET".
-   * @param {string} [metadata.jobId] Custom job id.
-   * @param {string} [metadata.jobPrefix] Prefix to apply to the job id.
-   * @returns {Writable} Emits a "job" event upon completion.
-   *
-   * @throws {Error} If the source isn't a string file name.
-   *
-   * @example
-   * const {BigQuery} = require('@google-cloud/bigquery');
-   * const bigquery = new BigQuery();
-   * const dataset = bigquery.dataset('my-dataset');
-   * const table = dataset.table('my-table');
-   *
-   * const onJob = (job, apiResponse) => {
-   *   // `job` is a Job object that can be used to check the status of the
-   *   // request.
-   * };
-   *
-   * const onError = err => {
-   *   // got an error
-   * }
-   *
-   * //-
-   * // Load data from a local file.
-   * //-
-   * table.createLoadJob('./institutions.csv')
-   *   .once('error', onError)
-   *   .once('job', onJob);
-   *
-   * //-
-   * // You may also pass in metadata in the format of a Jobs resource. See
-   * // (http://goo.gl/BVcXk4) for a full list of supported values.
-   * //-
-   * const metadata = {
-   *   encoding: 'ISO-8859-1',
-   *   sourceFormat: 'NEWLINE_DELIMITED_JSON'
-   * };
-   *
-   * table.createLoadJob('./my-data.csv', metadata)
-   *   .once('error', onError)
-   *   .once('job', onJob);
-   */
-  createLoadJobStream(
-    source: string,
-    metadata?: JobLoadMetadata,
-  ): Writable {
-    const jobLoadMetadata = this._prepareLoadJobMetadata(metadata);
-
-    // If a sourceFormat wasn't specified, try to find a match from the
-    // file's extension.
-    const detectedFormat =
-      FORMATS[
-        path
-          .extname(source)
-          .substr(1)
-          .toLowerCase()
-        ];
-    if (!jobLoadMetadata.sourceFormat && detectedFormat) {
-      jobLoadMetadata.sourceFormat = detectedFormat;
-    }
-
-    // Read the file into a new write stream.
-    return fs.createReadStream(source)
-      .pipe(this.createWriteStream_(jobLoadMetadata));
-  }
-
-  createLoadJob(source: string | File, metadata?: JobLoadMetadata): Promise<JobResponse>;
+  createLoadJob(
+    source: string | File,
+    metadata?: JobLoadMetadata
+  ): Promise<JobResponse>;
   createLoadJob(
     source: string | File,
     metadata: JobLoadMetadata,
@@ -1327,15 +1223,40 @@ class Table extends common.ServiceObject {
    * @returns {Promise<JobResponse>}
    * @private
    */
-  async _createLoadJob(source: string | File | File[], metadata: JobLoadMetadata): Promise<JobResponse> {
-    if (typeof source === 'string') {
-      // A path to a file was given.
-      const jobWritable = this.createLoadJobStream(source, metadata);
-      const jobResponse = await pEvent(jobWritable, 'job') as Job;
-      return [jobResponse, jobResponse.metadata];
+  async _createLoadJob(
+    source: string | File | File[],
+    metadata: JobLoadMetadata
+  ): Promise<JobResponse> {
+    if (metadata.format) {
+      metadata.sourceFormat = FORMATS[metadata.format.toLowerCase()];
+      delete metadata.format;
     }
 
-    const jobLoadMetadata = this._prepareLoadJobMetadata(metadata);
+    if (this.location) {
+      metadata.location = this.location;
+    }
+
+    if (typeof source === 'string') {
+      // A path to a file was given. If a sourceFormat wasn't specified, try to
+      // find a match from the file's extension.
+      const detectedFormat =
+        FORMATS[
+          path
+            .extname(source)
+            .substr(1)
+            .toLowerCase()
+        ];
+      if (!metadata.sourceFormat && detectedFormat) {
+        metadata.sourceFormat = detectedFormat;
+      }
+
+      // Read the file into a new write stream.
+      const jobWritable = fs
+        .createReadStream(source)
+        .pipe(this.createWriteStream_(metadata));
+      const jobResponse = (await pEvent(jobWritable, 'job')) as Job;
+      return [jobResponse, jobResponse.metadata];
+    }
 
     // tslint:disable-next-line no-any
     const body: any = {
@@ -1350,22 +1271,22 @@ class Table extends common.ServiceObject {
       },
     };
 
-    if (jobLoadMetadata.jobPrefix) {
-      body.jobPrefix = jobLoadMetadata.jobPrefix;
-      delete jobLoadMetadata.jobPrefix;
+    if (metadata.jobPrefix) {
+      body.jobPrefix = metadata.jobPrefix;
+      delete metadata.jobPrefix;
     }
 
-    if (jobLoadMetadata.location) {
-      body.location = jobLoadMetadata.location;
-      delete jobLoadMetadata.location;
+    if (metadata.location) {
+      body.location = metadata.location;
+      delete metadata.location;
     }
 
-    if (jobLoadMetadata.jobId) {
-      body.jobId = jobLoadMetadata.jobId;
-      delete jobLoadMetadata.jobId;
+    if (metadata.jobId) {
+      body.jobId = metadata.jobId;
+      delete metadata.jobId;
     }
 
-    extend(true, body.configuration.load, jobLoadMetadata, {
+    extend(true, body.configuration.load, metadata, {
       sourceUris: arrify(source).map(src => {
         if (!common.util.isCustomType(src, 'storage/file')) {
           throw new Error('Source must be a File object.');
@@ -1381,7 +1302,7 @@ class Table extends common.ServiceObject {
               .substr(1)
               .toLowerCase()
           ];
-        if (!jobLoadMetadata.sourceFormat && format) {
+        if (!metadata.sourceFormat && format) {
           body.configuration.load.sourceFormat = format;
         }
         return 'gs://' + src.bucket.name + '/' + src.name;

--- a/src/table.ts
+++ b/src/table.ts
@@ -1207,13 +1207,11 @@ class Table extends common.ServiceObject {
     const metadata =
       typeof metadataOrCallback === 'object' ? metadataOrCallback : {};
     const callback =
-      typeof metadataOrCallback === 'function'
-        ? metadataOrCallback
-        : cb || common.util.noop;
+      typeof metadataOrCallback === 'function' ? metadataOrCallback : cb;
 
     this._createLoadJob(source, metadata).then(
-      ([resp]) => callback(null, resp, resp.metadata),
-      err => callback(err)
+      ([resp]) => callback!(null, resp, resp.metadata),
+      err => callback!(err)
     );
   }
 


### PR DESCRIPTION
Breaking change to fix #640:

- `createLoadJob` now only returns a promise (or handles the callback), and provides the completed job response. in some signatures this used to return a Writable stream
- added `createLoadJobStream` to explicitly return the Writable without any async operations, unless the writable is specifically desired by the consumer, `createLoadJob` is recommended.

fix!(table): createLoadJobStream sync returns a stream, createLoadJob always returns a job #640

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #640 🦕
