### PR TITLE
fix: promise never returned on table.insert

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1904,14 +1904,17 @@ class Table extends common.ServiceObject {
         ? optionsOrCallback
         : ({} as InsertRowsOptions);
     const callback =
-      typeof optionsOrCallback === 'function'
-        ? optionsOrCallback
-        : (cb as InsertRowsCallback);
+      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
 
-    this._insertAndCreateTable(rows, options).then(
-      resp => callback(null, resp),
-      err => callback(err, null)
-    );
+    const promise = this._insertAndCreateTable(rows, options);
+    if (callback) {
+      promise.then(
+        resp => callback(null, resp),
+        err => callback(err, null)
+      );
+    } else {
+      return promise.then(r => [r]);
+    }
   }
 
   /**

--- a/test/table.ts
+++ b/test/table.ts
@@ -2274,6 +2274,16 @@ describe('BigQuery/Table', () => {
       );
     });
 
+    it('should return a promise if no callback is provided', () => {
+      const promise = table.insert(data);
+      assert(promise instanceof Promise);
+    });
+
+    it('should resolve to an array on success', async () => {
+      const resp = await table.insert(data);
+      assert(Array.isArray(resp));
+    });
+
     it('should generate insertId', async () => {
       await table.insert([data[0]]);
       assert(


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #948 

So the `table.insert` function never returned its promise. This PR fixes that.
It also gets rid of an unnecessary cast.

Two new tests were written:
- `it should return a promise if no callback is provided`
- `it should resolve to an array on success`

Code coverage goes down to 99.92, due to line 1916 being uncovered (even though thats what the new tests were for).