### PR TITLE
fix: pass Query.wrapIntegers to job.getQueryResults

### DIFF
--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -75,7 +75,7 @@ describe('Datasets', () => {
       error = err;
     }
     assert.isNotNull(error);
-    assert.equal(error.message, 'Invalid storage region');
+    assert.include(error.message, 'Invalid storage region');
   });
 
   it('should create/update a dataset with a different default collation', async () => {

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -927,7 +927,7 @@ export class BigQuery extends Service {
           'value ' +
           value.integerValue +
           " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-          "To prevent this error, please consider passing 'options.wrapNumbers' as\n" +
+          "To prevent this error, please consider passing 'options.wrapIntegers' as\n" +
           '{\n' +
           '  integerTypeCastFunction: provide <your_custom_function>\n' +
           '  fields: optionally specify field name(s) to be custom casted\n' +
@@ -2024,6 +2024,12 @@ export class BigQuery extends Service {
   ): void | Promise<SimpleQueryRowsResponse> | Promise<QueryRowsResponse> {
     let options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+    const queryOpts =
+      typeof query === 'object'
+        ? {
+            wrapIntegers: query.wrapIntegers,
+          }
+        : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
     this.createQueryJob(query, (err, job, resp) => {
@@ -2037,7 +2043,7 @@ export class BigQuery extends Service {
       }
       // The Job is important for the `queryAsStream_` method, so a new query
       // isn't created each time results are polled for.
-      options = extend({job}, options);
+      options = extend({job}, queryOpts, options);
       job!.getQueryResults(options, callback as QueryRowsCallback);
     });
   }
@@ -2248,7 +2254,6 @@ export class BigQueryInt extends Number {
         throw error;
       }
     } else {
-      // return this.value;
       return BigQuery.decodeIntegerValue_({
         integerValue: this.value,
         schemaFieldName: this._schemaFieldName,

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -907,7 +907,7 @@ describe('BigQuery', () => {
               'value ' +
               opts.integerValue +
               " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-              "To prevent this error, please consider passing 'options.wrapNumbers' as\n" +
+              "To prevent this error, please consider passing 'options.wrapIntegers' as\n" +
               '{\n' +
               '  integerTypeCastFunction: provide <your_custom_function>\n' +
               '  fields: optionally specify field name(s) to be custom casted\n' +
@@ -2695,6 +2695,35 @@ describe('BigQuery', () => {
 
       bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
         assert.ifError(err);
+        assert.strictEqual(rows, FAKE_ROWS);
+        assert.strictEqual(resp, FAKE_RESPONSE);
+        done();
+      });
+    });
+
+    it('should call job#getQueryResults with query options', done => {
+      let queryResultsOpts = {};
+      const fakeJob = {
+        getQueryResults: (options: {}, callback: Function) => {
+          queryResultsOpts = options;
+          callback(null, FAKE_ROWS, FAKE_RESPONSE);
+        },
+      };
+
+      bq.createQueryJob = (query: {}, callback: Function) => {
+        callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      const query = {
+        query: QUERY_STRING,
+        wrapIntegers: true,
+      };
+      bq.query(query, (err: Error, rows: {}, resp: {}) => {
+        assert.ifError(err);
+        assert.deepEqual(queryResultsOpts, {
+          job: fakeJob,
+          wrapIntegers: true,
+        });
         assert.strictEqual(rows, FAKE_ROWS);
         assert.strictEqual(resp, FAKE_RESPONSE);
         done();


### PR DESCRIPTION
`Query.wrapIntegers` was being ignored and not passed to `job.getQueryResults` when used in `bigquery.query`. 
