### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1172,16 +1172,6 @@ export class BigQuery extends common.Service {
     );
   }
 
-  createDataset(
-    id: string,
-    options?: DatasetResource
-  ): Promise<DatasetResponse>;
-  createDataset(
-    id: string,
-    options: DatasetResource,
-    callback: DatasetCallback
-  ): void;
-  createDataset(id: string, callback: DatasetCallback): void;
   /**
    * @callback DatasetCallback
    * @param {?Error} err Request error, if any.
@@ -1219,6 +1209,16 @@ export class BigQuery extends common.Service {
    * });
    * ```
    */
+  createDataset(
+    id: string,
+    options?: DatasetResource
+  ): Promise<DatasetResponse>;
+  createDataset(
+    id: string,
+    options: DatasetResource,
+    callback: DatasetCallback
+  ): void;
+  createDataset(id: string, callback: DatasetCallback): void;
   createDataset(
     id: string,
     optionsOrCallback?: DatasetResource | DatasetCallback,
@@ -1260,8 +1260,6 @@ export class BigQuery extends common.Service {
     );
   }
 
-  createQueryJob(options: Query | string): Promise<JobResponse>;
-  createQueryJob(options: Query | string, callback: JobCallback): void;
   /**
    * @callback JobCallback
    * @param {?Error} err Request error, if any.
@@ -1357,6 +1355,8 @@ export class BigQuery extends common.Service {
    * });
    * ```
    */
