### PR TITLE
fix(perf): disable prettyPrint for slimmer API responses

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -366,6 +366,14 @@ export class BigQuery extends common.Service {
      *   });
      */
     this.getJobsStream = paginator.streamify<Job>('getJobs');
+
+    // Disable `prettyPrint` for better performance.
+    // https://github.com/googleapis/nodejs-bigquery/issues/858
+    this.interceptors.push({
+      request: (reqOpts: common.DecorateRequestOptions) => {
+        return extend(true, {}, reqOpts, {qs: {prettyPrint: false}});
+      },
+    });
   }
 
   /**

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -248,6 +248,27 @@ describe('BigQuery', () => {
       assert.notDeepStrictEqual(calledWith, options);
       assert.deepStrictEqual(calledWith, expectedCalledWith);
     });
+
+    describe('prettyPrint request interceptor', () => {
+      let requestInterceptor: Function;
+
+      beforeEach(() => {
+        requestInterceptor = bq.interceptors.pop().request;
+      });
+
+      it('should disable prettyPrint', () => {
+        assert.deepStrictEqual(requestInterceptor({}), {
+          qs: {prettyPrint: false},
+        });
+      });
+
+      it('should clone json', () => {
+        const reqOpts = {qs: {a: 'b'}};
+        const expectedReqOpts = {qs: {a: 'b', prettyPrint: false}};
+        assert.deepStrictEqual(requestInterceptor(reqOpts), expectedReqOpts);
+        assert.notDeepStrictEqual(reqOpts, expectedReqOpts);
+      });
+    });
   });
 
   describe('mergeSchemaWithRows_', () => {


### PR DESCRIPTION
Fixes #858 

This disables the `prettyPrint` setting for all API requests, leading to smaller JSON response payloads.