### PR TITLE
chore(deps): remove readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "extend": "^3.0.2",
     "is": "^3.3.0",
     "p-event": "^4.1.0",
-    "readable-stream": "^4.0.0",
     "stream-events": "^1.0.5",
     "uuid": "^9.0.0"
   },

--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -174,16 +174,16 @@ describe('Datasets', () => {
     );
 
     for (const dataset of datasets) {
-      try {
-        const [metadata] = await dataset.getMetadata();
-        const creationTime = Number(metadata.creationTime);
+      const [metadata] = await dataset.getMetadata();
+      const creationTime = Number(metadata.creationTime);
 
-        if (isResourceStale(creationTime)) {
+      if (isResourceStale(creationTime)) {
+        try {
           await dataset.delete({force: true});
+        } catch (e) {
+          console.log(`dataset(${dataset.id}).delete() failed`);
+          console.log(e);
         }
-      } catch (e) {
-        console.log(`dataset(${dataset.id}).delete() failed`);
-        console.log(e);
       }
     }
   }

--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -174,16 +174,16 @@ describe('Datasets', () => {
     );
 
     for (const dataset of datasets) {
-      const [metadata] = await dataset.getMetadata();
-      const creationTime = Number(metadata.creationTime);
+      try {
+        const [metadata] = await dataset.getMetadata();
+        const creationTime = Number(metadata.creationTime);
 
-      if (isResourceStale(creationTime)) {
-        try {
+        if (isResourceStale(creationTime)) {
           await dataset.delete({force: true});
-        } catch (e) {
-          console.log(`dataset(${dataset.id}).delete() failed`);
-          console.log(e);
         }
+      } catch (e) {
+        console.log(`dataset(${dataset.id}).delete() failed`);
+        console.log(e);
       }
     }
   }

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -23,7 +23,7 @@ import {describe, it, before, after} from 'mocha';
 import Big from 'big.js';
 import * as fs from 'fs';
 import * as uuid from 'uuid';
-import { Readable } from 'stream';
+import {Readable} from 'stream';
 
 import {
   BigQuery,

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -23,7 +23,7 @@ import {describe, it, before, after} from 'mocha';
 import Big from 'big.js';
 import * as fs from 'fs';
 import * as uuid from 'uuid';
-const Readable = require('readable-stream').Readable;
+import { Readable } from 'stream';
 
 import {
   BigQuery,
@@ -854,7 +854,7 @@ describe('BigQuery', () => {
     });
 
     it('should insert rows via insert stream', done => {
-      const stream = Readable({objectMode: true});
+      const stream = new Readable({objectMode: true});
       stream._read = () => {};
 
       for (let i = 0; i < 10; i++) {
@@ -873,7 +873,7 @@ describe('BigQuery', () => {
     });
 
     it('should return errors from insert stream', done => {
-      const stream = Readable({objectMode: true});
+      const stream = new Readable({objectMode: true});
       stream._read = () => {};
 
       stream.push({wrong_name: 'foo', id: 1});

--- a/test/table.ts
+++ b/test/table.ts
@@ -42,7 +42,7 @@ import {
   ViewDefinition,
 } from '../src/table';
 import bigquery from '../src/types';
-import {Duplex, Stream} from 'stream';
+import {Duplex} from 'stream';
 import {RowQueue} from '../src/rowQueue';
 
 interface CalledWithTable extends ServiceObject {


### PR DESCRIPTION
Remove `readable-stream` as was being used only on system-tests and it can actually be imported from the native `streams` package.

Fixes #1200  🦕
