### PR TITLE
testing: double the timeout for the installation test (40s->80s).

### DIFF
--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -45,5 +45,5 @@ describe('Installation test', () => {
     await mvp(tarball, `${stagingPath}/google-cloud-bigquery.tgz`);
     await ncpp('system-test/fixtures/kitchen', `${stagingPath}/`);
     await execa('npm', ['install'], {cwd: `${stagingPath}/`, stdio: 'inherit'});
-  }).timeout(40000);
+  }).timeout(80000);
 });


### PR DESCRIPTION
We're getting flakes related to timeout, so bumping this up to accomodate slower resolution for commands like `npm install`.

Fixes: https://github.com/googleapis/nodejs-bigquery/issues/1181
