### PR TITLE
fix: call rowQueue insert callback only if present

### DIFF
--- a/src/rowQueue.ts
+++ b/src/rowQueue.ts
@@ -194,9 +194,9 @@ export class RowQueue {
         } else {
           callbacks.forEach(callback => callback!(err, resp));
           this.stream.emit('response', resp);
-          cb!(err, resp);
+          cb?.(err, resp);
         }
-        cb!(err, resp);
+        cb?.(err, resp);
       }
     );
   }


### PR DESCRIPTION
This fixes issue where callback is called even if it's not present. 

Issue happens when using `table.createInsertStream()` and after success/failure callback is being called, but it's not passed in `roqQueue.add` method.