### PR TITLE
feat: add support for accessing jobs cross-project

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -66,6 +66,7 @@ export type JobRequest<J> = J & {
   jobId?: string;
   jobPrefix?: string;
   location?: string;
+  projectId?: string;
 };
 
 export type PagedRequest<P> = P & {

--- a/src/job.ts
+++ b/src/job.ts
@@ -124,6 +124,7 @@ export type QueryResultsOptions = {
 class Job extends Operation {
   bigQuery: BigQuery;
   location?: string;
+  projectId?: string;
   getQueryResultsStream(
     options?: QueryResultsOptions
   ): ResourceStream<RowMetadata> {
@@ -342,6 +343,10 @@ class Job extends Operation {
 
     if (options && options.location) {
       this.location = options.location;
+    }
+
+    if (options?.projectId) {
+      this.projectId = options.projectId;
     }
 
     /**

--- a/test/job.ts
+++ b/test/job.ts
@@ -73,7 +73,7 @@ const fakePaginator = {
 
 const sandbox = sinon.createSandbox();
 
-describe.only('BigQuery/Job', () => {
+describe('BigQuery/Job', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const BIGQUERY: any = {
     projectId: 'my-project',

--- a/test/job.ts
+++ b/test/job.ts
@@ -73,7 +73,7 @@ const fakePaginator = {
 
 const sandbox = sinon.createSandbox();
 
-describe('BigQuery/Job', () => {
+describe.only('BigQuery/Job', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const BIGQUERY: any = {
     projectId: 'my-project',
@@ -145,6 +145,13 @@ describe('BigQuery/Job', () => {
       const job = new Job(BIGQUERY, JOB_ID, options);
 
       assert.strictEqual(job.location, options.location);
+    });
+
+    it('should accept a projectId option', () => {
+      const options = {projectId: 'cool-project'};
+      const job = new Job(BIGQUERY, JOB_ID, options);
+
+      assert.strictEqual(job.projectId, options.projectId);
     });
 
     it('should send the location via getMetadata', () => {


### PR DESCRIPTION
Adds the ability for user to provide projectId option in order to access Job resources in other projects to which they have been granted access.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1030  🦕
