### PR TITLE
docs: use googleapis.dev links in jsdoc

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -246,7 +246,7 @@ class Model extends common.ServiceObject {
    *
    * @param {string|File} destination Where the model should be exported
    *    to. A string or {@link
-   *    https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   *    https://googleapis.dev/nodejs/storage/latest/File.html File}
    *    object.
    * @param {object} [options] The configuration object.
    * @param {string} [options.format] The format to export the data in.
@@ -276,7 +276,7 @@ class Model extends common.ServiceObject {
    *
    * //-
    * // To use the default options, just pass a string or a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * //
    * // Note: The default format is 'ML_TF_SAVED_MODEL'.
@@ -380,7 +380,7 @@ class Model extends common.ServiceObject {
    *
    * @param {string|File} destination Where the model should be exported
    *    to. A string or {@link
-   *    https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   *    https://googleapis.dev/nodejs/storage/latest/File.html File}
    *    object.
    * @param {object} [options] The configuration object.
    * @param {string} [options.format] The format to export
@@ -412,7 +412,7 @@ class Model extends common.ServiceObject {
    *
    * //-
    * // To use the default options, just pass a string or a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * //
    * // Note: The default format is 'ML_TF_SAVED_MODEL'.

--- a/src/table.ts
+++ b/src/table.ts
@@ -971,7 +971,7 @@ class Table extends common.ServiceObject {
    *
    * @param {string|File} destination Where the file should be exported
    *     to. A string or a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * @param {object=} options - The configuration object.
    * @param {string} options.format - The format to export the data in. Allowed
@@ -1007,7 +1007,7 @@ class Table extends common.ServiceObject {
    *
    * //-
    * // To use the default options, just pass a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * //
    * // Note: The exported format type will be inferred by the file's extension.
@@ -1131,7 +1131,7 @@ class Table extends common.ServiceObject {
   createLoadJob(source: string | File, callback: JobCallback): void;
   /**
    * Load data from a local file or Storage {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}.
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}.
    *
    * By loading data this way, you create a load job that will run your data
    * load asynchronously. If you would like instantaneous access to your data,
@@ -1144,7 +1144,7 @@ class Table extends common.ServiceObject {
    *
    * @param {string|File|File[]} source The source file to load. A string (path)
    * to a local file, or one or more {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * objects.
    * @param {object} [metadata] Metadata to set with the load operation. The
    *     metadata object should be in the format of the
@@ -1536,7 +1536,7 @@ class Table extends common.ServiceObject {
    *
    * @param {string|File} destination Where the file should be exported
    *     to. A string or a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}.
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}.
    * @param {object} [options] The configuration object.
    * @param {string} [options.format="CSV"] The format to export the data in.
    *     Allowed options are "AVRO", "CSV", "JSON", "ORC" or "PARQUET".
@@ -1566,7 +1566,7 @@ class Table extends common.ServiceObject {
    *
    * //-
    * // To use the default options, just pass a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * //
    * // Note: The exported format type will be inferred by the file's extension.
@@ -2077,7 +2077,7 @@ class Table extends common.ServiceObject {
   load(source: string | File, callback: JobMetadataCallback): void;
   /**
    * Load data from a local file or Storage {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}.
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}.
    *
    * By loading data this way, you create a load job that will run your data
    * load asynchronously. If you would like instantaneous access to your data,
@@ -2088,7 +2088,7 @@ class Table extends common.ServiceObject {
    *
    * @param {string|File} source The source file to load. A filepath as a string
    *     or a {@link
-   * https://cloud.google.com/nodejs/docs/reference/storage/latest/File File}
+   * https://googleapis.dev/nodejs/storage/latest/File.html File}
    * object.
    * @param {object} [metadata] Metadata to set with the load operation. The
    *     metadata object should be in the format of the

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -589,9 +589,7 @@ describe('BigQuery', () => {
           assert.strictEqual(job.location, LOCATION);
           await job.promise();
           const options = {timeoutMs: 1};
-          await job.getQueryResults(options, (err, resp) => {
-            assert.ifError(err);
-          });
+          await job.getQueryResults(options);
         });
       });
 


### PR DESCRIPTION
The redirect link on cloud.google.com started returning a 404 followed by a JavaScript redirect instead of a 302. 