### PR TITLE
chore: remove autoassignment

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,0 @@
-assign_issues:
-  - loferris
-assign_prs:
-  - loferris


### PR DESCRIPTION
We use a common triage across the BQ SDK team, and auto-assigning to a specific user conflicts with that.  Removes blunderbuss rules forcing issues to be assigned to a specific contributor.