### PR TITLE
feat: support JSON query param

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1005,6 +1005,8 @@ export class BigQuery extends Service {
       'GEOGRAPHY',
       'ARRAY',
       'STRUCT',
+      'JSON',
+      'RANGE',
     ];
 
     if (is.array(providedType)) {
@@ -1182,6 +1184,8 @@ export class BigQuery extends Service {
         },
         {}
       );
+    } else if (typeName === 'JSON' && is.object(value)) {      
+      queryParameter.parameterValue!.value = JSON.stringify(value);
     } else {
       queryParameter.parameterValue!.value = BigQuery._getValue(
         value,

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1184,7 +1184,7 @@ export class BigQuery extends Service {
         },
         {}
       );
-    } else if (typeName === 'JSON' && is.object(value)) {      
+    } else if (typeName === 'JSON' && is.object(value)) {
       queryParameter.parameterValue!.value = JSON.stringify(value);
     } else {
       queryParameter.parameterValue!.value = BigQuery._getValue(

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -1521,6 +1521,30 @@ describe('BigQuery', () => {
       assert.deepStrictEqual(param, expectedParam);
     });
 
+    it('should format JSON types', () => {
+      const typeName = 'JSON';
+      const value = {
+        foo: 'bar',
+      }
+      const strValue = JSON.stringify(value)
+      assert.deepStrictEqual(BigQuery.valueToQueryParameter_(value, typeName), {
+        parameterType: {
+          type: typeName,
+        },
+        parameterValue: {
+          value: strValue,
+        },
+      });
+      assert.deepStrictEqual(BigQuery.valueToQueryParameter_(strValue, typeName), {
+        parameterType: {
+          type: typeName,
+        },
+        parameterValue: {
+          value: strValue,
+        },
+      });
+    });
+
     it('should format all other types', () => {
       const typeName = 'ANY-TYPE';
       sandbox.stub(BigQuery, 'getTypeDescriptorFromValue_').returns({

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -1525,8 +1525,8 @@ describe('BigQuery', () => {
       const typeName = 'JSON';
       const value = {
         foo: 'bar',
-      }
-      const strValue = JSON.stringify(value)
+      };
+      const strValue = JSON.stringify(value);
       assert.deepStrictEqual(BigQuery.valueToQueryParameter_(value, typeName), {
         parameterType: {
           type: typeName,
@@ -1535,14 +1535,17 @@ describe('BigQuery', () => {
           value: strValue,
         },
       });
-      assert.deepStrictEqual(BigQuery.valueToQueryParameter_(strValue, typeName), {
-        parameterType: {
-          type: typeName,
-        },
-        parameterValue: {
-          value: strValue,
-        },
-      });
+      assert.deepStrictEqual(
+        BigQuery.valueToQueryParameter_(strValue, typeName),
+        {
+          parameterType: {
+            type: typeName,
+          },
+          parameterValue: {
+            value: strValue,
+          },
+        }
+      );
     });
 
     it('should format all other types', () => {


### PR DESCRIPTION
Update array with known types for query parameters and add custom logic to format `JSON` query parameters.

Fixes #1320 🦕
