### PR TITLE
fix: refactor to extract options from query

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2057,7 +2057,7 @@ export class BigQuery extends common.Service {
    */
   queryAsStream_(query: Query, callback?: SimpleQueryRowsCallback) {
     if (query.job) {
-      query.job!.getQueryResults(query, callback as QueryRowsCallback);
+      query.job.getQueryResults(query, callback as QueryRowsCallback);
       return;
     }
 

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2055,28 +2055,28 @@ export class BigQuery extends common.Service {
    *
    * @private
    */
-  queryAsStream_(
-    query: Query,
-    optionsOrCallback?: QueryStreamOptions,
-    cb?: SimpleQueryRowsCallback
-  ) {
-    let options =
-      // Default to using query as options to ensure the options set
-      // in a Query type are passed through to the query() method.
-      typeof optionsOrCallback === 'object' ? optionsOrCallback : query;
-    const callback =
-      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
-
-    options = query.job
-      ? extend(query, options)
-      : extend(options, {autoPaginate: false});
-
+  queryAsStream_(query: Query, callback?: SimpleQueryRowsCallback) {
     if (query.job) {
-      query.job!.getQueryResults(options, callback as QueryRowsCallback);
+      query.job!.getQueryResults(query, callback as QueryRowsCallback);
       return;
     }
 
-    this.query(query, options, callback);
+    const {location, maxResults, pageToken, wrapIntegers} = query;
+
+    const opts = {
+      location,
+      maxResults,
+      pageToken,
+      wrapIntegers,
+      autoPaginate: false,
+    };
+
+    delete query.location;
+    delete query.maxResults;
+    delete query.pageToken;
+    delete query.wrapIntegers;
+
+    this.query(query, opts, callback);
   }
 }
 

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -2706,6 +2706,13 @@ describe('BigQuery', () => {
 
   describe('queryAsStream_', () => {
     let queryStub: SinonStub;
+    let defaultOpts = {
+      location: undefined,
+      maxResults: undefined,
+      pageToken: undefined,
+      wrapIntegers: undefined,
+      autoPaginate: false,
+    };
 
     beforeEach(() => {
       queryStub = sandbox.stub(bq, 'query').callsArgAsync(2);
@@ -2715,23 +2722,16 @@ describe('BigQuery', () => {
       const query = 'SELECT';
       bq.queryAsStream_(query, done);
       assert(
-        queryStub.calledOnceWithExactly(
-          query,
-          {autoPaginate: false},
-          sinon.match.func
-        )
+        queryStub.calledOnceWithExactly(query, defaultOpts, sinon.match.func)
       );
     });
 
     it('should call query correctly with a Query object', done => {
       const query = {query: 'SELECT', wrapIntegers: true};
       bq.queryAsStream_(query, done);
+      defaultOpts = extend(defaultOpts, {wrapIntegers: true});
       assert(
-        queryStub.calledOnceWithExactly(
-          query,
-          extend(query, {autoPaginate: false}),
-          sinon.match.func
-        )
+        queryStub.calledOnceWithExactly(query, defaultOpts, sinon.match.func)
       );
     });
 
@@ -2748,22 +2748,20 @@ describe('BigQuery', () => {
     });
 
     it('should pass wrapIntegers if supplied', done => {
-      const statement = 'SELECT';
+      const wrapIntegers = {
+        integerValue: 100,
+      };
       const query = {
-        query: statement,
+        query: 'SELECT',
+        wrapIntegers,
       };
-      const options = {
-        wrapIntegers: {
-          integerValue: 100,
-        },
-      };
-      bq.queryAsStream_(query, options, done);
+
+      bq.queryAsStream_(query, done);
+
+      defaultOpts = extend(defaultOpts, {wrapIntegers});
+
       assert(
-        queryStub.calledOnceWithExactly(
-          query,
-          {autoPaginate: false, wrapIntegers: options.wrapIntegers},
-          sinon.match.func
-        )
+        queryStub.calledOnceWithExactly(query, defaultOpts, sinon.match.func)
       );
     });
   });


### PR DESCRIPTION
Updates queryAsStream_ to pass only necessary properties as options rather than entire query object.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1043  🦕
