### PR TITLE
test: parallel tests can error on already deleted dataset

### DIFF
--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -174,7 +174,7 @@ describe('Datasets', () => {
     );
 
     for (const dataset of datasets) {
-      let metadata
+      let metadata;
       try {
         [metadata] = await dataset.getMetadata();
       } catch (e) {
@@ -182,14 +182,14 @@ describe('Datasets', () => {
         console.log(e);
         return;
       }
-      try {
-        const creationTime = Number(metadata.creationTime);
-        if (isResourceStale(creationTime)) {
+      const creationTime = Number(metadata.creationTime);
+      if (isResourceStale(creationTime)) {
+        try {
           await dataset.delete({force: true});
+        } catch (e) {
+          console.log(`dataset(${dataset.id}).delete() failed`);
+          console.log(e);
         }
-      } catch (e) {
-        console.log(`dataset(${dataset.id}).delete() failed`);
-        console.log(e);
       }
     }
   }

--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -174,10 +174,16 @@ describe('Datasets', () => {
     );
 
     for (const dataset of datasets) {
+      let metadata
       try {
-        const [metadata] = await dataset.getMetadata();
+        [metadata] = await dataset.getMetadata();
+      } catch (e) {
+        console.log(`dataset(${dataset.id}).getMetadata() failed`);
+        console.log(e);
+        return;
+      }
+      try {
         const creationTime = Number(metadata.creationTime);
-
         if (isResourceStale(creationTime)) {
           await dataset.delete({force: true});
         }

--- a/samples/test/datasets.test.js
+++ b/samples/test/datasets.test.js
@@ -174,16 +174,16 @@ describe('Datasets', () => {
     );
 
     for (const dataset of datasets) {
-      const [metadata] = await dataset.getMetadata();
-      const creationTime = Number(metadata.creationTime);
+      try {
+        const [metadata] = await dataset.getMetadata();
+        const creationTime = Number(metadata.creationTime);
 
-      if (isResourceStale(creationTime)) {
-        try {
+        if (isResourceStale(creationTime)) {
           await dataset.delete({force: true});
-        } catch (e) {
-          console.log(`dataset(${dataset.id}).delete() failed`);
-          console.log(e);
         }
+      } catch (e) {
+        console.log(`dataset(${dataset.id}).delete() failed`);
+        console.log(e);
       }
     }
   }


### PR DESCRIPTION
`samples-test` fail sometimes when datasets were already deleted by another process ( in this case system tests ) running in parallel.

Example:
[build #703](https://source.cloud.google.com/results/invocations/63e650e8-01a8-4fc5-967c-537563f50fe9/targets)