### PR TITLE
fix: prefer usage of projectId from the Dataset

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1420,7 +1420,7 @@ export class BigQuery extends Service {
 
       query.destinationTable = {
         datasetId: options.destination.dataset.id,
-        projectId: options.destination.dataset.bigQuery.projectId,
+        projectId: options.destination.dataset.projectId,
         tableId: options.destination.id,
       };
 

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -123,7 +123,7 @@ export type TableCallback = ResourceCallback<Table, bigquery.ITable>;
 class Dataset extends ServiceObject {
   bigQuery: BigQuery;
   location?: string;
-  projectId?: string;
+  projectId: string;
   getModelsStream(options?: GetModelsOptions): ResourceStream<Model> {
     // placeholder body, overwritten in constructor
     return new ResourceStream<Model>({}, () => {});
@@ -389,6 +389,8 @@ class Dataset extends ServiceObject {
 
     if (options?.projectId) {
       this.projectId = options.projectId;
+    } else {
+      this.projectId = bigQuery.projectId;
     }
 
     this.bigQuery = bigQuery;
@@ -740,7 +742,7 @@ class Dataset extends ServiceObject {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (body as any).tableReference = {
       datasetId: this.id,
-      projectId: this.bigQuery.projectId,
+      projectId: this.projectId,
       tableId: id,
     };
 
@@ -1303,6 +1305,7 @@ class Dataset extends ServiceObject {
     options = extend(
       {
         location: this.location,
+        projectId: this.projectId,
       },
       options
     );

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -644,7 +644,7 @@ class Dataset extends ServiceObject {
       routineReference: {
         routineId: id,
         datasetId: this.id,
-        projectId: this.bigQuery.projectId,
+        projectId: this.projectId,
       },
     });
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -430,7 +430,7 @@ class Model extends ServiceObject {
         extract: extend(true, options, {
           sourceModel: {
             datasetId: this.dataset.id,
-            projectId: this.bigQuery.projectId,
+            projectId: this.dataset.projectId,
             modelId: this.id,
           },
         }),

--- a/src/table.ts
+++ b/src/table.ts
@@ -929,12 +929,12 @@ class Table extends ServiceObject {
         copy: extend(true, metadata, {
           destinationTable: {
             datasetId: destination.dataset.id,
-            projectId: destination.bigQuery.projectId,
+            projectId: destination.dataset.projectId,
             tableId: destination.id,
           },
           sourceTable: {
             datasetId: this.dataset.id,
-            projectId: this.bigQuery.projectId,
+            projectId: this.dataset.projectId,
             tableId: this.id,
           },
         }),
@@ -1051,14 +1051,14 @@ class Table extends ServiceObject {
         copy: extend(true, metadata, {
           destinationTable: {
             datasetId: this.dataset.id,
-            projectId: this.bigQuery.projectId,
+            projectId: this.dataset.projectId,
             tableId: this.id,
           },
 
           sourceTables: sourceTables.map(sourceTable => {
             return {
               datasetId: sourceTable.dataset.id,
-              projectId: sourceTable.bigQuery.projectId,
+              projectId: sourceTable.dataset.projectId,
               tableId: sourceTable.id,
             };
           }),
@@ -1224,7 +1224,7 @@ class Table extends ServiceObject {
         extract: extend(true, options, {
           sourceTable: {
             datasetId: this.dataset.id,
-            projectId: this.bigQuery.projectId,
+            projectId: this.dataset.projectId,
             tableId: this.id,
           },
         }),
@@ -1404,7 +1404,7 @@ class Table extends ServiceObject {
       configuration: {
         load: {
           destinationTable: {
-            projectId: this.bigQuery.projectId,
+            projectId: this.dataset.projectId,
             datasetId: this.dataset.id,
             tableId: this.id,
           },
@@ -1510,7 +1510,7 @@ class Table extends ServiceObject {
       true,
       {
         destinationTable: {
-          projectId: this.bigQuery.projectId,
+          projectId: this.dataset.projectId,
           datasetId: this.dataset.id,
           tableId: this.id,
         },
@@ -1542,12 +1542,12 @@ class Table extends ServiceObject {
             },
             jobReference: {
               jobId,
-              projectId: this.bigQuery.projectId,
+              projectId: this.dataset.projectId,
               location: this.location,
             },
           } as {},
           request: {
-            uri: `${this.bigQuery.apiEndpoint}/upload/bigquery/v2/projects/${this.bigQuery.projectId}/jobs`,
+            uri: `${this.bigQuery.apiEndpoint}/upload/bigquery/v2/projects/${this.dataset.projectId}/jobs`,
           },
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -1977,7 +1977,7 @@ describe('BigQuery', () => {
             reqOpts.json.configuration.query.destinationTable,
             {
               datasetId: dataset.id,
-              projectId: dataset.bigQuery.projectId,
+              projectId: dataset.projectId,
               tableId: TABLE_ID,
             }
           );

--- a/test/model.ts
+++ b/test/model.ts
@@ -56,9 +56,9 @@ describe('BigQuery/Model', () => {
 
   const DATASET = {
     id: 'dataset-id',
+    projectId: 'project-id',
     createTable: util.noop,
     bigQuery: {
-      projectId: 'project-id',
       job: (id: string) => {
         return {id};
       },
@@ -137,7 +137,7 @@ describe('BigQuery/Model', () => {
       model.bigQuery.createJob = (reqOpts: JobOptions) => {
         assert.deepStrictEqual(reqOpts.configuration!.extract!.sourceModel, {
           datasetId: model.dataset.id,
-          projectId: model.bigQuery.projectId,
+          projectId: model.dataset.projectId,
           modelId: model.id,
         });
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -173,9 +173,9 @@ describe('BigQuery/Table', () => {
 
   const DATASET = {
     id: 'dataset-id',
+    projectId: 'project-id',
     createTable: util.noop,
     bigQuery: {
-      projectId: 'project-id',
       job: (id: string) => {
         return {id};
       },
@@ -721,12 +721,12 @@ describe('BigQuery/Table', () => {
               c: 'd',
               destinationTable: {
                 datasetId: DEST_TABLE.dataset.id,
-                projectId: DEST_TABLE.bigQuery.projectId,
+                projectId: DEST_TABLE.dataset.projectId,
                 tableId: DEST_TABLE.id,
               },
               sourceTable: {
                 datasetId: table.dataset.id,
-                projectId: table.bigQuery.projectId,
+                projectId: table.dataset.projectId,
                 tableId: table.id,
               },
             },
@@ -842,13 +842,13 @@ describe('BigQuery/Table', () => {
               c: 'd',
               destinationTable: {
                 datasetId: table.dataset.id,
-                projectId: table.bigQuery.projectId,
+                projectId: table.dataset.projectId,
                 tableId: table.id,
               },
               sourceTables: [
                 {
                   datasetId: SOURCE_TABLE.dataset.id,
-                  projectId: SOURCE_TABLE.bigQuery.projectId,
+                  projectId: SOURCE_TABLE.dataset.projectId,
                   tableId: SOURCE_TABLE.id,
                 },
               ],
@@ -867,12 +867,12 @@ describe('BigQuery/Table', () => {
         assert.deepStrictEqual(reqOpts.configuration!.copy!.sourceTables, [
           {
             datasetId: SOURCE_TABLE.dataset.id,
-            projectId: SOURCE_TABLE.bigQuery.projectId,
+            projectId: SOURCE_TABLE.dataset.projectId,
             tableId: SOURCE_TABLE.id,
           },
           {
             datasetId: SOURCE_TABLE.dataset.id,
-            projectId: SOURCE_TABLE.bigQuery.projectId,
+            projectId: SOURCE_TABLE.dataset.projectId,
             tableId: SOURCE_TABLE.id,
           },
         ]);
@@ -1002,7 +1002,7 @@ describe('BigQuery/Table', () => {
       table.bigQuery.createJob = (reqOpts: JobOptions) => {
         assert.deepStrictEqual(reqOpts.configuration!.extract!.sourceTable, {
           datasetId: table.dataset.id,
-          projectId: table.bigQuery.projectId,
+          projectId: table.dataset.projectId,
           tableId: table.id,
         });
 
@@ -1685,14 +1685,14 @@ describe('BigQuery/Table', () => {
                 a: 'b',
                 c: 'd',
                 destinationTable: {
-                  projectId: table.bigQuery.projectId,
+                  projectId: table.dataset.projectId,
                   datasetId: table.dataset.id,
                   tableId: table.id,
                 },
               },
             },
             jobReference: {
-              projectId: table.bigQuery.projectId,
+              projectId: table.dataset.projectId,
               jobId: fakeJobId,
               location: undefined,
             },
@@ -1711,7 +1711,7 @@ describe('BigQuery/Table', () => {
           const uri =
             table.bigQuery.apiEndpoint +
             '/upload/bigquery/v2/projects/' +
-            table.bigQuery.projectId +
+            table.dataset.projectId +
             '/jobs';
           assert.strictEqual(options.request.uri, uri);
           done();


### PR DESCRIPTION
Make the internal `projectId` attribute on the `Dataset` class required and use it instead of the one set on the `Client`. This way all `Datasets` by default uses the Client `projectId`, but it can be override manually by the user if needed (which was enabled on PR #1230). This fixes some issues with users wanting to make operations on different projects with the same client.  

Fixes #1133 #1265 🦕
