### PR TITLE
fix: add string type for query types

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -89,7 +89,7 @@ export type Query = JobRequest<bigquery.IJobConfigurationQuery> & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params?: any[] | {[param: string]: any};
   dryRun?: boolean;
-  types?: string[] | string[][] | {[type: string]: string[]};
+  types?: string[] | string[][] | {[type: string]: string | string[]};
   defaultDataset?: Dataset;
   job?: Job;
   maxResults?: number;


### PR DESCRIPTION
Adds missing 'string' type to provided query types.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

Fixes #825 🦕
