### PR TITLE
docs(samples): update table.load samples' error handling

### DIFF
--- a/samples/loadCSVFromGCS.js
+++ b/samples/loadCSVFromGCS.js
@@ -64,12 +64,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_csv]
   loadCSVFromGCS();

--- a/samples/loadCSVFromGCSAutodetect.js
+++ b/samples/loadCSVFromGCSAutodetect.js
@@ -58,12 +58,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
       .load(storage.bucket(bucketName).file(filename), metadata);
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_csv_autodetect]
   loadCSVFromGCSAutodetect();

--- a/samples/loadCSVFromGCSTruncate.js
+++ b/samples/loadCSVFromGCSTruncate.js
@@ -70,12 +70,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
     console.log(
       `Write disposition used: ${job.configuration.load.writeDisposition}.`
     );
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_csv_truncate]
   loadCSVFromGCSTruncate();

--- a/samples/loadJSONFromGCS.js
+++ b/samples/loadJSONFromGCS.js
@@ -62,12 +62,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
       .load(storage.bucket(bucketName).file(filename), metadata);
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_json]
   loadJSONFromGCS();

--- a/samples/loadJSONFromGCSAutodetect.js
+++ b/samples/loadJSONFromGCSAutodetect.js
@@ -57,12 +57,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
       .load(storage.bucket(bucketName).file(filename), metadata);
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   loadJSONFromGCSAutodetect();
   // [END bigquery_load_table_gcs_json_autodetect]

--- a/samples/loadJSONFromGCSTruncate.js
+++ b/samples/loadJSONFromGCSTruncate.js
@@ -69,12 +69,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
     console.log(
       `Write disposition used: ${job.configuration.load.writeDisposition}.`
     );
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_json_truncate]
   loadJSONFromGCSTruncate();

--- a/samples/loadLocalFile.js
+++ b/samples/loadLocalFile.js
@@ -41,12 +41,6 @@ function main(
       .load(filename);
 
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_from_file]
   loadLocalFile();

--- a/samples/loadOrcFromGCSTruncate.js
+++ b/samples/loadOrcFromGCSTruncate.js
@@ -63,12 +63,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
     console.log(
       `Write disposition used: ${job.configuration.load.writeDisposition}.`
     );
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_orc_truncate]
   loadORCFromGCSTruncate();

--- a/samples/loadParquetFromGCSTruncate.js
+++ b/samples/loadParquetFromGCSTruncate.js
@@ -63,12 +63,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
     console.log(
       `Write disposition used: ${job.configuration.load.writeDisposition}.`
     );
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_parquet_truncate]
   loadParquetFromGCSTruncate();

--- a/samples/loadTableClustered.js
+++ b/samples/loadTableClustered.js
@@ -66,12 +66,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_clustered]
   loadTableClustered(datasetId, tableId);

--- a/samples/loadTableGCSAvro.js
+++ b/samples/loadTableGCSAvro.js
@@ -59,12 +59,6 @@ function main(
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_avro]
   loadTableGCSAvro();

--- a/samples/loadTableGCSAvroTruncate.js
+++ b/samples/loadTableGCSAvroTruncate.js
@@ -66,12 +66,6 @@ function main(
     console.log(
       `Write disposition used: ${job.configuration.load.writeDisposition}.`
     );
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_avro_truncate]
   loadTableGCSAvroTruncate();

--- a/samples/loadTableGCSORC.js
+++ b/samples/loadTableGCSORC.js
@@ -57,12 +57,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_orc]
   loadTableGCSORC();

--- a/samples/loadTableGCSParquet.js
+++ b/samples/loadTableGCSParquet.js
@@ -57,12 +57,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_gcs_parquet]
   loadTableGCSParquet();

--- a/samples/loadTablePartitioned.js
+++ b/samples/loadTablePartitioned.js
@@ -72,12 +72,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_new_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_partitioned]
   loadTablePartitioned();

--- a/samples/loadTableURIFirestore.js
+++ b/samples/loadTableURIFirestore.js
@@ -48,12 +48,6 @@ function main(datasetId = 'my_dataset', tableId = 'my_table') {
 
     // load() waits for the job to finish
     console.log(`Job ${job.id} completed.`);
-
-    // Check the job's status for errors
-    const errors = job.status.errors;
-    if (errors && errors.length > 0) {
-      throw errors;
-    }
   }
   // [END bigquery_load_table_uri_firestore]
   loadTableURIFirestore();


### PR DESCRIPTION
Removes outdated error handling from load samples because `job.status.errors` are raised in the `table.load` method.
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

🦕
