### PR TITLE
test: provide hint that calledWith_ exists on stubbed objects

### DIFF
--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -48,6 +48,14 @@ class FakeApiError {
   }
 }
 
+interface CalledWithService extends Service {
+  calledWith_: Array<{
+    baseUrl: string;
+    scopes: string[];
+    packageJson: {};
+  }>;
+}
+
 let promisified = false;
 const fakePfy = extend({}, pfy, {
   promisifyAll: (c: Function, options: pfy.PromisifyAllOptions) => {
@@ -179,7 +187,7 @@ describe('BigQuery', () => {
     it('should inherit from Service', () => {
       assert(bq instanceof Service);
 
-      const calledWith = bq.calledWith_[0];
+      const calledWith = (bq as CalledWithService).calledWith_[0];
 
       const baseUrl = 'https://bigquery.googleapis.com/bigquery/v2';
       assert.strictEqual(calledWith.baseUrl, baseUrl);

--- a/test/dataset.ts
+++ b/test/dataset.ts
@@ -29,6 +29,15 @@ import * as _root from '../src';
 import {DatasetOptions} from '../src/dataset';
 import {FormattedMetadata, TableOptions} from '../src/table';
 
+interface CalledWithDataset extends ServiceObject {
+  calledWith_: Array<{
+    parent: {};
+    baseUrl: string;
+    id: string;
+    methods: string[];
+  }>;
+}
+
 let promisified = false;
 const fakePfy = extend({}, pfy, {
   promisifyAll: (c: Function, options: pfy.PromisifyAllOptions) => {
@@ -118,7 +127,7 @@ describe('BigQuery/Dataset', () => {
     it('should inherit from ServiceObject', () => {
       assert(ds instanceof ServiceObject);
 
-      const calledWith = ds.calledWith_[0];
+      const calledWith = (ds as CalledWithDataset).calledWith_[0];
 
       assert.strictEqual(calledWith.parent, BIGQUERY);
       assert.strictEqual(calledWith.baseUrl, '/datasets');

--- a/test/job.ts
+++ b/test/job.ts
@@ -36,6 +36,15 @@ class FakeOperation {
   }
 }
 
+interface CalledWithJob extends FakeOperation {
+  calledWith_: Array<{
+    parent: {};
+    baseUrl: string;
+    id: string;
+    methods: string[];
+  }>;
+}
+
 let promisified = false;
 const fakePfy = extend({}, pfy, {
   promisifyAll: (c: Function) => {
@@ -109,7 +118,7 @@ describe('BigQuery/Job', () => {
     it('should inherit from Operation', () => {
       assert(job instanceof FakeOperation);
 
-      const calledWith = job.calledWith_[0];
+      const calledWith = (job as CalledWithJob).calledWith_[0];
 
       assert.strictEqual(calledWith.parent, BIGQUERY);
       assert.strictEqual(calledWith.baseUrl, '/jobs');

--- a/test/table.ts
+++ b/test/table.ts
@@ -45,6 +45,15 @@ import {
 } from '../src/table';
 import bigquery from '../src/types';
 
+interface CalledWithTable extends ServiceObject {
+  calledWith_: Array<{
+    parent: {};
+    baseUrl: string;
+    id: string;
+    methods: string[];
+  }>;
+}
+
 let promisified = false;
 let makeWritableStreamOverride: Function | null;
 let isCustomTypeOverride: Function | null;
@@ -217,7 +226,7 @@ describe('BigQuery/Table', () => {
       const table = new Table(datasetInstance, TABLE_ID);
       assert(table instanceof ServiceObject);
 
-      const calledWith = table.calledWith_[0];
+      const calledWith = (table as CalledWithTable).calledWith_[0];
 
       assert.strictEqual(calledWith.parent, datasetInstance);
       assert.strictEqual(calledWith.baseUrl, '/tables');
@@ -2333,7 +2342,6 @@ describe('BigQuery/Table', () => {
       assert.strictEqual(reqOpts.method, 'POST');
       assert.strictEqual(reqOpts.uri, '/insertAll');
       assert.deepStrictEqual(reqOpts.json, {rows: rawData});
-      assert.strictEqual(reqOpts.json.raw, undefined);
     });
 
     it('should accept options', async () => {


### PR DESCRIPTION
I'm not 100% sure why we suddenly started getting these failures (there hasn't been an update to typescript recently, which would seem like it would be the natural culprit).

Regardless, this approach seemed reasonable to me to better hint to the compiler that we have added `calledWith_` to our objects in test.

fixes #691