### PR TITLE
testing: sync system test dependencies with package

### DIFF
--- a/system-test/fixtures/kitchen/package.json
+++ b/system-test/fixtures/kitchen/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^3.0.0",
-    "gts": "^3.0.0"
+    "typescript": "^4.6.4",
+    "gts": "^3.1.0"
   }
 }


### PR DESCRIPTION
System test package.json file is not updated with renovate bot and was using an outdated/incompatible version of Typescript. This PR updates the given package.json file to have the dependencies in sync with the library itself.

Fixes: https://github.com/googleapis/nodejs-bigquery/issues/1181