### PR TITLE
docs: update links for job resources

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1467,7 +1467,7 @@ export class BigQuery extends common.Service {
    *
    * However in the event you need a finer level of control over the job
    * creation, you can use this method to pass in a raw [Job
-   * resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs)
+   * resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job)
    * object.
    *
    * @see [Jobs Overview]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs}
@@ -1715,7 +1715,7 @@ export class BigQuery extends common.Service {
   /**
    * @callback GetJobsCallback
    * @param {?Error} err Request error, if any.
-   * @param {object} jobs An array of [Job]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs} objects.
+   * @param {object} jobs An array of [Job]{@link https://cloud.google.com/bigquery/docs/reference/v2/Job} objects.
    */
   /**
    * @typedef {array} GetJobsResponse

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1473,7 +1473,7 @@ export class BigQuery extends common.Service {
    * @see [Jobs Overview]{@link https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs}
    * @see [Jobs: insert API Documentation]{@link https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert}
    *
-   * @param {object} options Object in the form of a [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs);
+   * @param {object} options Object in the form of a [Job resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job);
    * @param {string} [options.jobId] Custom job id.
    * @param {string} [options.jobPrefix] Prefix to apply to the job id.
    * @param {string} [options.location] The geographic location of the job.


### PR DESCRIPTION
Updates links to point more directly to documentation for job resources.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

🦕
