### PR TITLE
test: refactors system test deleteDatasets()

### DIFF
--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -1701,7 +1701,8 @@ describe('BigQuery', () => {
     const deleteDatasetPromises = datasets
       .filter(async dataset => {
         const [metadata] = await dataset.getMetadata();
-        return isResourceStale(parseInt(metadata.creationTime));
+        const creationTime = parseInt(metadata.creationTime);
+        return creationTime && isResourceStale(creationTime);
       })
       .map(dataset => {
         return dataset.delete({force: true});

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -102,11 +102,13 @@ describe('BigQuery', () => {
 
   before(async () => {
     // Remove buckets created for the tests.
-    await deleteBuckets(),
-      // Remove datasets created for the tests.
-      await deleteDatasets(),
-      // Create the test dataset with a label tagging this as a test run.
-      await dataset.create({labels: {[GCLOUD_TESTS_PREFIX]: ''}});
+    await deleteBuckets();
+
+    // Remove datasets created for the tests.
+    await deleteDatasets();
+
+    // Create the test dataset with a label tagging this as a test run.
+    await dataset.create({labels: {[GCLOUD_TESTS_PREFIX]: ''}});
 
     // Create the test table.
     await table.create({schema: SCHEMA});

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -101,11 +101,13 @@ describe('BigQuery', () => {
   ];
 
   before(async () => {
-    // Remove buckets created for the tests.
-    await deleteBuckets();
+    await Promise.all([
+      // Remove buckets created for the tests.
+      deleteBuckets(),
 
-    // Remove datasets created for the tests.
-    await deleteDatasets();
+      // Remove datasets created for the tests.
+      deleteDatasets(),
+    ]);
 
     // Create the test dataset with a label tagging this as a test run.
     await dataset.create({labels: {[GCLOUD_TESTS_PREFIX]: ''}});

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -1701,7 +1701,7 @@ describe('BigQuery', () => {
     const deleteDatasetPromises = datasets
       .filter(async dataset => {
         const [metadata] = await dataset.getMetadata();
-        const creationTime = parseInt(metadata.creationTime);
+        const creationTime = Number(metadata.creationTime);
         return creationTime && isResourceStale(creationTime);
       })
       .map(dataset => {


### PR DESCRIPTION
This refactor adds logic to check the existence of a stale testing dataset before attempting to delete it. This should fix tests that are failing due to parallel CI test runs attempting to delete the same resource.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

 🦕