+  createQueryJob(options: Query | string): Promise<JobResponse>;
+  createQueryJob(options: Query | string, callback: JobCallback): void;
   createQueryJob(
     opts: Query | string,
     callback?: JobCallback
@@ -1492,8 +1492,6 @@ export class BigQuery extends common.Service {
     this.createJob(reqOpts, callback!);
   }
 
-  createJob(options: JobOptions): Promise<JobResponse>;
-  createJob(options: JobOptions, callback: JobCallback): void;
   /**
    * Creates a job. Typically when creating a job you'll have a very specific
    * task in mind. For this we recommend one of the following methods:
@@ -1553,6 +1551,8 @@ export class BigQuery extends common.Service {
    * });
    * ```
    */
+  createJob(options: JobOptions): Promise<JobResponse>;
+  createJob(options: JobOptions, callback: JobCallback): void;
   createJob(
     options: JobOptions,
     callback?: JobCallback
@@ -1659,9 +1659,6 @@ export class BigQuery extends common.Service {
     return new Dataset(this, id, options);
   }
 
-  getDatasets(options?: GetDatasetsOptions): Promise<DatasetsResponse>;
-  getDatasets(options: GetDatasetsOptions, callback: DatasetsCallback): void;
-  getDatasets(callback: DatasetsCallback): void;
   /**
    * List all or some of the datasets in your project.
    *
@@ -1712,6 +1709,9 @@ export class BigQuery extends common.Service {
    * bigquery.getDatasets().then(function(datasets) {});
    * ```
    */
+  getDatasets(options?: GetDatasetsOptions): Promise<DatasetsResponse>;
+  getDatasets(options: GetDatasetsOptions, callback: DatasetsCallback): void;
+  getDatasets(callback: DatasetsCallback): void;
   getDatasets(
     optionsOrCallback?: GetDatasetsOptions | DatasetsCallback,
     cb?: DatasetsCallback
@@ -1757,9 +1757,6 @@ export class BigQuery extends common.Service {
     );
   }
 
-  getJobs(options?: GetJobsOptions): Promise<GetJobsResponse>;
-  getJobs(options: GetJobsOptions, callback: GetJobsCallback): void;
-  getJobs(callback: GetJobsCallback): void;
   /**
    * @callback GetJobsCallback
    * @param {?Error} err Request error, if any.
@@ -1829,6 +1826,9 @@ export class BigQuery extends common.Service {
    * });
    * ```
    */
+  getJobs(options?: GetJobsOptions): Promise<GetJobsResponse>;
+  getJobs(options: GetJobsOptions, callback: GetJobsCallback): void;
+  getJobs(callback: GetJobsCallback): void;
   getJobs(
     optionsOrCallback?: GetJobsOptions | GetJobsCallback,
     cb?: GetJobsCallback
@@ -1890,20 +1890,6 @@ export class BigQuery extends common.Service {
     return new Job(this, id, options);
   }
 
-  query(query: string, options?: QueryOptions): Promise<QueryRowsResponse>;
-  query(query: Query, options?: QueryOptions): Promise<SimpleQueryRowsResponse>;
-  query(
-    query: string,
-    options: QueryOptions,
-    callback?: QueryRowsCallback
-  ): void;
-  query(
-    query: Query,
-    options: QueryOptions,
-    callback?: SimpleQueryRowsCallback
-  ): void;
-  query(query: string, callback?: QueryRowsCallback): void;
-  query(query: Query, callback?: SimpleQueryRowsCallback): void;
   /**
    * Run a query scoped to your project. For manual pagination please refer to
    * {@link BigQuery#createQueryJob}.
@@ -2021,6 +2007,20 @@ export class BigQuery extends common.Service {
    * });
    * ```
    */
+  query(query: string, options?: QueryOptions): Promise<QueryRowsResponse>;
+  query(query: Query, options?: QueryOptions): Promise<SimpleQueryRowsResponse>;
+  query(
+    query: string,
+    options: QueryOptions,
+    callback?: QueryRowsCallback
+  ): void;
+  query(
+    query: Query,
+    options: QueryOptions,
+    callback?: SimpleQueryRowsCallback
+  ): void;
+  query(query: string, callback?: QueryRowsCallback): void;
+  query(query: Query, callback?: SimpleQueryRowsCallback): void;
   query(
     query: string | Query,
     optionsOrCallback?:

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -484,8 +484,6 @@ class Dataset extends ServiceObject {
     this.getTablesStream = paginator.streamify<Table>('getTables');
   }
 
-  createQueryJob(options: string | Query): Promise<JobResponse>;
-  createQueryJob(options: string | Query, callback: JobCallback): void;
   /**
    * Run a query as a job. No results are immediately returned. Instead, your
    * callback will be executed with a {@link Job} object that you must
@@ -498,6 +496,8 @@ class Dataset extends ServiceObject {
    * @param {JobCallback} [callback] See {@link BigQuery#createQueryJob} for full documentation of this method.
    * @returns {Promise<JobResponse>} See {@link BigQuery#createQueryJob} for full documentation of this method.
    */
+  createQueryJob(options: string | Query): Promise<JobResponse>;
+  createQueryJob(options: string | Query, callback: JobCallback): void;
   createQueryJob(
     options: string | Query,
     callback?: JobCallback
@@ -544,12 +544,6 @@ class Dataset extends ServiceObject {
     return this.bigQuery.createQueryStream(options);
   }
 
-  createRoutine(id: string, config: RoutineMetadata): Promise<RoutineResponse>;
-  createRoutine(
-    id: string,
-    config: RoutineMetadata,
-    callback: RoutineCallback
-  ): void;
   /**
    * @callback CreateRoutineCallback
    * @param {?Error} err Request error, if any.
@@ -604,6 +598,12 @@ class Dataset extends ServiceObject {
    * const [routine, apiResponse] = await dataset.createRoutine(id, config);
    * ```
    */
+  createRoutine(id: string, config: RoutineMetadata): Promise<RoutineResponse>;
+  createRoutine(
+    id: string,
+    config: RoutineMetadata,
+    callback: RoutineCallback
+  ): void;
   createRoutine(
     id: string,
     config: RoutineMetadata,
@@ -636,13 +636,6 @@ class Dataset extends ServiceObject {
     );
   }
 
-  createTable(id: string, options: TableMetadata): Promise<TableResponse>;
-  createTable(
-    id: string,
-    options: TableMetadata,
-    callback: TableCallback
-  ): void;
-  createTable(id: string, callback: TableCallback): void;
   /**
    * @callback TableCallback
    * @param {?Error} err Request error, if any.
@@ -698,6 +691,13 @@ class Dataset extends ServiceObject {
    * });
    * ```
    */
+  createTable(id: string, options: TableMetadata): Promise<TableResponse>;
+  createTable(
+    id: string,
+    options: TableMetadata,
+    callback: TableCallback
+  ): void;
+  createTable(id: string, callback: TableCallback): void;
   createTable(
     id: string,
     optionsOrCallback?: TableMetadata | TableCallback,
@@ -737,9 +737,6 @@ class Dataset extends ServiceObject {
     );
   }
 
-  delete(options?: DatasetDeleteOptions): Promise<[Metadata]>;
-  delete(options: DatasetDeleteOptions, callback: DeleteCallback): void;
-  delete(callback: DeleteCallback): void;
   /**
    * @callback DeleteCallback
    * @param {?Error} err Request error, if any.
@@ -785,6 +782,9 @@ class Dataset extends ServiceObject {
    * });
    * ```
    */
+  delete(options?: DatasetDeleteOptions): Promise<[Metadata]>;
+  delete(options: DatasetDeleteOptions, callback: DeleteCallback): void;
+  delete(callback: DeleteCallback): void;
   delete(
     optionsOrCallback?: DeleteCallback | DatasetDeleteOptions,
     callback?: DeleteCallback
@@ -808,9 +808,6 @@ class Dataset extends ServiceObject {
     );
   }
 
-  getModels(options?: GetModelsOptions): Promise<GetModelsResponse>;
-  getModels(options: GetModelsOptions, callback: GetModelsCallback): void;
-  getModels(callback: GetModelsCallback): void;
   /**
    * @typedef {object} GetModelsOptions
    * @property {boolean} [autoPaginate=true] Have pagination handled
@@ -888,6 +885,9 @@ class Dataset extends ServiceObject {
    * });
    * ```
    */
+  getModels(options?: GetModelsOptions): Promise<GetModelsResponse>;
+  getModels(options: GetModelsOptions, callback: GetModelsCallback): void;
+  getModels(callback: GetModelsCallback): void;
   getModels(
     optsOrCb?: GetModelsOptions | GetModelsCallback,
     cb?: GetModelsCallback
@@ -924,9 +924,6 @@ class Dataset extends ServiceObject {
     );
   }
 
-  getRoutines(options?: GetRoutinesOptions): Promise<GetRoutinesResponse>;
-  getRoutines(options: GetRoutinesOptions, callback: GetRoutinesCallback): void;
-  getRoutines(callback: GetRoutinesCallback): void;
   /**
    * @typedef {object} GetRoutinesOptions
    * @property {boolean} [autoPaginate=true] Have pagination handled
@@ -1002,6 +999,9 @@ class Dataset extends ServiceObject {
    * const [routines] = await dataset.getRoutines();
    * ```
    */
+  getRoutines(options?: GetRoutinesOptions): Promise<GetRoutinesResponse>;
+  getRoutines(options: GetRoutinesOptions, callback: GetRoutinesCallback): void;
+  getRoutines(callback: GetRoutinesCallback): void;
   getRoutines(
     optsOrCb?: GetRoutinesOptions | GetRoutinesCallback,
     cb?: GetRoutinesCallback
@@ -1038,9 +1038,6 @@ class Dataset extends ServiceObject {
     );
   }
 
-  getTables(options?: GetTablesOptions): Promise<GetTablesResponse>;
-  getTables(options: GetTablesOptions, callback: GetTablesCallback): void;
-  getTables(callback: GetTablesCallback): void;
   /**
    * @typedef {object} GetTablesOptions
    * @property {boolean} [autoPaginate=true] Have pagination handled
@@ -1118,6 +1115,9 @@ class Dataset extends ServiceObject {
    * });
    * ```
    */
+  getTables(options?: GetTablesOptions): Promise<GetTablesResponse>;
+  getTables(options: GetTablesOptions, callback: GetTablesCallback): void;
+  getTables(callback: GetTablesCallback): void;
   getTables(
     optionsOrCallback?: GetTablesOptions | GetTablesCallback,
     cb?: GetTablesCallback
@@ -1183,10 +1183,6 @@ class Dataset extends ServiceObject {
     return new Model(this, id);
   }
 
-  query(options: Query): Promise<QueryRowsResponse>;
-  query(options: string): Promise<QueryRowsResponse>;
-  query(options: Query, callback: SimpleQueryRowsCallback): void;
-  query(options: string, callback: SimpleQueryRowsCallback): void;
   /**
    * Run a query scoped to your dataset.
    *
@@ -1197,6 +1193,10 @@ class Dataset extends ServiceObject {
    * @returns {Promise<SimpleQueryRowsResponse>}
    * @returns {Promise<QueryRowsResponse>} See {@link BigQuery#query} for full documentation of this method.
    */
+  query(options: Query): Promise<QueryRowsResponse>;
+  query(options: string): Promise<QueryRowsResponse>;
+  query(options: Query, callback: SimpleQueryRowsCallback): void;
+  query(options: string, callback: SimpleQueryRowsCallback): void;
   query(
     options: Query | string,
     callback?: SimpleQueryRowsCallback

--- a/src/job.ts
+++ b/src/job.ts
@@ -323,8 +323,6 @@ class Job extends Operation {
     );
   }
 
-  cancel(): Promise<CancelResponse>;
-  cancel(callback: CancelCallback): void;
   /**
    * @callback CancelCallback
    * @param {?Error} err Request error, if any.
@@ -368,6 +366,8 @@ class Job extends Operation {
    * });
    * ```
    */
+  cancel(): Promise<CancelResponse>;
+  cancel(callback: CancelCallback): void;
   cancel(callback?: CancelCallback): void | Promise<CancelResponse> {
     let qs;
 
@@ -385,12 +385,6 @@ class Job extends Operation {
     );
   }
 
-  getQueryResults(options?: QueryResultsOptions): Promise<QueryRowsResponse>;
-  getQueryResults(
-    options: QueryResultsOptions,
-    callback: QueryRowsCallback
-  ): void;
-  getQueryResults(callback: QueryRowsCallback): void;
   /**
    * Get the results of a job.
    *
@@ -465,6 +459,12 @@ class Job extends Operation {
    * });
    * ```
    */
+  getQueryResults(options?: QueryResultsOptions): Promise<QueryRowsResponse>;
+  getQueryResults(
+    options: QueryResultsOptions,
+    callback: QueryRowsCallback
+  ): void;
+  getQueryResults(callback: QueryRowsCallback): void;
   getQueryResults(
     optionsOrCallback?: QueryResultsOptions | QueryRowsCallback,
     cb?: QueryRowsCallback

--- a/src/model.ts
+++ b/src/model.ts
@@ -301,16 +301,6 @@ class Model extends common.ServiceObject {
     this.bigQuery = dataset.bigQuery;
   }
 
-  createExtractJob(
-    destination: string | File,
-    options?: CreateExtractJobOptions
-  ): Promise<JobResponse>;
-  createExtractJob(
-    destination: string | File,
-    options: CreateExtractJobOptions,
-    callback: JobCallback
-  ): void;
-  createExtractJob(destination: string | File, callback: JobCallback): void;
   /**
    * @callback JobCallback
    * @param {?Error} err Request error, if any.
@@ -389,6 +379,16 @@ class Model extends common.ServiceObject {
    */
   createExtractJob(
     destination: string | File,
+    options?: CreateExtractJobOptions
+  ): Promise<JobResponse>;
+  createExtractJob(
+    destination: string | File,
+    options: CreateExtractJobOptions,
+    callback: JobCallback
+  ): void;
+  createExtractJob(destination: string | File, callback: JobCallback): void;
+  createExtractJob(
+    destination: string | File,
     optionsOrCallback?: CreateExtractJobOptions | JobCallback,
     cb?: JobCallback
   ): void | Promise<JobResponse> {
@@ -451,16 +451,6 @@ class Model extends common.ServiceObject {
     this.bigQuery.createJob(body, callback!);
   }
 
-  extract(
-    destination: string | File,
-    options?: CreateExtractJobOptions
-  ): Promise<JobMetadataResponse>;
-  extract(
-    destination: string | File,
-    options: CreateExtractJobOptions,
-    callback?: JobMetadataCallback
-  ): void;
-  extract(destination: string | File, callback?: JobMetadataCallback): void;
   /**
    * @callback JobMetadataCallback
    * @param {?Error} err Request error, if any.
@@ -536,6 +526,16 @@ class Model extends common.ServiceObject {
    * });
    * ```
    */
+  extract(
+    destination: string | File,
+    options?: CreateExtractJobOptions
+  ): Promise<JobMetadataResponse>;
+  extract(
+    destination: string | File,
+    options: CreateExtractJobOptions,
+    callback?: JobMetadataCallback
+  ): void;
+  extract(destination: string | File, callback?: JobMetadataCallback): void;
   extract(
     destination: string | File,
     optionsOrCallback?: CreateExtractJobOptions | JobMetadataCallback,

--- a/src/table.ts
+++ b/src/table.ts
@@ -624,16 +624,6 @@ class Table extends common.ServiceObject {
     return body;
   }
 
-  copy(
-    destination: Table,
-    metadata?: CopyTableMetadata
-  ): Promise<JobMetadataResponse>;
-  copy(
-    destination: Table,
-    metadata: CopyTableMetadata,
-    callback: JobMetadataCallback
-  ): void;
-  copy(destination: Table, callback: JobMetadataCallback): void;
   /**
    * @callback JobMetadataCallback
    * @param {?Error} err Request error, if any.
@@ -694,6 +684,16 @@ class Table extends common.ServiceObject {
    */
   copy(
     destination: Table,
+    metadata?: CopyTableMetadata
+  ): Promise<JobMetadataResponse>;
+  copy(
+    destination: Table,
+    metadata: CopyTableMetadata,
+    callback: JobMetadataCallback
+  ): void;
+  copy(destination: Table, callback: JobMetadataCallback): void;
+  copy(
+    destination: Table,
     metadataOrCallback?: CopyTableMetadata | JobMetadataCallback,
     cb?: JobMetadataCallback
   ): void | Promise<JobMetadataResponse> {
@@ -717,16 +717,6 @@ class Table extends common.ServiceObject {
     );
   }
 
-  copyFrom(
-    sourceTables: Table | Table[],
-    metadata?: CopyTableMetadata
-  ): Promise<JobMetadataResponse>;
-  copyFrom(
-    sourceTables: Table | Table[],
-    metadata: CopyTableMetadata,
-    callback: JobMetadataCallback
-  ): void;
-  copyFrom(sourceTables: Table | Table[], callback: JobMetadataCallback): void;
   /**
    * @callback JobMetadataCallback
    * @param {?Error} err Request error, if any.
@@ -790,6 +780,16 @@ class Table extends common.ServiceObject {
    */
   copyFrom(
     sourceTables: Table | Table[],
+    metadata?: CopyTableMetadata
+  ): Promise<JobMetadataResponse>;
+  copyFrom(
+    sourceTables: Table | Table[],
+    metadata: CopyTableMetadata,
+    callback: JobMetadataCallback
+  ): void;
+  copyFrom(sourceTables: Table | Table[], callback: JobMetadataCallback): void;
+  copyFrom(
+    sourceTables: Table | Table[],
     metadataOrCallback?: CopyTableMetadata | JobMetadataCallback,
     cb?: JobMetadataCallback
   ): void | Promise<JobMetadataResponse> {
@@ -808,16 +808,6 @@ class Table extends common.ServiceObject {
     });
   }
 
-  createCopyJob(
-    destination: Table,
-    metadata?: CreateCopyJobMetadata
-  ): Promise<JobResponse>;
-  createCopyJob(
-    destination: Table,
-    metadata: CreateCopyJobMetadata,
-    callback: JobCallback
-  ): void;
-  createCopyJob(destination: Table, callback: JobCallback): void;
   /**
    * Copy data from one table to another, optionally creating that table.
    *
@@ -873,6 +863,16 @@ class Table extends common.ServiceObject {
    */
   createCopyJob(
     destination: Table,
+    metadata?: CreateCopyJobMetadata
+  ): Promise<JobResponse>;
+  createCopyJob(
+    destination: Table,
+    metadata: CreateCopyJobMetadata,
+    callback: JobCallback
+  ): void;
+  createCopyJob(destination: Table, callback: JobCallback): void;
+  createCopyJob(
+    destination: Table,
     metadataOrCallback?: CreateCopyJobMetadata | JobCallback,
     cb?: JobCallback
   ): void | Promise<JobResponse> {
@@ -921,16 +921,6 @@ class Table extends common.ServiceObject {
     this.bigQuery.createJob(body, callback!);
   }
 
-  createCopyFromJob(
-    source: Table | Table[],
-    metadata?: CopyTableMetadata
-  ): Promise<JobResponse>;
-  createCopyFromJob(
-    source: Table | Table[],
-    metadata: CopyTableMetadata,
-    callback: JobCallback
-  ): void;
-  createCopyFromJob(source: Table | Table[], callback: JobCallback): void;
   /**
    * Copy data from multiple tables into this table.
    *
@@ -993,6 +983,16 @@ class Table extends common.ServiceObject {
    */
   createCopyFromJob(
     source: Table | Table[],
+    metadata?: CopyTableMetadata
+  ): Promise<JobResponse>;
+  createCopyFromJob(
+    source: Table | Table[],
+    metadata: CopyTableMetadata,
+    callback: JobCallback
+  ): void;
+  createCopyFromJob(source: Table | Table[], callback: JobCallback): void;
+  createCopyFromJob(
+    source: Table | Table[],
     metadataOrCallback?: CopyTableMetadata | JobCallback,
     cb?: JobCallback
   ): void | Promise<JobResponse> {
@@ -1046,16 +1046,6 @@ class Table extends common.ServiceObject {
     this.bigQuery.createJob(body, callback!);
   }
 
-  createExtractJob(
-    destination: File,
-    options?: CreateExtractJobOptions
-  ): Promise<JobResponse>;
-  createExtractJob(
-    destination: File,
-    options: CreateExtractJobOptions,
-    callback: JobCallback
-  ): void;
-  createExtractJob(destination: File, callback: JobCallback): void;
   /**
    * Export table to Cloud Storage.
    *
@@ -1139,6 +1129,16 @@ class Table extends common.ServiceObject {
    */
   createExtractJob(
     destination: File,
+    options?: CreateExtractJobOptions
+  ): Promise<JobResponse>;
+  createExtractJob(
+    destination: File,
+    options: CreateExtractJobOptions,
+    callback: JobCallback
+  ): void;
+  createExtractJob(destination: File, callback: JobCallback): void;
+  createExtractJob(
+    destination: File,
     optionsOrCallback?: CreateExtractJobOptions | JobCallback,
     cb?: JobCallback
   ): void | Promise<JobResponse> {
@@ -1214,16 +1214,6 @@ class Table extends common.ServiceObject {
     this.bigQuery.createJob(body, callback!);
   }
 
-  createLoadJob(
-    source: string | File,
-    metadata?: JobLoadMetadata
-  ): Promise<JobResponse>;
-  createLoadJob(
-    source: string | File,
-    metadata: JobLoadMetadata,
-    callback: JobCallback
-  ): void;
-  createLoadJob(source: string | File, callback: JobCallback): void;
   /**
    * Load data from a local file or Storage {@link
    * https://googleapis.dev/nodejs/storage/latest/File.html File}.
@@ -1313,6 +1303,16 @@ class Table extends common.ServiceObject {
    * });
    * ```
    */
+  createLoadJob(
+    source: string | File,
+    metadata?: JobLoadMetadata
+  ): Promise<JobResponse>;
+  createLoadJob(
+    source: string | File,
+    metadata: JobLoadMetadata,
+    callback: JobCallback
+  ): void;
+  createLoadJob(source: string | File, callback: JobCallback): void;
   createLoadJob(
     source: string | File | File[],
     metadataOrCallback?: JobLoadMetadata | JobCallback,
@@ -1424,8 +1424,6 @@ class Table extends common.ServiceObject {
     return this.bigQuery.createJob(body);
   }
 
-  createQueryJob(options: Query): Promise<JobResponse>;
-  createQueryJob(options: Query, callback: JobCallback): void;
   /**
    * Run a query as a job. No results are immediately returned. Instead, your
    * callback will be executed with a {@link Job} object that you must
@@ -1434,6 +1432,8 @@ class Table extends common.ServiceObject {
    *
    * See {@link BigQuery#createQueryJob} for full documentation of this method.
    */
+  createQueryJob(options: Query): Promise<JobResponse>;
+  createQueryJob(options: Query, callback: JobCallback): void;
   createQueryJob(
     options: Query,
     callback?: JobCallback
@@ -1620,16 +1620,6 @@ class Table extends common.ServiceObject {
     return stream;
   }
 
-  extract(
-    destination: File,
-    options?: CreateExtractJobOptions
-  ): Promise<JobMetadataResponse>;
-  extract(
-    destination: File,
-    options: CreateExtractJobOptions,
-    callback?: JobMetadataCallback
-  ): void;
-  extract(destination: File, callback?: JobMetadataCallback): void;
   /**
    * Export table to Cloud Storage.
    *
@@ -1703,6 +1693,16 @@ class Table extends common.ServiceObject {
    */
   extract(
     destination: File,
+    options?: CreateExtractJobOptions
+  ): Promise<JobMetadataResponse>;
+  extract(
+    destination: File,
+    options: CreateExtractJobOptions,
+    callback?: JobMetadataCallback
+  ): void;
+  extract(destination: File, callback?: JobMetadataCallback): void;
+  extract(
+    destination: File,
     optionsOrCallback?: CreateExtractJobOptions | JobMetadataCallback,
     cb?: JobMetadataCallback
   ): void | Promise<JobMetadataResponse> {
@@ -1721,9 +1721,6 @@ class Table extends common.ServiceObject {
     });
   }
 
-  getRows(options?: GetRowsOptions): Promise<RowsResponse>;
-  getRows(options: GetRowsOptions, callback: RowsCallback): void;
-  getRows(callback: RowsCallback): void;
   /**
    * @callback RowsCallback
    * @param {?Error} err Request error, if any.
@@ -1734,6 +1731,9 @@ class Table extends common.ServiceObject {
    * @typedef {array} RowsResponse
    * @property {array} 0 The rows.
    */
+  getRows(options?: GetRowsOptions): Promise<RowsResponse>;
+  getRows(options: GetRowsOptions, callback: RowsCallback): void;
+  getRows(callback: RowsCallback): void;
 
   /**
    * Retrieves table data from a specified set of rows. The rows are returned to
@@ -1862,16 +1862,6 @@ class Table extends common.ServiceObject {
     );
   }
 
-  insert(
-    rows: RowMetadata | RowMetadata[],
-    options?: InsertRowsOptions
-  ): Promise<InsertRowsResponse>;
-  insert(
-    rows: RowMetadata | RowMetadata[],
-    options: InsertRowsOptions,
-    callback: InsertRowsCallback
-  ): void;
-  insert(rows: RowMetadata | RowMetadata[], callback: InsertRowsCallback): void;
   /**
    * @callback InsertRowsCallback
    * @param {?Error} err Request error, if any.
@@ -2022,6 +2012,16 @@ class Table extends common.ServiceObject {
    *   });
    * ```
    */
+  insert(
+    rows: RowMetadata | RowMetadata[],
+    options?: InsertRowsOptions
+  ): Promise<InsertRowsResponse>;
+  insert(
+    rows: RowMetadata | RowMetadata[],
+    options: InsertRowsOptions,
+    callback: InsertRowsCallback
+  ): void;
+  insert(rows: RowMetadata | RowMetadata[], callback: InsertRowsCallback): void;
   insert(
     rows: RowMetadata | RowMetadata[],
     optionsOrCallback?: InsertRowsOptions | InsertRowsCallback,
@@ -2193,16 +2193,6 @@ class Table extends common.ServiceObject {
     return resp;
   }
 
-  load(
-    source: string | File,
-    metadata?: JobLoadMetadata
-  ): Promise<JobMetadataResponse>;
-  load(
-    source: string | File,
-    metadata: JobLoadMetadata,
-    callback: JobMetadataCallback
-  ): void;
-  load(source: string | File, callback: JobMetadataCallback): void;
   /**
    * Load data from a local file or Storage {@link
    * https://googleapis.dev/nodejs/storage/latest/File.html File}.
@@ -2285,6 +2275,16 @@ class Table extends common.ServiceObject {
    */
   load(
     source: string | File,
+    metadata?: JobLoadMetadata
+  ): Promise<JobMetadataResponse>;
+  load(
+    source: string | File,
+    metadata: JobLoadMetadata,
+    callback: JobMetadataCallback
+  ): void;
+  load(source: string | File, callback: JobMetadataCallback): void;
+  load(
+    source: string | File,
     metadataOrCallback?: JobLoadMetadata | JobMetadataCallback,
     cb?: JobMetadataCallback
   ): void | Promise<JobMetadataResponse> {
@@ -2305,9 +2305,6 @@ class Table extends common.ServiceObject {
     });
   }
 
-  query(query: Query): Promise<SimpleQueryRowsResponse>;
-  query(query: string): Promise<SimpleQueryRowsResponse>;
-  query(query: Query, callback: SimpleQueryRowsCallback): void;
   /**
    * Run a query scoped to your dataset.
    *
@@ -2316,6 +2313,9 @@ class Table extends common.ServiceObject {
    * @param {function} [callback] See {@link BigQuery#query} for full documentation of this method.
    * @returns {Promise<SimpleQueryRowsResponse>}
    */
+  query(query: Query): Promise<SimpleQueryRowsResponse>;
+  query(query: string): Promise<SimpleQueryRowsResponse>;
+  query(query: Query, callback: SimpleQueryRowsCallback): void;
   query(
     query: Query | string,
     callback?: SimpleQueryRowsCallback
@@ -2328,13 +2328,6 @@ class Table extends common.ServiceObject {
     this.dataset.query(query, callback!);
   }
 
-  setMetadata(
-    metadata: SetTableMetadataOptions
-  ): Promise<common.SetMetadataResponse>;
-  setMetadata(
-    metadata: SetTableMetadataOptions,
-    callback: common.ResponseCallback
-  ): void;
   /**
    * Set the metadata on the table.
    *
@@ -2381,6 +2374,13 @@ class Table extends common.ServiceObject {
    * ```
    */
   setMetadata(
+    metadata: SetTableMetadataOptions
+  ): Promise<common.SetMetadataResponse>;
+  setMetadata(
+    metadata: SetTableMetadataOptions,
+    callback: common.ResponseCallback
+  ): void;
+  setMetadata(
     metadata: SetTableMetadataOptions,
     callback?: common.ResponseCallback
   ): void | Promise<common.SetMetadataResponse> {
@@ -2388,14 +2388,14 @@ class Table extends common.ServiceObject {
     super.setMetadata(body, callback!);
   }
 
-  getIamPolicy(
-    optionsOrCallback?: GetPolicyOptions | PolicyCallback
-  ): Promise<PolicyResponse>;
-  getIamPolicy(options: GetPolicyOptions, callback: PolicyCallback): void;
   /**
    * Run a query scoped to your dataset.
    * @returns {Promise<PolicyResponse>}
    */
+  getIamPolicy(
+    optionsOrCallback?: GetPolicyOptions | PolicyCallback
+  ): Promise<PolicyResponse>;
+  getIamPolicy(options: GetPolicyOptions, callback: PolicyCallback): void;
   getIamPolicy(
     optionsOrCallback?: GetPolicyOptions,
     cb?: PolicyCallback
@@ -2430,6 +2430,10 @@ class Table extends common.ServiceObject {
     );
   }
 
+  /**
+   * Run a query scoped to your dataset.
+   * @returns {Promise<PolicyResponse>}
+   */
   setIamPolicy(
     policy: Policy,
     options?: SetPolicyOptions
@@ -2440,10 +2444,6 @@ class Table extends common.ServiceObject {
     callback: PolicyCallback
   ): void;
   setIamPolicy(policy: Policy, callback: PolicyCallback): void;
-  /**
-   * Run a query scoped to your dataset.
-   * @returns {Promise<PolicyResponse>}
-   */
   setIamPolicy(
     policy: Policy,
     optionsOrCallback?: SetPolicyOptions | PolicyCallback,
@@ -2476,6 +2476,10 @@ class Table extends common.ServiceObject {
     );
   }
 
+  /**
+   * Run a query scoped to your dataset.
+   * @returns {Promise<PermissionsResponse>}
+   */
   testIamPermissions(
     permissions: string | string[]
   ): Promise<PermissionsResponse>;
@@ -2483,10 +2487,6 @@ class Table extends common.ServiceObject {
     permissions: string | string[],
     callback: PermissionsCallback
   ): void;
-  /**
-   * Run a query scoped to your dataset.
-   * @returns {Promise<PermissionsResponse>}
-   */
   testIamPermissions(
     permissions: string | string[],
     callback?: PermissionsCallback


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js
