### PR TITLE
feat: update types and generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "pretest": "npm run compile",
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs",
-    "types": "dtsd bigquery v2 > ./src/types.d.ts",
+    "types": "node scripts/gen-types.js",
     "prelint": "cd samples; npm link ../; npm install",
     "precompile": "gts clean"
   },

--- a/scripts/gen-types.js
+++ b/scripts/gen-types.js
@@ -20,7 +20,7 @@ const {promisify} = require('util');
 
 const writeFile = promisify(fs.writeFile);
 
-const LICENSE = `// Copyright 2023 Google LLC
+const LICENSE = `// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/gen-types.js
+++ b/scripts/gen-types.js
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const {fetch} = require('discovery-tsd');
 const TypeGenerator = require('discovery-tsd/src/generator');
 const prettier = require('prettier');

--- a/scripts/gen-types.js
+++ b/scripts/gen-types.js
@@ -1,0 +1,51 @@
+const {fetch} = require('discovery-tsd');
+const TypeGenerator = require('discovery-tsd/src/generator');
+const prettier = require('prettier');
+const fs = require('fs');
+const {promisify} = require('util');
+
+const writeFile = promisify(fs.writeFile);
+
+const LICENSE = `// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.`;
+
+function overridedRender() {
+  const source = this.template({
+    title: this.title ? this.converter.toJSDoc(this.title) : '',
+    name: this.name,
+    schemas: this.schemas.map(schema => this.converter.createType(schema)),
+    resources: this.resources.map(resource => resource.render()),
+  });
+
+  const patched = source.replaceAll(
+    'formatOptions.useInt64Timestamp',
+    "'formatOptions.useInt64Timestamp'"
+  );
+  const sourceWithLicense = LICENSE + '\n' + patched;
+
+  return prettier.format(sourceWithLicense, {
+    parser: 'typescript',
+    singleQuote: true,
+  });
+}
+
+async function genTypes() {
+  const json = await fetch('bigquery', 'v2');
+  const generator = new TypeGenerator(json);
+  generator.render = overridedRender.bind(generator);
+  const types = await generator.render();
+  await writeFile('./src/types.d.ts', types);
+}
+
+genTypes();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -51,6 +51,20 @@ declare namespace bigquery {
   };
 
   /**
+   * Represents privacy policy associated with "aggregation threshold" method.
+   */
+  type IAggregationThresholdPolicy = {
+    /**
+     * Optional. The privacy unit column(s) associated with this policy. For now, only one column per data source object (table, view) is allowed as a privacy unit column. Representing as a repeated field in metadata for extensibility to multiple columns in future. Duplicates and Repeated struct fields are not allowed. For nested fields, use dot notation ("outer.inner")
+     */
+    privacyUnitColumns?: Array<string>;
+    /**
+     * Optional. The threshold for the "aggregation threshold" policy.
+     */
+    threshold?: string;
+  };
+
+  /**
    * Input/output argument of a function or a stored procedure.
    */
   type IArgument = {
@@ -62,6 +76,10 @@ declare namespace bigquery {
      * Required unless argument_kind = ANY_TYPE.
      */
     dataType?: IStandardSqlDataType;
+    /**
+     * Optional. Whether the argument is an aggregate function parameter. Must be Unset for routine types other than AGGREGATE_FUNCTION. For AGGREGATE_FUNCTION, if set to false, it is equivalent to adding "NOT AGGREGATE" clause in DDL; Otherwise, it is equivalent to omitting "NOT AGGREGATE" clause in DDL.
+     */
+    isAggregate?: boolean;
     /**
      * Optional. Specifies whether the argument is input or output. Can be set for procedures only.
      */
@@ -322,100 +340,137 @@ declare namespace bigquery {
       | 'DATA_READ';
   };
 
+  /**
+   * Options for external data sources.
+   */
   type IAvroOptions = {
     /**
-     * [Optional] If sourceFormat is set to "AVRO", indicates whether to interpret logical types as the corresponding BigQuery data type (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
+     * Optional. If sourceFormat is set to "AVRO", indicates whether to interpret logical types as the corresponding BigQuery data type (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
      */
     useAvroLogicalTypes?: boolean;
   };
 
+  /**
+   * Reason why BI Engine didn't accelerate the query (or sub-query).
+   */
   type IBiEngineReason = {
     /**
-     * [Output-only] High-level BI Engine reason for partial or disabled acceleration.
+     * Output only. High-level BI Engine reason for partial or disabled acceleration
      */
-    code?: string;
+    code?:
+      | 'CODE_UNSPECIFIED'
+      | 'NO_RESERVATION'
+      | 'INSUFFICIENT_RESERVATION'
+      | 'UNSUPPORTED_SQL_TEXT'
+      | 'INPUT_TOO_LARGE'
+      | 'OTHER_REASON'
+      | 'TABLE_EXCLUDED';
     /**
-     * [Output-only] Free form human-readable reason for partial or disabled acceleration.
+     * Output only. Free form human-readable reason for partial or disabled acceleration.
      */
     message?: string;
   };
 
+  /**
+   * Statistics for a BI Engine specific query. Populated as part of JobStatistics2
+   */
   type IBiEngineStatistics = {
     /**
-     * [Output-only] Specifies which mode of BI Engine acceleration was performed (if any).
+     * Output only. Specifies which mode of BI Engine acceleration was performed (if any).
      */
-    accelerationMode?: string;
+    accelerationMode?:
+      | 'BI_ENGINE_ACCELERATION_MODE_UNSPECIFIED'
+      | 'BI_ENGINE_DISABLED'
+      | 'PARTIAL_INPUT'
+      | 'FULL_INPUT'
+      | 'FULL_QUERY';
     /**
-     * [Output-only] Specifies which mode of BI Engine acceleration was performed (if any).
+     * Output only. Specifies which mode of BI Engine acceleration was performed (if any).
      */
-    biEngineMode?: string;
+    biEngineMode?:
+      | 'ACCELERATION_MODE_UNSPECIFIED'
+      | 'DISABLED'
+      | 'PARTIAL'
+      | 'FULL';
     /**
      * In case of DISABLED or PARTIAL bi_engine_mode, these contain the explanatory reasons as to why BI Engine could not accelerate. In case the full query was accelerated, this field is not populated.
      */
     biEngineReasons?: Array<IBiEngineReason>;
   };
 
+  /**
+   * Configuration for BigLake managed tables.
+   */
   type IBigLakeConfiguration = {
     /**
-     * [Required] Required and immutable. Credential reference for accessing external storage system. Normalized as project_id.location_id.connection_id.
+     * Required. The connection specifying the credentials to be used to read and write to external storage, such as Cloud Storage. The connection_id can have the form "<project\_id>.<location\_id>.<connection\_id>" or "projects/<project\_id>/locations/<location\_id>/connections/<connection\_id>".
      */
     connectionId?: string;
     /**
-     * [Required] Required and immutable. Open source file format that the table data is stored in. Currently only PARQUET is supported.
+     * Required. The file format the table data is stored in.
      */
-    fileFormat?: string;
+    fileFormat?: 'FILE_FORMAT_UNSPECIFIED' | 'PARQUET';
     /**
-     * [Required] Required and immutable. Fully qualified location prefix of the external folder where data is stored. Normalized to standard format: "gs:////". Starts with "gs://" rather than "/bigstore/". Ends with "/". Does not contain "*". See also BigLakeStorageMetadata on how it is used.
+     * Required. The fully qualified location prefix of the external folder where table data is stored. The '*' wildcard character is not allowed. The URI should be in the format "gs://bucket/path_to_table/"
      */
     storageUri?: string;
     /**
-     * [Required] Required and immutable. Open source file format that the table data is stored in. Currently only PARQUET is supported.
+     * Required. The table format the metadata only snapshots are stored in.
      */
-    tableFormat?: string;
+    tableFormat?: 'TABLE_FORMAT_UNSPECIFIED' | 'ICEBERG';
   };
 
   type IBigQueryModelTraining = {
     /**
-     * [Output-only, Beta] Index of current ML training iteration. Updated during create model query job to show job progress.
+     * Deprecated.
      */
     currentIteration?: number;
     /**
-     * [Output-only, Beta] Expected number of iterations for the create model query job specified as num_iterations in the input query. The actual total number of iterations may be less than this number due to early stop.
+     * Deprecated.
      */
     expectedTotalIterations?: string;
   };
 
+  /**
+   * Information related to a Bigtable column.
+   */
   type IBigtableColumn = {
     /**
-     * [Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
+     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
      */
     encoding?: string;
     /**
-     * [Optional] If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries.
+     * Optional. If the qualifier is not a valid BigQuery field identifier i.e. does not match a-zA-Z*, a valid identifier must be provided as the column field name and is used as field name in queries.
      */
     fieldName?: string;
     /**
-     * [Optional] If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.
+     * Optional. If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.
      */
     onlyReadLatest?: boolean;
     /**
-     * [Required] Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifier_string field. Otherwise, a base-64 encoded value must be set to qualifier_encoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as field_name.
+     * [Required] Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifier_string field. Otherwise, a base-64 encoded value must be set to qualifier_encoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match a-zA-Z*, a valid identifier must be provided as field_name.
      */
     qualifierEncoded?: string;
+    /**
+     * Qualifier string.
+     */
     qualifierString?: string;
     /**
-     * [Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.
+     * Optional. The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): * BYTES * STRING * INTEGER * FLOAT * BOOLEAN * JSON Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.
      */
     type?: string;
   };
 
+  /**
+   * Information related to a Bigtable column family.
+   */
   type IBigtableColumnFamily = {
     /**
-     * [Optional] Lists of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as .. Other columns can be accessed as a list through .Column field.
+     * Optional. Lists of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as .. Other columns can be accessed as a list through .Column field.
      */
     columns?: Array<IBigtableColumn>;
     /**
-     * [Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
+     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
      */
     encoding?: string;
     /**
@@ -423,26 +478,33 @@ declare namespace bigquery {
      */
     familyId?: string;
     /**
-     * [Optional] If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.
+     * Optional. If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.
      */
     onlyReadLatest?: boolean;
     /**
-     * [Optional] The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.
+     * Optional. The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): * BYTES * STRING * INTEGER * FLOAT * BOOLEAN * JSON Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.
      */
     type?: string;
   };
 
+  /**
+   * Options specific to Google Cloud Bigtable data sources.
+   */
   type IBigtableOptions = {
     /**
-     * [Optional] List of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.
+     * Optional. List of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.
      */
     columnFamilies?: Array<IBigtableColumnFamily>;
     /**
-     * [Optional] If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.
+     * Optional. If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.
      */
     ignoreUnspecifiedColumnFamilies?: boolean;
     /**
-     * [Optional] If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.
+     * Optional. If field is true, then each column family will be read as a single JSON column. Otherwise they are read as a repeated cell structure containing timestamp/value tuples. The default value is false.
+     */
+    outputColumnFamiliesAsJson?: boolean;
+    /**
+     * Optional. If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.
      */
     readRowkeyAsString?: boolean;
   };
@@ -520,53 +582,53 @@ declare namespace bigquery {
      */
     condition?: IExpr;
     /**
-     * Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding.
+     * Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`.
      */
     members?: Array<string>;
     /**
-     * Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
+     * Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles).
      */
     role?: string;
   };
 
   type IBqmlIterationResult = {
     /**
-     * [Output-only, Beta] Time taken to run the training iteration in milliseconds.
+     * Deprecated.
      */
     durationMs?: string;
     /**
-     * [Output-only, Beta] Eval loss computed on the eval data at the end of the iteration. The eval loss is used for early stopping to avoid overfitting. No eval loss if eval_split_method option is specified as no_split or auto_split with input data size less than 500 rows.
+     * Deprecated.
      */
     evalLoss?: number;
     /**
-     * [Output-only, Beta] Index of the ML training iteration, starting from zero for each training run.
+     * Deprecated.
      */
     index?: number;
     /**
-     * [Output-only, Beta] Learning rate used for this iteration, it varies for different training iterations if learn_rate_strategy option is not constant.
+     * Deprecated.
      */
     learnRate?: number;
     /**
-     * [Output-only, Beta] Training loss computed on the training data at the end of the iteration. The training loss function is defined by model type.
+     * Deprecated.
      */
     trainingLoss?: number;
   };
 
   type IBqmlTrainingRun = {
     /**
-     * [Output-only, Beta] List of each iteration results.
+     * Deprecated.
      */
     iterationResults?: Array<IBqmlIterationResult>;
     /**
-     * [Output-only, Beta] Training run start time in milliseconds since the epoch.
+     * Deprecated.
      */
     startTime?: string;
     /**
-     * [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
+     * Deprecated.
      */
     state?: string;
     /**
-     * [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
+     * Deprecated.
      */
     trainingOptions?: {
       earlyStop?: boolean;
@@ -605,13 +667,16 @@ declare namespace bigquery {
     count?: string;
   };
 
+  /**
+   * Information about base table and clone time of a table clone.
+   */
   type ICloneDefinition = {
     /**
-     * [Required] Reference describing the ID of the table that was cloned.
+     * Required. Reference describing the ID of the table that was cloned.
      */
     baseTableReference?: ITableReference;
     /**
-     * [Required] The time at which the base table was cloned. This value is reported in the JSON response using RFC3339 format.
+     * Required. The time at which the base table was cloned. This value is reported in the JSON response using RFC3339 format.
      */
     cloneTime?: string;
   };
@@ -652,9 +717,12 @@ declare namespace bigquery {
     clusterSize?: string;
   };
 
+  /**
+   * Configures table clustering.
+   */
   type IClustering = {
     /**
-     * [Repeated] One or more fields on which data should be clustered. Only top-level, non-repeated, simple-type fields are supported. When you cluster a table using multiple columns, the order of columns you specify is important. The order of the specified columns determines the sort order of the data.
+     * One or more fields on which data should be clustered. Only top-level, non-repeated, simple-type fields are supported. The ordering of the clustering fields should be prioritized from most to least important for filtering purposes. Additional information on limitations can be found here: https://cloud.google.com/bigquery/docs/creating-clustered-tables#limitations
      */
     fields?: Array<string>;
   };
@@ -691,55 +759,74 @@ declare namespace bigquery {
     rows?: Array<IRow>;
   };
 
+  /**
+   * A connection-level property to customize query behavior. Under JDBC, these correspond directly to connection properties passed to the DriverManager. Under ODBC, these correspond to properties in the connection string. Currently supported connection properties: * **dataset_project_id**: represents the default project for datasets that are used in the query. Setting the system variable `@@dataset_project_id` achieves the same behavior. For more information about system variables, see: https://cloud.google.com/bigquery/docs/reference/system-variables * **time_zone**: represents the default timezone used to run the query. * **session_id**: associates the query with a given session. * **query_label**: associates the query with a given job label. If set, all subsequent queries in a script or session will have this label. For the format in which a you can specify a query label, see labels in the JobConfiguration resource type: https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration Additional properties are allowed, but ignored. Specifying multiple connection properties with the same key returns an error.
+   */
   type IConnectionProperty = {
     /**
-     * [Required] Name of the connection property to set.
+     * The key of the property to set.
      */
     key?: string;
     /**
-     * [Required] Value of the connection property.
+     * The value of the property to set.
      */
     value?: string;
   };
 
+  /**
+   * Information related to a CSV data source.
+   */
   type ICsvOptions = {
     /**
-     * [Optional] Indicates if BigQuery should accept rows that are missing trailing optional columns. If true, BigQuery treats missing trailing columns as null values. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.
+     * Optional. Indicates if BigQuery should accept rows that are missing trailing optional columns. If true, BigQuery treats missing trailing columns as null values. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.
      */
     allowJaggedRows?: boolean;
     /**
-     * [Optional] Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.
+     * Optional. Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.
      */
     allowQuotedNewlines?: boolean;
     /**
-     * [Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.
+     * Optional. The character encoding of the data. The supported values are UTF-8, ISO-8859-1, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.
      */
     encoding?: string;
     /**
-     * [Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence "\t" to specify a tab separator. The default value is a comma (',').
+     * Optional. The separator character for fields in a CSV file. The separator is interpreted as a single byte. For files encoded in ISO-8859-1, any single character can be used as a separator. For files encoded in UTF-8, characters represented in decimal range 1-127 (U+0001-U+007F) can be used without any modification. UTF-8 characters encoded with multiple bytes (i.e. U+0080 and above) will have only the first byte used for separating fields. The remaining bytes will be treated as a part of the field. BigQuery also supports the escape sequence "\t" (U+0009) to specify a tab separator. The default value is comma (",", U+002C).
      */
     fieldDelimiter?: string;
     /**
-     * [Optional] An custom string that will represent a NULL value in CSV import data.
+     * [Optional] A custom string that will represent a NULL value in CSV import data.
      */
-    null_marker?: string;
+    nullMarker?: string;
     /**
-     * [Optional] Preserves the embedded ASCII control characters (the first 32 characters in the ASCII-table, from '\x00' to '\x1F') when loading from CSV. Only applicable to CSV, ignored for other formats.
+     * Optional. Indicates if the embedded ASCII control characters (the first 32 characters in the ASCII-table, from '\x00' to '\x1F') are preserved.
      */
     preserveAsciiControlCharacters?: boolean;
     /**
-     * [Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.
+     * Optional. The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ("). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true. To include the specific quote character within a quoted value, precede it with an additional matching quote character. For example, if you want to escape the default character ' " ', use ' "" '.
      */
     quote?: string;
     /**
-     * [Optional] The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
+     * Optional. The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: string;
   };
 
+  /**
+   * Options for data format adjustments.
+   */
+  type IDataFormatOptions = {
+    /**
+     * Optional. Output timestamp as usec int64. Default is false.
+     */
+    useInt64Timestamp?: boolean;
+  };
+
+  /**
+   * Statistics for data-masking.
+   */
   type IDataMaskingStatistics = {
     /**
-     * [Output-only] [Preview] Whether any accessed data was protected by data masking. The actual evaluation is done by accessStats.masked_field_count > 0. Since this is only used for the discovery_doc generation purpose, as long as the type (boolean) matches, client library can leverage this. The actual evaluation of the variable is done else-where.
+     * Whether any accessed data was protected by the data masking.
      */
     dataMaskingApplied?: boolean;
   };
@@ -764,7 +851,7 @@ declare namespace bigquery {
 
   type IDataset = {
     /**
-     * [Optional] An array of objects that define dataset access for one or more entities. You can set this property when inserting or updating a dataset in order to control who is allowed to access the data. If unspecified at dataset creation time, BigQuery adds default dataset access for the following entities: access.specialGroup: projectReaders; access.role: READER; access.specialGroup: projectWriters; access.role: WRITER; access.specialGroup: projectOwners; access.role: OWNER; access.userByEmail: [dataset creator email]; access.role: OWNER;
+     * Optional. An array of objects that define dataset access for one or more entities. You can set this property when inserting or updating a dataset in order to control who is allowed to access the data. If unspecified at dataset creation time, BigQuery adds default dataset access for the following entities: access.specialGroup: projectReaders; access.role: READER; access.specialGroup: projectWriters; access.role: WRITER; access.specialGroup: projectOwners; access.role: OWNER; access.userByEmail: [dataset creator email]; access.role: OWNER;
      */
     access?: Array<{
       /**
@@ -784,7 +871,7 @@ declare namespace bigquery {
        */
       iamMember?: string;
       /**
-       * [Required] An IAM role ID that should be granted to the user, group, or domain specified in this access entry. The following legacy mappings will be applied: OWNER  roles/bigquery.dataOwner WRITER  roles/bigquery.dataEditor READER  roles/bigquery.dataViewer This field will accept any of the above formats, but will return only the legacy format. For example, if you set this field to "roles/bigquery.dataOwner", it will be returned back as "OWNER".
+       * An IAM role ID that should be granted to the user, group, or domain specified in this access entry. The following legacy mappings will be applied: OWNER <=> roles/bigquery.dataOwner WRITER <=> roles/bigquery.dataEditor READER <=> roles/bigquery.dataViewer This field will accept any of the above formats, but will return only the legacy format. For example, if you set this field to "roles/bigquery.dataOwner", it will be returned back as "OWNER".
        */
       role?: string;
       /**
@@ -800,61 +887,67 @@ declare namespace bigquery {
        */
       userByEmail?: string;
       /**
-       * [Pick one] A view from a different dataset to grant access to. Queries executed against that view will have read access to tables in this dataset. The role field is not required when this field is set. If that view is updated by any user, access to the view needs to be granted again via an update operation.
+       * [Pick one] A view from a different dataset to grant access to. Queries executed against that view will have read access to views/tables/routines in this dataset. The role field is not required when this field is set. If that view is updated by any user, access to the view needs to be granted again via an update operation.
        */
       view?: ITableReference;
     }>;
     /**
-     * [Output-only] The time when this dataset was created, in milliseconds since the epoch.
+     * Output only. The time when this dataset was created, in milliseconds since the epoch.
      */
     creationTime?: string;
     /**
-     * [Required] A reference that identifies the dataset.
+     * Required. A reference that identifies the dataset.
      */
     datasetReference?: IDatasetReference;
     /**
-     * [Output-only] The default collation of the dataset.
+     * Optional. Defines the default collation specification of future tables created in the dataset. If a table is created in this dataset without table-level default collation, then the table inherits the dataset default collation, which is applied to the string fields that do not have explicit collation specified. A change to this field affects only tables created afterwards, and does not alter the existing tables. The following values are supported: * 'und:ci': undetermined locale, case insensitive. * '': empty string. Default to case-sensitive behavior.
      */
     defaultCollation?: string;
+    /**
+     * The default encryption key for all tables in the dataset. Once this property is set, all newly-created partitioned tables in the dataset will have encryption key set to this value, unless table creation request (or query) overrides the key.
+     */
     defaultEncryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Optional] The default partition expiration for all partitioned tables in the dataset, in milliseconds. Once this property is set, all newly-created partitioned tables in the dataset will have an expirationMs property in the timePartitioning settings set to this value, and changing the value will only affect new tables, not existing ones. The storage in a partition will have an expiration time of its partition time plus this value. Setting this property overrides the use of defaultTableExpirationMs for partitioned tables: only one of defaultTableExpirationMs and defaultPartitionExpirationMs will be used for any new partitioned table. If you provide an explicit timePartitioning.expirationMs when creating or updating a partitioned table, that value takes precedence over the default partition expiration time indicated by this property.
+     * This default partition expiration, expressed in milliseconds. When new time-partitioned tables are created in a dataset where this property is set, the table will inherit this value, propagated as the `TimePartitioning.expirationMs` property on the new table. If you set `TimePartitioning.expirationMs` explicitly when creating a table, the `defaultPartitionExpirationMs` of the containing dataset is ignored. When creating a partitioned table, if `defaultPartitionExpirationMs` is set, the `defaultTableExpirationMs` value is ignored and the table will not be inherit a table expiration deadline.
      */
     defaultPartitionExpirationMs?: string;
     /**
-     * [Output-only] The default rounding mode of the dataset.
+     * Optional. Defines the default rounding mode specification of new tables created within this dataset. During table creation, if this field is specified, the table within this dataset will inherit the default rounding mode of the dataset. Setting the default rounding mode on a table overrides this option. Existing tables in the dataset are unaffected. If columns are defined during that table creation, they will immediately inherit the table's default rounding mode, unless otherwise specified.
      */
-    defaultRoundingMode?: string;
+    defaultRoundingMode?:
+      | 'ROUNDING_MODE_UNSPECIFIED'
+      | 'ROUND_HALF_AWAY_FROM_ZERO'
+      | 'ROUND_HALF_EVEN';
     /**
-     * [Optional] The default lifetime of all tables in the dataset, in milliseconds. The minimum value is 3600000 milliseconds (one hour). Once this property is set, all newly-created tables in the dataset will have an expirationTime property set to the creation time plus the value in this property, and changing the value will only affect new tables, not existing ones. When the expirationTime for a given table is reached, that table will be deleted automatically. If a table's expirationTime is modified or removed before the table expires, or if you provide an explicit expirationTime when creating a table, that value takes precedence over the default expiration time indicated by this property.
+     * Optional. The default lifetime of all tables in the dataset, in milliseconds. The minimum lifetime value is 3600000 milliseconds (one hour). To clear an existing default expiration with a PATCH request, set to 0. Once this property is set, all newly-created tables in the dataset will have an expirationTime property set to the creation time plus the value in this property, and changing the value will only affect new tables, not existing ones. When the expirationTime for a given table is reached, that table will be deleted automatically. If a table's expirationTime is modified or removed before the table expires, or if you provide an explicit expirationTime when creating a table, that value takes precedence over the default expiration time indicated by this property.
      */
     defaultTableExpirationMs?: string;
     /**
-     * [Optional] A user-friendly description of the dataset.
+     * Optional. A user-friendly description of the dataset.
      */
     description?: string;
     /**
-     * [Output-only] A hash of the resource.
+     * Output only. A hash of the resource.
      */
     etag?: string;
     /**
-     * [Optional] Information about the external metadata storage where the dataset is defined. Filled out when the dataset type is EXTERNAL.
+     * Optional. Information about the external metadata storage where the dataset is defined. Filled out when the dataset type is EXTERNAL.
      */
     externalDatasetReference?: IExternalDatasetReference;
     /**
-     * [Optional] A descriptive name for the dataset.
+     * Optional. A descriptive name for the dataset.
      */
     friendlyName?: string;
     /**
-     * [Output-only] The fully-qualified unique name of the dataset in the format projectId:datasetId. The dataset name without the project name is given in the datasetId field. When creating a new dataset, leave this field blank, and instead specify the datasetId field.
+     * Output only. The fully-qualified unique name of the dataset in the format projectId:datasetId. The dataset name without the project name is given in the datasetId field. When creating a new dataset, leave this field blank, and instead specify the datasetId field.
      */
     id?: string;
     /**
-     * [Optional] Indicates if table names are case insensitive in the dataset.
+     * Optional. TRUE if the dataset and its table names are case-insensitive, otherwise FALSE. By default, this is FALSE, which means the dataset and its table names are case-sensitive. This field does not affect routine references.
      */
     isCaseInsensitive?: boolean;
     /**
-     * [Output-only] The resource type.
+     * Output only. The resource type.
      */
     kind?: string;
     /**
@@ -862,52 +955,72 @@ declare namespace bigquery {
      */
     labels?: {[key: string]: string};
     /**
-     * [Output-only] The date when this dataset or any of its tables was last modified, in milliseconds since the epoch.
+     * Output only. The date when this dataset was last modified, in milliseconds since the epoch.
      */
     lastModifiedTime?: string;
     /**
-     * The geographic location where the dataset should reside. The default value is US. See details at https://cloud.google.com/bigquery/docs/locations.
+     * Optional. The source dataset reference when the dataset is of type LINKED. For all other dataset types it is not set. This field cannot be updated once it is set. Any attempt to update this field using Update and Patch API Operations will be ignored.
+     */
+    linkedDatasetSource?: ILinkedDatasetSource;
+    /**
+     * The geographic location where the dataset should reside. See https://cloud.google.com/bigquery/docs/locations for supported locations.
      */
     location?: string;
     /**
-     * [Optional] Number of hours for the max time travel for all tables in the dataset.
+     * Optional. Defines the time travel window in hours. The value can be from 48 to 168 hours (2 to 7 days). The default value is 168 hours if this is not set.
      */
     maxTimeTravelHours?: string;
     /**
-     * [Output-only] Reserved for future use.
+     * Output only. Reserved for future use.
      */
     satisfiesPzs?: boolean;
     /**
-     * [Output-only] A URL that can be used to access the resource again. You can use this URL in Get or Update requests to the resource.
+     * Output only. A URL that can be used to access the resource again. You can use this URL in Get or Update requests to the resource.
      */
     selfLink?: string;
     /**
-     * [Optional] Storage billing model to be used for all tables in the dataset. Can be set to PHYSICAL. Default is LOGICAL.
+     * Optional. Updates storage_billing_model for the dataset.
      */
-    storageBillingModel?: string;
+    storageBillingModel?:
+      | 'STORAGE_BILLING_MODEL_UNSPECIFIED'
+      | 'LOGICAL'
+      | 'PHYSICAL';
     /**
-     * [Optional]The tags associated with this dataset. Tag keys are globally unique.
+     * Output only. Tags for the Dataset.
      */
     tags?: Array<{
       /**
-       * [Required] The namespaced friendly name of the tag key, e.g. "12345/environment" where 12345 is org id.
+       * Required. The namespaced friendly name of the tag key, e.g. "12345/environment" where 12345 is org id.
        */
       tagKey?: string;
       /**
-       * [Required] Friendly short name of the tag value, e.g. "production".
+       * Required. The friendly short name of the tag value, e.g. "production".
        */
       tagValue?: string;
     }>;
+    /**
+     * Output only. Same as `type` in `ListFormatDataset`. The type of the dataset, one of: * DEFAULT - only accessible by owner and authorized accounts, * PUBLIC - accessible by everyone, * LINKED - linked dataset, * EXTERNAL - dataset with definition in external metadata catalog. -- *BIGLAKE_METASTORE - dataset that references a database created in BigLakeMetastore service. --
+     */
+    type?: string;
   };
 
+  /**
+   * Grants all resources of particular types in a particular dataset read access to the current dataset. Similar to how individually authorized views work, updates to any resource granted through its dataset (including creation of new resources) requires read permission to referenced resources, plus write permission to the authorizing dataset.
+   */
   type IDatasetAccessEntry = {
     /**
-     * [Required] The dataset this entry applies to.
+     * The dataset this entry applies to
      */
     dataset?: IDatasetReference;
+    /**
+     * Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future.
+     */
     targetTypes?: Array<'TARGET_TYPE_UNSPECIFIED' | 'VIEWS' | 'ROUTINES'>;
   };
 
+  /**
+   * Response format for a page of results when listing datasets.
+   */
   type IDatasetList = {
     /**
      * An array of the dataset resources in the project. Each resource contains basic information. For full information about a particular dataset resource, use the Datasets: get method. This property is omitted when there are no datasets in the project.
@@ -918,7 +1031,7 @@ declare namespace bigquery {
        */
       datasetReference?: IDatasetReference;
       /**
-       * A descriptive name for the dataset, if one exists.
+       * An alternate name for the dataset. The friendly name is purely decorative in nature.
        */
       friendlyName?: string;
       /**
@@ -926,7 +1039,7 @@ declare namespace bigquery {
        */
       id?: string;
       /**
-       * The resource type. This property always returns the value "bigquery#dataset".
+       * The resource type. This property always returns the value "bigquery#dataset"
        */
       kind?: string;
       /**
@@ -934,50 +1047,57 @@ declare namespace bigquery {
        */
       labels?: {[key: string]: string};
       /**
-       * The geographic location where the data resides.
+       * The geographic location where the dataset resides.
        */
       location?: string;
     }>;
     /**
-     * A hash value of the results page. You can use this property to determine if the page has changed since the last request.
+     * Output only. A hash value of the results page. You can use this property to determine if the page has changed since the last request.
      */
     etag?: string;
     /**
-     * The list type. This property always returns the value "bigquery#datasetList".
+     * Output only. The resource type. This property always returns the value "bigquery#datasetList"
      */
     kind?: string;
     /**
      * A token that can be used to request the next results page. This property is omitted on the final results page.
      */
     nextPageToken?: string;
+    /**
+     * A list of skipped locations that were unreachable. For more information about BigQuery locations, see: https://cloud.google.com/bigquery/docs/locations. Example: "europe-west5"
+     */
+    unreachable?: Array<string>;
   };
 
   type IDatasetReference = {
     /**
-     * [Required] A unique ID for this dataset, without the project name. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.
+     * Required. A unique ID for this dataset, without the project name. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.
      */
     datasetId?: string;
     /**
-     * [Optional] The ID of the project containing this dataset.
+     * Optional. The ID of the project containing this dataset.
      */
     projectId?: string;
   };
 
+  /**
+   * Properties for the destination table.
+   */
   type IDestinationTableProperties = {
     /**
-     * [Optional] The description for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current description is provided, the job will fail.
+     * Optional. The description for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current description is provided, the job will fail.
      */
     description?: string;
     /**
-     * [Internal] This field is for Google internal use only.
+     * Internal use only.
      */
     expirationTime?: string;
     /**
-     * [Optional] The friendly name for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current friendly name is provided, the job will fail.
+     * Optional. Friendly name for the destination table. If the table already exists, it should be same as the existing friendly name.
      */
     friendlyName?: string;
     /**
-     * [Optional] The labels associated with this table. You can use these to organize and group your tables. This will only be used if the destination table is newly created. If the table already exists and labels are different than the current labels are provided, the job will fail.
+     * Optional. The labels associated with this table. You can use these to organize and group your tables. This will only be used if the destination table is newly created. If the table already exists and labels are different than the current labels are provided, the job will fail.
      */
     labels?: {[key: string]: string};
   };
@@ -992,17 +1112,20 @@ declare namespace bigquery {
     totalExplainedVarianceRatio?: number;
   };
 
+  /**
+   * Detailed statistics for DML statements
+   */
   type IDmlStatistics = {
     /**
-     * Number of deleted Rows. populated by DML DELETE, MERGE and TRUNCATE statements.
+     * Output only. Number of deleted Rows. populated by DML DELETE, MERGE and TRUNCATE statements.
      */
     deletedRowCount?: string;
     /**
-     * Number of inserted Rows. Populated by DML INSERT and MERGE statements.
+     * Output only. Number of inserted Rows. Populated by DML INSERT and MERGE statements
      */
     insertedRowCount?: string;
     /**
-     * Number of updated Rows. Populated by DML UPDATE and MERGE statements.
+     * Output only. Number of updated Rows. Populated by DML UPDATE and MERGE statements.
      */
     updatedRowCount?: string;
   };
@@ -1066,6 +1189,9 @@ declare namespace bigquery {
     predictedLabel?: string;
   };
 
+  /**
+   * Error details.
+   */
   type IErrorProto = {
     /**
      * Debugging information. This property is internal to Google and should not be used.
@@ -1119,11 +1245,18 @@ declare namespace bigquery {
     regressionMetrics?: IRegressionMetrics;
   };
 
+  /**
+   * A single stage of query execution.
+   */
   type IExplainQueryStage = {
     /**
      * Number of parallel input segments completed.
      */
     completedParallelInputs?: string;
+    /**
+     * Output only. Compute mode for this stage.
+     */
+    computeMode?: 'COMPUTE_MODE_UNSPECIFIED' | 'BIGQUERY' | 'BI_ENGINE';
     /**
      * Milliseconds the average shard spent on CPU-bound tasks.
      */
@@ -1141,11 +1274,11 @@ declare namespace bigquery {
      */
     computeRatioMax?: number;
     /**
-     * Stage end time represented as milliseconds since epoch.
+     * Stage end time represented as milliseconds since the epoch.
      */
     endMs?: string;
     /**
-     * Unique ID for stage within plan.
+     * Unique ID for the stage within the plan.
      */
     id?: string;
     /**
@@ -1153,11 +1286,11 @@ declare namespace bigquery {
      */
     inputStages?: Array<string>;
     /**
-     * Human-readable name for stage.
+     * Human-readable name for the stage.
      */
     name?: string;
     /**
-     * Number of parallel input segments to be processed.
+     * Number of parallel input segments to be processed
      */
     parallelInputs?: string;
     /**
@@ -1197,11 +1330,11 @@ declare namespace bigquery {
      */
     slotMs?: string;
     /**
-     * Stage start time represented as milliseconds since epoch.
+     * Stage start time represented as milliseconds since the epoch.
      */
     startMs?: string;
     /**
-     * Current status for the stage.
+     * Current status for this stage.
      */
     status?: string;
     /**
@@ -1242,13 +1375,16 @@ declare namespace bigquery {
     writeRatioMax?: number;
   };
 
+  /**
+   * An operation within a stage.
+   */
   type IExplainQueryStep = {
     /**
      * Machine-readable operation type.
      */
     kind?: string;
     /**
-     * Human-readable stage descriptions.
+     * Human-readable description of the step(s).
      */
     substeps?: Array<string>;
   };
@@ -1265,6 +1401,20 @@ declare namespace bigquery {
      * The full feature name. For non-numerical features, will be formatted like `.`. Overall size of feature name will always be truncated to first 120 characters.
      */
     featureName?: string;
+  };
+
+  /**
+   * Statistics for the EXPORT DATA statement as part of Query Job. EXTRACT JOB statistics are populated in JobStatistics4.
+   */
+  type IExportDataStatistics = {
+    /**
+     * Number of destination files generated in case of EXPORT DATA statement only.
+     */
+    fileCount?: string;
+    /**
+     * [Alpha] Number of destination rows generated in case of EXPORT DATA statement only.
+     */
+    rowCount?: string;
   };
 
   /**
@@ -1295,75 +1445,86 @@ declare namespace bigquery {
      */
     autodetect?: boolean;
     /**
-     * Additional properties to set if sourceFormat is set to Avro.
+     * Optional. Additional properties to set if sourceFormat is set to AVRO.
      */
     avroOptions?: IAvroOptions;
     /**
-     * [Optional] Additional options if sourceFormat is set to BIGTABLE.
+     * Optional. Additional options if sourceFormat is set to BIGTABLE.
      */
     bigtableOptions?: IBigtableOptions;
     /**
-     * [Optional] The compression type of the data source. Possible values include GZIP and NONE. The default value is NONE. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups and Avro formats.
+     * Optional. The compression type of the data source. Possible values include GZIP and NONE. The default value is NONE. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups, Avro, ORC and Parquet formats. An empty string is an invalid value.
      */
     compression?: string;
     /**
-     * [Optional, Trusted Tester] Connection for external data source.
+     * Optional. The connection specifying the credentials to be used to read external storage, such as Azure Blob, Cloud Storage, or S3. The connection_id can have the form "<project\_id>.<location\_id>.<connection\_id>" or "projects/<project\_id>/locations/<location\_id>/connections/<connection\_id>".
      */
     connectionId?: string;
     /**
-     * Additional properties to set if sourceFormat is set to CSV.
+     * Optional. Additional properties to set if sourceFormat is set to CSV.
      */
     csvOptions?: ICsvOptions;
     /**
-     * [Optional] Defines the list of possible SQL data types to which the source decimal values are converted. This list and the precision and the scale parameters of the decimal field determine the target type. In the order of NUMERIC, BIGNUMERIC, and STRING, a type is picked if it is in the specified list and if it supports the precision and the scale. STRING supports all precision and scale values. If none of the listed types supports the precision and the scale, the type supporting the widest range in the specified list is picked, and if a value exceeds the supported range when reading the data, an error will be thrown. Example: Suppose the value of this field is ["NUMERIC", "BIGNUMERIC"]. If (precision,scale) is: (38,9) -> NUMERIC; (39,9) -> BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -> BIGNUMERIC (NUMERIC cannot hold 10 fractional digits); (76,38) -> BIGNUMERIC; (77,38) -> BIGNUMERIC (error if value exeeds supported range). This field cannot contain duplicate types. The order of the types in this field is ignored. For example, ["BIGNUMERIC", "NUMERIC"] is the same as ["NUMERIC", "BIGNUMERIC"] and NUMERIC always takes precedence over BIGNUMERIC. Defaults to ["NUMERIC", "STRING"] for ORC and ["NUMERIC"] for the other file formats.
+     * Defines the list of possible SQL data types to which the source decimal values are converted. This list and the precision and the scale parameters of the decimal field determine the target type. In the order of NUMERIC, BIGNUMERIC, and STRING, a type is picked if it is in the specified list and if it supports the precision and the scale. STRING supports all precision and scale values. If none of the listed types supports the precision and the scale, the type supporting the widest range in the specified list is picked, and if a value exceeds the supported range when reading the data, an error will be thrown. Example: Suppose the value of this field is ["NUMERIC", "BIGNUMERIC"]. If (precision,scale) is: * (38,9) -> NUMERIC; * (39,9) -> BIGNUMERIC (NUMERIC cannot hold 30 integer digits); * (38,10) -> BIGNUMERIC (NUMERIC cannot hold 10 fractional digits); * (76,38) -> BIGNUMERIC; * (77,38) -> BIGNUMERIC (error if value exeeds supported range). This field cannot contain duplicate types. The order of the types in this field is ignored. For example, ["BIGNUMERIC", "NUMERIC"] is the same as ["NUMERIC", "BIGNUMERIC"] and NUMERIC always takes precedence over BIGNUMERIC. Defaults to ["NUMERIC", "STRING"] for ORC and ["NUMERIC"] for the other file formats.
      */
-    decimalTargetTypes?: Array<string>;
+    decimalTargetTypes?: Array<
+      'DECIMAL_TARGET_TYPE_UNSPECIFIED' | 'NUMERIC' | 'BIGNUMERIC' | 'STRING'
+    >;
     /**
-     * [Optional] Specifies how source URIs are interpreted for constructing the file set to load. By default source URIs are expanded against the underlying storage. Other options include specifying manifest files. Only applicable to object storage systems.
+     * Optional. Specifies how source URIs are interpreted for constructing the file set to load. By default source URIs are expanded against the underlying storage. Other options include specifying manifest files. Only applicable to object storage systems.
      */
-    fileSetSpecType?: string;
+    fileSetSpecType?:
+      | 'FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH'
+      | 'FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST';
     /**
-     * [Optional] Additional options if sourceFormat is set to GOOGLE_SHEETS.
+     * Optional. Additional options if sourceFormat is set to GOOGLE_SHEETS.
      */
     googleSheetsOptions?: IGoogleSheetsOptions;
     /**
-     * [Optional] Options to configure hive partitioning support.
+     * Optional. When set, configures hive partitioning support. Not all storage formats support hive partitioning -- requesting hive partitioning on an unsupported format will lead to an error, as will providing an invalid specification.
      */
     hivePartitioningOptions?: IHivePartitioningOptions;
     /**
-     * [Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names Google Cloud Bigtable: This setting is ignored. Google Cloud Datastore backups: This setting is ignored. Avro: This setting is ignored.
+     * Optional. Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names Google Cloud Bigtable: This setting is ignored. Google Cloud Datastore backups: This setting is ignored. Avro: This setting is ignored. ORC: This setting is ignored. Parquet: This setting is ignored.
      */
     ignoreUnknownValues?: boolean;
     /**
-     * Additional properties to set if `sourceFormat` is set to `NEWLINE_DELIMITED_JSON`.
+     * Optional. Load option to be used together with source_format newline-delimited JSON to indicate that a variant of JSON is being loaded. To load newline-delimited GeoJSON, specify GEOJSON (and source_format must be set to NEWLINE_DELIMITED_JSON).
+     */
+    jsonExtension?: 'JSON_EXTENSION_UNSPECIFIED' | 'GEOJSON';
+    /**
+     * Optional. Additional properties to set if sourceFormat is set to JSON.
      */
     jsonOptions?: IJsonOptions;
     /**
-     * [Optional] The maximum number of bad records that BigQuery can ignore when reading data. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV, JSON, and Google Sheets. The default value is 0, which requires that all records are valid. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups and Avro formats.
+     * Optional. The maximum number of bad records that BigQuery can ignore when reading data. If the number of bad records exceeds this value, an invalid error is returned in the job result. The default value is 0, which requires that all records are valid. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups, Avro, ORC and Parquet formats.
      */
     maxBadRecords?: number;
     /**
-     * [Optional] Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source.
+     * Optional. Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source.
      */
-    metadataCacheMode?: string;
+    metadataCacheMode?:
+      | 'METADATA_CACHE_MODE_UNSPECIFIED'
+      | 'AUTOMATIC'
+      | 'MANUAL';
     /**
-     * ObjectMetadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the source_uris. If ObjectMetadata is set, source_format should be omitted. Currently SIMPLE is the only supported Object Metadata type.
+     * Optional. ObjectMetadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the source_uris. If ObjectMetadata is set, source_format should be omitted. Currently SIMPLE is the only supported Object Metadata type.
      */
-    objectMetadata?: string;
+    objectMetadata?: 'OBJECT_METADATA_UNSPECIFIED' | 'DIRECTORY' | 'SIMPLE';
     /**
-     * Additional properties to set if sourceFormat is set to Parquet.
+     * Optional. Additional properties to set if sourceFormat is set to PARQUET.
      */
     parquetOptions?: IParquetOptions;
     /**
-     * [Optional] Provide a referencing file with the expected table schema. Enabled for the format: AVRO, PARQUET, ORC.
+     * Optional. When creating an external table, the user can provide a reference file with the table schema. This is enabled for the following formats: AVRO, PARQUET, ORC.
      */
     referenceFileSchemaUri?: string;
     /**
-     * [Optional] The schema for the data. Schema is required for CSV and JSON formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats.
+     * Optional. The schema for the data. Schema is required for CSV and JSON formats if autodetect is not on. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, Avro, ORC and Parquet formats.
      */
     schema?: ITableSchema;
     /**
-     * [Required] The data format. For CSV files, specify "CSV". For Google sheets, specify "GOOGLE_SHEETS". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro files, specify "AVRO". For Google Cloud Datastore backups, specify "DATASTORE_BACKUP". [Beta] For Google Cloud Bigtable, specify "BIGTABLE".
+     * [Required] The data format. For CSV files, specify "CSV". For Google sheets, specify "GOOGLE_SHEETS". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro files, specify "AVRO". For Google Cloud Datastore backups, specify "DATASTORE_BACKUP". For Apache Iceberg tables, specify "ICEBERG". For ORC files, specify "ORC". For Parquet files, specify "PARQUET". [Beta] For Google Cloud Bigtable, specify "BIGTABLE".
      */
     sourceFormat?: string;
     /**
@@ -1372,15 +1533,44 @@ declare namespace bigquery {
     sourceUris?: Array<string>;
   };
 
+  /**
+   * Configures the access a dataset defined in an external metadata storage.
+   */
   type IExternalDatasetReference = {
     /**
-     * [Required] The connection id that is used to access the external_source. Format: projects/{project_id}/locations/{location_id}/connections/{connection_id}
+     * Required. The connection id that is used to access the external_source. Format: projects/{project_id}/locations/{location_id}/connections/{connection_id}
      */
     connection?: string;
     /**
-     * [Required] External source that backs this dataset.
+     * Required. External source that backs this dataset.
      */
     externalSource?: string;
+  };
+
+  /**
+   * The external service cost is a portion of the total cost, these costs are not additive with total_bytes_billed. Moreover, this field only track external service costs that will show up as BigQuery costs (e.g. training BigQuery ML job with google cloud CAIP or Automl Tables services), not other costs which may be accrued by running the query (e.g. reading from Bigtable or Cloud Storage). The external service costs with different billing sku (e.g. CAIP job is charged based on VM usage) are converted to BigQuery billed_bytes and slot_ms with equivalent amount of US dollars. Services may not directly correlate to these metrics, but these are the equivalents for billing purposes. Output only.
+   */
+  type IExternalServiceCost = {
+    /**
+     * External service cost in terms of bigquery bytes billed.
+     */
+    bytesBilled?: string;
+    /**
+     * External service cost in terms of bigquery bytes processed.
+     */
+    bytesProcessed?: string;
+    /**
+     * External service name.
+     */
+    externalService?: string;
+    /**
+     * Non-preemptable reserved slots used for external job. For example, reserved slots for Cloua AI Platform job are the VM usages converted to BigQuery slot with equivalent mount of price.
+     */
+    reservedSlotCount?: string;
+    /**
+     * External service cost in terms of bigquery slot milliseconds.
+     */
+    slotMs?: string;
   };
 
   /**
@@ -1421,13 +1611,16 @@ declare namespace bigquery {
     requestedPolicyVersion?: number;
   };
 
+  /**
+   * Response object of GetQueryResults.
+   */
   type IGetQueryResultsResponse = {
     /**
      * Whether the query result was fetched from the query cache.
      */
     cacheHit?: boolean;
     /**
-     * [Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
+     * Output only. The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful. For more information about error messages, see [Error messages](https://cloud.google.com/bigquery/docs/error-messages).
      */
     errors?: Array<IErrorProto>;
     /**
@@ -1447,15 +1640,15 @@ declare namespace bigquery {
      */
     kind?: string;
     /**
-     * [Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
+     * Output only. The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
      */
     numDmlAffectedRows?: string;
     /**
-     * A token used for paging results.
+     * A token used for paging results. When this token is non-empty, it indicates additional results are available.
      */
     pageToken?: string;
     /**
-     * An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above. Present only when the query completes successfully.
+     * An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above. Present only when the query completes successfully. The REST-based representation of this data leverages a series of JSON f,v objects for indicating fields and values.
      */
     rows?: Array<ITableRow>;
     /**
@@ -1472,6 +1665,9 @@ declare namespace bigquery {
     totalRows?: string;
   };
 
+  /**
+   * Response object of GetServiceAccount
+   */
   type IGetServiceAccountResponse = {
     /**
      * The service account email address.
@@ -1497,32 +1693,60 @@ declare namespace bigquery {
     explanations?: Array<IExplanation>;
   };
 
+  /**
+   * Options specific to Google Sheets data sources.
+   */
   type IGoogleSheetsOptions = {
     /**
-     * [Optional] Range of a sheet to query from. Only used when non-empty. Typical format: sheet_name!top_left_cell_id:bottom_right_cell_id For example: sheet1!A1:B20
+     * Optional. Range of a sheet to query from. Only used when non-empty. Typical format: sheet_name!top_left_cell_id:bottom_right_cell_id For example: sheet1!A1:B20
      */
     range?: string;
     /**
-     * [Optional] The number of rows at the top of a sheet that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows that should be skipped. When autodetect is on, behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
+     * Optional. The number of rows at the top of a sheet that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: string;
   };
 
+  /**
+   * High cardinality join detailed information.
+   */
+  type IHighCardinalityJoin = {
+    /**
+     * Output only. Count of left input rows.
+     */
+    leftRows?: string;
+    /**
+     * Output only. Count of the output rows.
+     */
+    outputRows?: string;
+    /**
+     * Output only. Count of right input rows.
+     */
+    rightRows?: string;
+    /**
+     * Output only. The index of the join operator in the ExplainQueryStep lists.
+     */
+    stepIndex?: number;
+  };
+
+  /**
+   * Options for configuring hive partitioning detect.
+   */
   type IHivePartitioningOptions = {
     /**
-     * [Output-only] For permanent external tables, this field is populated with the hive partition keys in the order they were inferred. The types of the partition keys can be deduced by checking the table schema (which will include the partition keys). Not every API will populate this field in the output. For example, Tables.Get will populate it, but Tables.List will not contain this field.
+     * Output only. For permanent external tables, this field is populated with the hive partition keys in the order they were inferred. The types of the partition keys can be deduced by checking the table schema (which will include the partition keys). Not every API will populate this field in the output. For example, Tables.Get will populate it, but Tables.List will not contain this field.
      */
     fields?: Array<string>;
     /**
-     * [Optional] When set, what mode of hive partitioning to use when reading data. The following modes are supported. (1) AUTO: automatically infer partition key name(s) and type(s). (2) STRINGS: automatically infer partition key name(s). All types are interpreted as strings. (3) CUSTOM: partition key schema is encoded in the source URI prefix. Not all storage formats support hive partitioning. Requesting hive partitioning on an unsupported format will lead to an error. Currently supported types include: AVRO, CSV, JSON, ORC and Parquet.
+     * Optional. When set, what mode of hive partitioning to use when reading data. The following modes are supported: * AUTO: automatically infer partition key name(s) and type(s). * STRINGS: automatically infer partition key name(s). All types are strings. * CUSTOM: partition key schema is encoded in the source URI prefix. Not all storage formats support hive partitioning. Requesting hive partitioning on an unsupported format will lead to an error. Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
      */
     mode?: string;
     /**
-     * [Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. Note that this field should only be true when creating a permanent external table or querying a temporary external table. Hive-partitioned loads with requirePartitionFilter explicitly set to true will fail.
+     * Optional. If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. Note that this field should only be true when creating a permanent external table or querying a temporary external table. Hive-partitioned loads with require_partition_filter explicitly set to true will fail.
      */
     requirePartitionFilter?: boolean;
     /**
-     * [Optional] When hive partition detection is requested, a common prefix for all source uris should be supplied. The prefix must end immediately before the partition key encoding begins. For example, consider files following this data layout. gs://bucket/path_to_table/dt=2019-01-01/country=BR/id=7/file.avro gs://bucket/path_to_table/dt=2018-12-31/country=CA/id=3/file.avro When hive partitioning is requested with either AUTO or STRINGS detection, the common prefix can be either of gs://bucket/path_to_table or gs://bucket/path_to_table/ (trailing slash does not matter).
+     * Optional. When hive partition detection is requested, a common prefix for all source uris must be required. The prefix must end immediately before the partition key encoding begins. For example, consider files following this data layout: gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro When hive partitioning is requested with either AUTO or STRINGS detection, the common prefix can be either of gs://bucket/path_to_table or gs://bucket/path_to_table/. CUSTOM detection requires encoding the partitioning schema immediately after the common prefix. For CUSTOM, any of * gs://bucket/path_to_table/{dt:DATE}/{country:STRING}/{id:INTEGER} * gs://bucket/path_to_table/{dt:STRING}/{country:STRING}/{id:INTEGER} * gs://bucket/path_to_table/{dt:DATE}/{country:STRING}/{id:STRING} would all be valid source URI prefixes.
      */
     sourceUriPrefix?: string;
   };
@@ -1674,23 +1898,56 @@ declare namespace bigquery {
     trialId?: string;
   };
 
+  /**
+   * Reason about why no search index was used in the search query (or sub-query).
+   */
   type IIndexUnusedReason = {
     /**
-     * [Output-only] Specifies the base table involved in the reason that no search index was used.
+     * Specifies the base table involved in the reason that no search index was used.
      */
     baseTable?: ITableReference;
     /**
-     * [Output-only] Specifies the high-level reason for the scenario when no search index was used.
+     * Specifies the high-level reason for the scenario when no search index was used.
      */
-    code?: string;
+    code?:
+      | 'CODE_UNSPECIFIED'
+      | 'INDEX_CONFIG_NOT_AVAILABLE'
+      | 'PENDING_INDEX_CREATION'
+      | 'BASE_TABLE_TRUNCATED'
+      | 'INDEX_CONFIG_MODIFIED'
+      | 'TIME_TRAVEL_QUERY'
+      | 'NO_PRUNING_POWER'
+      | 'UNINDEXED_SEARCH_FIELDS'
+      | 'UNSUPPORTED_SEARCH_PATTERN'
+      | 'OPTIMIZED_WITH_MATERIALIZED_VIEW'
+      | 'SECURED_BY_DATA_MASKING'
+      | 'MISMATCHED_TEXT_ANALYZER'
+      | 'BASE_TABLE_TOO_SMALL'
+      | 'BASE_TABLE_TOO_LARGE'
+      | 'ESTIMATED_PERFORMANCE_GAIN_TOO_LOW'
+      | 'NOT_SUPPORTED_IN_STANDARD_EDITION'
+      | 'INDEX_SUPPRESSED_BY_FUNCTION_OPTION'
+      | 'INTERNAL_ERROR'
+      | 'QUERY_CACHE_HIT'
+      | 'OTHER_REASON';
     /**
-     * [Output-only] Specifies the name of the unused search index, if available.
+     * Specifies the name of the unused search index, if available.
      */
     indexName?: string;
     /**
-     * [Output-only] Free form human-readable reason for the scenario when no search index was used.
+     * Free form human-readable reason for the scenario when no search index was used.
      */
     message?: string;
+  };
+
+  /**
+   * Details about the input data change insight.
+   */
+  type IInputDataChange = {
+    /**
+     * Output only. Records read difference percentage compared to a previous run.
+     */
+    recordsReadDiffPercentage?: number;
   };
 
   /**
@@ -1751,7 +2008,18 @@ declare namespace bigquery {
     min?: string;
   };
 
+  /**
+   * Information about a single iteration of the training run.
+   */
   type IIterationResult = {
+    /**
+     * Arima result.
+     */
+    arimaResult?: IArimaResult;
+    /**
+     * Information about top clusters for clustering models.
+     */
+    clusterInfos?: Array<IClusterInfo>;
     /**
      * Time taken to run the iteration in milliseconds.
      */
@@ -1769,6 +2037,10 @@ declare namespace bigquery {
      */
     learnRate?: number;
     /**
+     * The information of the principal components.
+     */
+    principalComponentInfos?: Array<IPrincipalComponentInfo>;
+    /**
      * Loss computed on the training data at the end of iteration.
      */
     trainingLoss?: number;
@@ -1776,43 +2048,54 @@ declare namespace bigquery {
 
   type IJob = {
     /**
-     * [Required] Describes the job configuration.
+     * Required. Describes the job configuration.
      */
     configuration?: IJobConfiguration;
     /**
-     * [Output-only] A hash of this resource.
+     * Output only. A hash of this resource.
      */
     etag?: string;
     /**
-     * [Output-only] Opaque ID field of the job
+     * Output only. Opaque ID field of the job.
      */
     id?: string;
     /**
-     * [Optional] Reference describing the unique-per-user name of the job.
+     * Output only. If set, it provides the reason why a Job was created. If not set, it should be treated as the default: REQUESTED. This feature is not yet available. Jobs will always be created.
+     */
+    jobCreationReason?: IJobCreationReason;
+    /**
+     * Optional. Reference describing the unique-per-user name of the job.
      */
     jobReference?: IJobReference;
     /**
-     * [Output-only] The type of the resource.
+     * Output only. The type of the resource.
      */
     kind?: string;
     /**
-     * [Output-only] A URL that can be used to access this resource again.
+     * Output only. [Full-projection-only] String representation of identity of requesting party. Populated for both first- and third-party identities. Only present for APIs that support third-party identities.
+     */
+    principal_subject?: string;
+    /**
+     * Output only. A URL that can be used to access the resource again.
      */
     selfLink?: string;
     /**
-     * [Output-only] Information about the job, including starting time and ending time of the job.
+     * Output only. Information about the job, including starting time and ending time of the job.
      */
     statistics?: IJobStatistics;
     /**
-     * [Output-only] The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
+     * Output only. The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
      */
     status?: IJobStatus;
     /**
-     * [Output-only] Email address of the user who ran the job.
+     * Output only. Email address of the user who ran the job.
      */
     user_email?: string;
   };
 
+  /**
+   * Describes format of a jobs cancellation response.
+   */
   type IJobCancelResponse = {
     /**
      * The final state of the job.
@@ -1830,7 +2113,7 @@ declare namespace bigquery {
      */
     copy?: IJobConfigurationTableCopy;
     /**
-     * [Optional] If set, don't actually run this job. A valid query will return a mostly empty response with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run. Behavior of non-query jobs is undefined.
+     * Optional. If set, don't actually run this job. A valid query will return a mostly empty response with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run. Behavior of non-query jobs is undefined.
      */
     dryRun?: boolean;
     /**
@@ -1838,11 +2121,11 @@ declare namespace bigquery {
      */
     extract?: IJobConfigurationExtract;
     /**
-     * [Optional] Job timeout in milliseconds. If this time limit is exceeded, BigQuery may attempt to terminate the job.
+     * Optional. Job timeout in milliseconds. If this time limit is exceeded, BigQuery might attempt to stop the job.
      */
     jobTimeoutMs?: string;
     /**
-     * [Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or UNKNOWN.
+     * Output only. The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or UNKNOWN.
      */
     jobType?: string;
     /**
@@ -1859,13 +2142,16 @@ declare namespace bigquery {
     query?: IJobConfigurationQuery;
   };
 
+  /**
+   * JobConfigurationExtract configures a job that exports data from a BigQuery table into Google Cloud Storage.
+   */
   type IJobConfigurationExtract = {
     /**
-     * [Optional] The compression type to use for exported files. Possible values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is NONE. DEFLATE and SNAPPY are only supported for Avro. Not applicable when extracting models.
+     * Optional. The compression type to use for exported files. Possible values include DEFLATE, GZIP, NONE, SNAPPY, and ZSTD. The default value is NONE. Not all compression formats are support for all file formats. DEFLATE is only supported for Avro. ZSTD is only supported for Parquet. Not applicable when extracting models.
      */
     compression?: string;
     /**
-     * [Optional] The exported file format. Possible values include CSV, NEWLINE_DELIMITED_JSON, PARQUET or AVRO for tables and ML_TF_SAVED_MODEL or ML_XGBOOST_BOOSTER for models. The default value for tables is CSV. Tables with nested or repeated fields cannot be exported as CSV. The default value for models is ML_TF_SAVED_MODEL.
+     * Optional. The exported file format. Possible values include CSV, NEWLINE_DELIMITED_JSON, PARQUET, or AVRO for tables and ML_TF_SAVED_MODEL or ML_XGBOOST_BOOSTER for models. The default value for tables is CSV. Tables with nested or repeated fields cannot be exported as CSV. The default value for models is ML_TF_SAVED_MODEL.
      */
     destinationFormat?: string;
     /**
@@ -1877,11 +2163,15 @@ declare namespace bigquery {
      */
     destinationUris?: Array<string>;
     /**
-     * [Optional] Delimiter to use between fields in the exported data. Default is ','. Not applicable when extracting models.
+     * Optional. When extracting data in CSV format, this defines the delimiter to use between fields in the exported data. Default is ','. Not applicable when extracting models.
      */
     fieldDelimiter?: string;
     /**
-     * [Optional] Whether to print out a header row in the results. Default is true. Not applicable when extracting models.
+     * Optional. Model extract options only applicable when extracting models.
+     */
+    modelExtractOptions?: IModelExtractOptions;
+    /**
+     * Optional. Whether to print out a header row in the results. Default is true. Not applicable when extracting models.
      */
     printHeader?: boolean;
     /**
@@ -1893,14 +2183,17 @@ declare namespace bigquery {
      */
     sourceTable?: ITableReference;
     /**
-     * [Optional] If destinationFormat is set to "AVRO", this flag indicates whether to enable extracting applicable column types (such as TIMESTAMP) to their corresponding AVRO logical types (timestamp-micros), instead of only using their raw types (avro-long). Not applicable when extracting models.
+     * Whether to use logical types when extracting to AVRO format. Not applicable when extracting models.
      */
     useAvroLogicalTypes?: boolean;
   };
 
+  /**
+   * JobConfigurationLoad contains the configuration properties for loading data into a destination table.
+   */
   type IJobConfigurationLoad = {
     /**
-     * [Optional] Accept rows that are missing trailing optional columns. The missing values are treated as nulls. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. Only applicable to CSV, ignored for other formats.
+     * Optional. Accept rows that are missing trailing optional columns. The missing values are treated as nulls. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. Only applicable to CSV, ignored for other formats.
      */
     allowJaggedRows?: boolean;
     /**
@@ -1908,31 +2201,33 @@ declare namespace bigquery {
      */
     allowQuotedNewlines?: boolean;
     /**
-     * [Optional] Indicates if we should automatically infer the options and schema for CSV and JSON sources.
+     * Optional. Indicates if we should automatically infer the options and schema for CSV and JSON sources.
      */
     autodetect?: boolean;
     /**
-     * [Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.
+     * Clustering specification for the destination table.
      */
     clustering?: IClustering;
     /**
-     * Connection properties.
+     * Optional. Connection properties which can modify the load job behavior. Currently, only the 'session_id' connection property is supported, and is used to resolve _SESSION appearing as the dataset id.
      */
     connectionProperties?: Array<IConnectionProperty>;
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies whether the job is allowed to create new tables. The following values are supported: * CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. * CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
-     * If true, creates a new session, where session id will be a server generated random id. If false, runs query with an existing session_id passed in ConnectionProperty, otherwise runs the load job in non-session mode.
+     * Optional. If this property is true, the job creates a new session using a randomly generated session_id. To continue using a created session with subsequent queries, pass the existing session identifier as a `ConnectionProperty` value. The session identifier is returned as part of the `SessionInfo` message within the query statistics. The new session's location will be set to `Job.JobReference.location` if it is present, otherwise it's set to the default location based on existing routing logic.
      */
     createSession?: boolean;
     /**
-     * [Optional] Defines the list of possible SQL data types to which the source decimal values are converted. This list and the precision and the scale parameters of the decimal field determine the target type. In the order of NUMERIC, BIGNUMERIC, and STRING, a type is picked if it is in the specified list and if it supports the precision and the scale. STRING supports all precision and scale values. If none of the listed types supports the precision and the scale, the type supporting the widest range in the specified list is picked, and if a value exceeds the supported range when reading the data, an error will be thrown. Example: Suppose the value of this field is ["NUMERIC", "BIGNUMERIC"]. If (precision,scale) is: (38,9) -> NUMERIC; (39,9) -> BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -> BIGNUMERIC (NUMERIC cannot hold 10 fractional digits); (76,38) -> BIGNUMERIC; (77,38) -> BIGNUMERIC (error if value exeeds supported range). This field cannot contain duplicate types. The order of the types in this field is ignored. For example, ["BIGNUMERIC", "NUMERIC"] is the same as ["NUMERIC", "BIGNUMERIC"] and NUMERIC always takes precedence over BIGNUMERIC. Defaults to ["NUMERIC", "STRING"] for ORC and ["NUMERIC"] for the other file formats.
+     * Defines the list of possible SQL data types to which the source decimal values are converted. This list and the precision and the scale parameters of the decimal field determine the target type. In the order of NUMERIC, BIGNUMERIC, and STRING, a type is picked if it is in the specified list and if it supports the precision and the scale. STRING supports all precision and scale values. If none of the listed types supports the precision and the scale, the type supporting the widest range in the specified list is picked, and if a value exceeds the supported range when reading the data, an error will be thrown. Example: Suppose the value of this field is ["NUMERIC", "BIGNUMERIC"]. If (precision,scale) is: * (38,9) -> NUMERIC; * (39,9) -> BIGNUMERIC (NUMERIC cannot hold 30 integer digits); * (38,10) -> BIGNUMERIC (NUMERIC cannot hold 10 fractional digits); * (76,38) -> BIGNUMERIC; * (77,38) -> BIGNUMERIC (error if value exeeds supported range). This field cannot contain duplicate types. The order of the types in this field is ignored. For example, ["BIGNUMERIC", "NUMERIC"] is the same as ["NUMERIC", "BIGNUMERIC"] and NUMERIC always takes precedence over BIGNUMERIC. Defaults to ["NUMERIC", "STRING"] for ORC and ["NUMERIC"] for the other file formats.
      */
-    decimalTargetTypes?: Array<string>;
+    decimalTargetTypes?: Array<
+      'DECIMAL_TARGET_TYPE_UNSPECIFIED' | 'NUMERIC' | 'BIGNUMERIC' | 'STRING'
+    >;
     /**
-     * Custom encryption configuration (e.g., Cloud KMS keys).
+     * Custom encryption configuration (e.g., Cloud KMS keys)
      */
     destinationEncryptionConfiguration?: IEncryptionConfiguration;
     /**
@@ -1940,47 +2235,49 @@ declare namespace bigquery {
      */
     destinationTable?: ITableReference;
     /**
-     * [Beta] [Optional] Properties with which to create the destination table if it is new.
+     * Optional. [Experimental] Properties with which to create the destination table if it is new.
      */
     destinationTableProperties?: IDestinationTableProperties;
     /**
-     * [Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.
+     * Optional. The character encoding of the data. The supported values are UTF-8, ISO-8859-1, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the `quote` and `fieldDelimiter` properties. If you don't specify an encoding, or if you specify a UTF-8 encoding when the CSV file is not UTF-8 encoded, BigQuery attempts to convert the data to UTF-8. Generally, your data loads successfully, but it may not match byte-for-byte what you expect. To avoid this, specify the correct encoding by using the `--encoding` flag. If BigQuery can't convert a character other than the ASCII `0` character, BigQuery converts the character to the standard Unicode replacement character: �.
      */
     encoding?: string;
     /**
-     * [Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence "\t" to specify a tab separator. The default value is a comma (',').
+     * Optional. The separator character for fields in a CSV file. The separator is interpreted as a single byte. For files encoded in ISO-8859-1, any single character can be used as a separator. For files encoded in UTF-8, characters represented in decimal range 1-127 (U+0001-U+007F) can be used without any modification. UTF-8 characters encoded with multiple bytes (i.e. U+0080 and above) will have only the first byte used for separating fields. The remaining bytes will be treated as a part of the field. BigQuery also supports the escape sequence "\t" (U+0009) to specify a tab separator. The default value is comma (",", U+002C).
      */
     fieldDelimiter?: string;
     /**
-     * [Optional] Specifies how source URIs are interpreted for constructing the file set to load. By default source URIs are expanded against the underlying storage. Other options include specifying manifest files. Only applicable to object storage systems.
+     * Optional. Specifies how source URIs are interpreted for constructing the file set to load. By default, source URIs are expanded against the underlying storage. You can also specify manifest files to control how the file set is constructed. This option is only applicable to object storage systems.
      */
-    fileSetSpecType?: string;
+    fileSetSpecType?:
+      | 'FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH'
+      | 'FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST';
     /**
-     * [Optional] Options to configure hive partitioning support.
+     * Optional. When set, configures hive partitioning support. Not all storage formats support hive partitioning -- requesting hive partitioning on an unsupported format will lead to an error, as will providing an invalid specification.
      */
     hivePartitioningOptions?: IHivePartitioningOptions;
     /**
-     * [Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names
+     * Optional. Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names in the table schema Avro, Parquet, ORC: Fields in the file schema that don't exist in the table schema.
      */
     ignoreUnknownValues?: boolean;
     /**
-     * [Optional] If sourceFormat is set to newline-delimited JSON, indicates whether it should be processed as a JSON variant such as GeoJSON. For a sourceFormat other than JSON, omit this field. If the sourceFormat is newline-delimited JSON: - for newline-delimited GeoJSON: set to GEOJSON.
+     * Optional. Load option to be used together with source_format newline-delimited JSON to indicate that a variant of JSON is being loaded. To load newline-delimited GeoJSON, specify GEOJSON (and source_format must be set to NEWLINE_DELIMITED_JSON).
      */
-    jsonExtension?: string;
+    jsonExtension?: 'JSON_EXTENSION_UNSPECIFIED' | 'GEOJSON';
     /**
-     * [Optional] The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV and JSON. The default value is 0, which requires that all records are valid.
+     * Optional. The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. The default value is 0, which requires that all records are valid. This is only supported for CSV and NEWLINE_DELIMITED_JSON file formats.
      */
     maxBadRecords?: number;
     /**
-     * [Optional] Specifies a string that represents a null value in a CSV file. For example, if you specify "\N", BigQuery interprets "\N" as a null value when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as an empty value.
+     * Optional. Specifies a string that represents a null value in a CSV file. For example, if you specify "\N", BigQuery interprets "\N" as a null value when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as an empty value.
      */
     nullMarker?: string;
     /**
-     * [Optional] Options to configure parquet support.
+     * Optional. Additional properties to set if sourceFormat is set to PARQUET.
      */
     parquetOptions?: IParquetOptions;
     /**
-     * [Optional] Preserves the embedded ASCII control characters (the first 32 characters in the ASCII-table, from '\x00' to '\x1F') when loading from CSV. Only applicable to CSV, ignored for other formats.
+     * Optional. When sourceFormat is set to "CSV", this indicates whether the embedded ASCII control characters (the first 32 characters in the ASCII-table, from '\x00' to '\x1F') are preserved.
      */
     preserveAsciiControlCharacters?: boolean;
     /**
@@ -1988,19 +2285,19 @@ declare namespace bigquery {
      */
     projectionFields?: Array<string>;
     /**
-     * [Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.
+     * Optional. The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true. To include the specific quote character within a quoted value, precede it with an additional matching quote character. For example, if you want to escape the default character ' " ', use ' "" '. @default "
      */
     quote?: string;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
+     * Range partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * User provided referencing file with the expected reader schema, Available for the format: AVRO, PARQUET, ORC.
+     * Optional. The user can provide a reference file with the reader schema. This file is only loaded if it is part of source URIs, but is not loaded otherwise. It is enabled for the following formats: AVRO, PARQUET, ORC.
      */
     referenceFileSchemaUri?: string;
     /**
-     * [Optional] The schema for the destination table. The schema can be omitted if the destination table already exists, or if you're loading data from Google Cloud Datastore.
+     * Optional. The schema for the destination table. The schema can be omitted if the destination table already exists, or if you're loading data from Google Cloud Datastore.
      */
     schema?: ITableSchema;
     /**
@@ -2012,15 +2309,15 @@ declare namespace bigquery {
      */
     schemaInlineFormat?: string;
     /**
-     * Allows the schema of the destination table to be updated as a side effect of the load job if a schema is autodetected or supplied in the job configuration. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
+     * Allows the schema of the destination table to be updated as a side effect of the load job if a schema is autodetected or supplied in the job configuration. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
      */
     schemaUpdateOptions?: Array<string>;
     /**
-     * [Optional] The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.
+     * Optional. The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: number;
     /**
-     * [Optional] The format of the data files. For CSV files, specify "CSV". For datastore backups, specify "DATASTORE_BACKUP". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro, specify "AVRO". For parquet, specify "PARQUET". For orc, specify "ORC". The default value is CSV.
+     * Optional. The format of the data files. For CSV files, specify "CSV". For datastore backups, specify "DATASTORE_BACKUP". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro, specify "AVRO". For parquet, specify "PARQUET". For orc, specify "ORC". The default value is CSV.
      */
     sourceFormat?: string;
     /**
@@ -2032,26 +2329,29 @@ declare namespace bigquery {
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * [Optional] If sourceFormat is set to "AVRO", indicates whether to interpret logical types as the corresponding BigQuery data type (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
+     * Optional. If sourceFormat is set to "AVRO", indicates whether to interpret logical types as the corresponding BigQuery data type (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
      */
     useAvroLogicalTypes?: boolean;
     /**
-     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints and uses the schema from the load job. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
   };
 
+  /**
+   * JobConfigurationQuery configures a BigQuery query job.
+   */
   type IJobConfigurationQuery = {
     /**
-     * [Optional] If true and query uses legacy SQL dialect, allows the query to produce arbitrarily large result tables at a slight cost in performance. Requires destinationTable to be set. For standard SQL queries, this flag is ignored and large results are always allowed. However, you must still set destinationTable when result size exceeds the allowed maximum response size.
+     * Optional. If true and query uses legacy SQL dialect, allows the query to produce arbitrarily large result tables at a slight cost in performance. Requires destinationTable to be set. For GoogleSQL queries, this flag is ignored and large results are always allowed. However, you must still set destinationTable when result size exceeds the allowed maximum response size.
      */
     allowLargeResults?: boolean;
     /**
-     * [Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.
+     * Clustering specification for the destination table.
      */
     clustering?: IClustering;
     /**
-     * Connection properties.
+     * Connection properties which can modify the query behavior.
      */
     connectionProperties?: Array<IConnectionProperty>;
     /**
@@ -2059,39 +2359,39 @@ declare namespace bigquery {
      */
     continuous?: boolean;
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies whether the job is allowed to create new tables. The following values are supported: * CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. * CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
-     * If true, creates a new session, where session id will be a server generated random id. If false, runs query with an existing session_id passed in ConnectionProperty, otherwise runs query in non-session mode.
+     * If this property is true, the job creates a new session using a randomly generated session_id. To continue using a created session with subsequent queries, pass the existing session identifier as a `ConnectionProperty` value. The session identifier is returned as part of the `SessionInfo` message within the query statistics. The new session's location will be set to `Job.JobReference.location` if it is present, otherwise it's set to the default location based on existing routing logic.
      */
     createSession?: boolean;
     /**
-     * [Optional] Specifies the default dataset to use for unqualified table names in the query. Note that this does not alter behavior of unqualified dataset names.
+     * Optional. Specifies the default dataset to use for unqualified table names in the query. This setting does not alter behavior of unqualified dataset names. Setting the system variable `@@dataset_id` achieves the same behavior. See https://cloud.google.com/bigquery/docs/reference/system-variables for more information on system variables.
      */
     defaultDataset?: IDatasetReference;
     /**
-     * Custom encryption configuration (e.g., Cloud KMS keys).
+     * Custom encryption configuration (e.g., Cloud KMS keys)
      */
     destinationEncryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Optional] Describes the table where the query results should be stored. If not present, a new table will be created to store the results. This property must be set for large results that exceed the maximum response size.
+     * Optional. Describes the table where the query results should be stored. This property must be set for large results that exceed the maximum response size. For queries that produce anonymous (cached) results, this field will be populated by BigQuery.
      */
     destinationTable?: ITableReference;
     /**
-     * [Optional] If true and query uses legacy SQL dialect, flattens all nested and repeated fields in the query results. allowLargeResults must be true if this is set to false. For standard SQL queries, this flag is ignored and results are never flattened.
+     * Optional. If true and query uses legacy SQL dialect, flattens all nested and repeated fields in the query results. allowLargeResults must be true if this is set to false. For GoogleSQL queries, this flag is ignored and results are never flattened.
      */
     flattenResults?: boolean;
     /**
-     * [Optional] Limits the billing tier for this job. Queries that have resource usage beyond this tier will fail (without incurring a charge). If unspecified, this will be set to your project default.
+     * Optional. [Deprecated] Maximum billing tier allowed for this query. The billing tier controls the amount of compute resources allotted to the query, and multiplies the on-demand cost of the query accordingly. A query that runs within its allotted resources will succeed and indicate its billing tier in statistics.query.billingTier, but if the query exceeds its allotted resources, it will fail with billingTierLimitExceeded. WARNING: The billed byte amount can be multiplied by an amount up to this number! Most users should not need to alter this setting, and we recommend that you avoid introducing new uses of it.
      */
     maximumBillingTier?: number;
     /**
-     * [Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.
+     * Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.
      */
     maximumBytesBilled?: string;
     /**
-     * Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
+     * GoogleSQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
      */
     parameterMode?: string;
     /**
@@ -2099,27 +2399,35 @@ declare namespace bigquery {
      */
     preserveNulls?: boolean;
     /**
-     * [Optional] Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.
+     * Optional. Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.
      */
     priority?: string;
     /**
-     * [Required] SQL query text to execute. The useLegacySql field can be used to indicate whether the query uses legacy SQL or standard SQL.
+     * [Required] SQL query text to execute. The useLegacySql field can be used to indicate whether the query uses legacy SQL or GoogleSQL.
      */
     query?: string;
     /**
-     * Query parameters for standard SQL queries.
+     * Query parameters for GoogleSQL queries.
      */
     queryParameters?: Array<IQueryParameter>;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
+     * Range partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
+     * Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: * ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. * ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.
      */
     schemaUpdateOptions?: Array<string>;
     /**
-     * [Optional] If querying an external data source outside of BigQuery, describes the data format, location and other properties of the data source. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.
+     * Options controlling the execution of scripts.
+     */
+    scriptOptions?: IScriptOptions;
+    /**
+     * Output only. System variables for GoogleSQL queries. A system variable is output if the variable is settable and its value differs from the system default. "@@" prefix is not included in the name of the System variables.
+     */
+    systemVariables?: ISystemVariables;
+    /**
+     * Optional. You can specify external table definitions, which operate as ephemeral tables that can be queried. These definitions are configured using a JSON map, where the string key represents the table identifier, and the value is the corresponding external data configuration object.
      */
     tableDefinitions?: {[key: string]: IExternalDataConfiguration};
     /**
@@ -2127,11 +2435,11 @@ declare namespace bigquery {
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
+     * Optional. Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
      */
     useLegacySql?: boolean;
     /**
-     * [Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. Moreover, the query cache is only available when a query does not have a destination table specified. The default value is true.
+     * Optional. Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. Moreover, the query cache is only available when a query does not have a destination table specified. The default value is true.
      */
     useQueryCache?: boolean;
     /**
@@ -2139,14 +2447,17 @@ declare namespace bigquery {
      */
     userDefinedFunctionResources?: Array<IUserDefinedFunctionResource>;
     /**
-     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints, and uses the schema from the query result. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
   };
 
+  /**
+   * JobConfigurationTableCopy configures a job that copies data from one table to another. For more information on copying tables, see [Copy a table](https://cloud.google.com/bigquery/docs/managing-tables#copy-table).
+   */
   type IJobConfigurationTableCopy = {
     /**
-     * [Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies whether the job is allowed to create new tables. The following values are supported: * CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. * CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     createDisposition?: string;
     /**
@@ -2154,17 +2465,22 @@ declare namespace bigquery {
      */
     destinationEncryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Optional] The time when the destination table expires. Expired tables will be deleted and their storage reclaimed.
+     * Optional. The time when the destination table expires. Expired tables will be deleted and their storage reclaimed.
      */
-    destinationExpirationTime?: any;
+    destinationExpirationTime?: string;
     /**
-     * [Required] The destination table
+     * [Required] The destination table.
      */
     destinationTable?: ITableReference;
     /**
-     * [Optional] Supported operation types in table copy job.
+     * Optional. Supported operation types in table copy job.
      */
-    operationType?: string;
+    operationType?:
+      | 'OPERATION_TYPE_UNSPECIFIED'
+      | 'COPY'
+      | 'SNAPSHOT'
+      | 'RESTORE'
+      | 'CLONE';
     /**
      * [Pick one] Source table to copy.
      */
@@ -2174,11 +2490,29 @@ declare namespace bigquery {
      */
     sourceTables?: Array<ITableReference>;
     /**
-     * [Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema and table constraints from the source table. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
   };
 
+  /**
+   * Reason about why a Job was created from a [`jobs.query`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) method when used with `JOB_CREATION_OPTIONAL` Job creation mode. For [`jobs.insert`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert) method calls it will always be `REQUESTED`. This feature is not yet available. Jobs will always be created.
+   */
+  type IJobCreationReason = {
+    /**
+     * Output only. Specifies the high level reason why a Job was created.
+     */
+    code?:
+      | 'CODE_UNSPECIFIED'
+      | 'REQUESTED'
+      | 'LONG_RUNNING'
+      | 'LARGE_RESULTS'
+      | 'OTHER';
+  };
+
+  /**
+   * JobList is the response format for a jobs.list call.
+   */
   type IJobList = {
     /**
      * A hash of this page of results.
@@ -2189,7 +2523,7 @@ declare namespace bigquery {
      */
     jobs?: Array<{
       /**
-       * [Full-projection-only] Specifies the job configuration.
+       * Required. Describes the job configuration.
        */
       configuration?: IJobConfiguration;
       /**
@@ -2201,7 +2535,7 @@ declare namespace bigquery {
        */
       id?: string;
       /**
-       * Job reference uniquely identifying the job.
+       * Unique opaque ID of the job.
        */
       jobReference?: IJobReference;
       /**
@@ -2209,15 +2543,19 @@ declare namespace bigquery {
        */
       kind?: string;
       /**
+       * [Full-projection-only] String representation of identity of requesting party. Populated for both first- and third-party identities. Only present for APIs that support third-party identities.
+       */
+      principal_subject?: string;
+      /**
        * Running state of the job. When the state is DONE, errorResult can be checked to determine whether the job succeeded or failed.
        */
       state?: string;
       /**
-       * [Output-only] Information about the job, including starting time and ending time of the job.
+       * Output only. Information about the job, including starting time and ending time of the job.
        */
       statistics?: IJobStatistics;
       /**
-       * [Full-projection-only] Describes the state of the job.
+       * [Full-projection-only] Describes the status of this job.
        */
       status?: IJobStatus;
       /**
@@ -2233,315 +2571,393 @@ declare namespace bigquery {
      * A token to request the next page of results.
      */
     nextPageToken?: string;
+    /**
+     * A list of skipped locations that were unreachable. For more information about BigQuery locations, see: https://cloud.google.com/bigquery/docs/locations. Example: "europe-west5"
+     */
+    unreachable?: Array<string>;
   };
 
+  /**
+   * A job reference is a fully qualified identifier for referring to a job.
+   */
   type IJobReference = {
     /**
-     * [Required] The ID of the job. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024 characters.
+     * Required. The ID of the job. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024 characters.
      */
     jobId?: string;
     /**
-     * The geographic location of the job. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+     * Optional. The geographic location of the job. The default value is US. For more information about BigQuery locations, see: https://cloud.google.com/bigquery/docs/locations
      */
     location?: string;
     /**
-     * [Required] The ID of the project containing this job.
+     * Required. The ID of the project containing this job.
      */
     projectId?: string;
   };
 
+  /**
+   * Statistics for a single job execution.
+   */
   type IJobStatistics = {
     /**
-     * [TrustedTester] [Output-only] Job progress (0.0 -> 1.0) for LOAD and EXTRACT jobs.
+     * Output only. [TrustedTester] Job progress (0.0 -> 1.0) for LOAD and EXTRACT jobs.
      */
     completionRatio?: number;
     /**
-     * [Output-only] Statistics for a copy job.
+     * Output only. Statistics for a copy job.
      */
     copy?: IJobStatistics5;
     /**
-     * [Output-only] Creation time of this job, in milliseconds since the epoch. This field will be present on all jobs.
+     * Output only. Creation time of this job, in milliseconds since the epoch. This field will be present on all jobs.
      */
     creationTime?: string;
     /**
-     * [Output-only] Statistics for data masking. Present only for query and extract jobs.
+     * Output only. Statistics for data-masking. Present only for query and extract jobs.
      */
     dataMaskingStatistics?: IDataMaskingStatistics;
     /**
-     * [Output-only] End time of this job, in milliseconds since the epoch. This field will be present whenever a job is in the DONE state.
+     * Output only. End time of this job, in milliseconds since the epoch. This field will be present whenever a job is in the DONE state.
      */
     endTime?: string;
     /**
-     * [Output-only] Statistics for an extract job.
+     * Output only. Statistics for an extract job.
      */
     extract?: IJobStatistics4;
     /**
-     * [Output-only] Statistics for a load job.
+     * Output only. The duration in milliseconds of the execution of the final attempt of this job, as BigQuery may internally re-attempt to execute the job.
+     */
+    finalExecutionDurationMs?: string;
+    /**
+     * Output only. Statistics for a load job.
      */
     load?: IJobStatistics3;
     /**
-     * [Output-only] Number of child jobs executed.
+     * Output only. Number of child jobs executed.
      */
     numChildJobs?: string;
     /**
-     * [Output-only] If this is a child job, the id of the parent.
+     * Output only. If this is a child job, specifies the job ID of the parent.
      */
     parentJobId?: string;
     /**
-     * [Output-only] Statistics for a query job.
+     * Output only. Statistics for a query job.
      */
     query?: IJobStatistics2;
     /**
-     * [Output-only] Quotas which delayed this job's start time.
+     * Output only. Quotas which delayed this job's start time.
      */
     quotaDeferments?: Array<string>;
     /**
-     * [Output-only] Job resource usage breakdown by reservation.
+     * Output only. Job resource usage breakdown by reservation. This field reported misleading information and will no longer be populated.
      */
     reservationUsage?: Array<{
       /**
-       * [Output-only] Reservation name or "unreserved" for on-demand resources usage.
+       * Reservation name or "unreserved" for on-demand resources usage.
        */
       name?: string;
       /**
-       * [Output-only] Slot-milliseconds the job spent in the given reservation.
+       * Total slot milliseconds used by the reservation for a particular job.
        */
       slotMs?: string;
     }>;
     /**
-     * [Output-only] Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+     * Output only. Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
      */
     reservation_id?: string;
     /**
-     * [Output-only] [Preview] Statistics for row-level security. Present only for query and extract jobs.
+     * Output only. Statistics for row-level security. Present only for query and extract jobs.
      */
     rowLevelSecurityStatistics?: IRowLevelSecurityStatistics;
     /**
-     * [Output-only] Statistics for a child job of a script.
+     * Output only. If this a child job of a script, specifies information about the context of this job within the script.
      */
     scriptStatistics?: IScriptStatistics;
     /**
-     * [Output-only] [Preview] Information of the session if this job is part of one.
+     * Output only. Information of the session if this job is part of one.
      */
     sessionInfo?: ISessionInfo;
     /**
-     * [Output-only] Start time of this job, in milliseconds since the epoch. This field will be present when the job transitions from the PENDING state to either RUNNING or DONE.
+     * Output only. Start time of this job, in milliseconds since the epoch. This field will be present when the job transitions from the PENDING state to either RUNNING or DONE.
      */
     startTime?: string;
     /**
-     * [Output-only] [Deprecated] Use the bytes processed in the query statistics instead.
+     * Output only. Total bytes processed for the job.
      */
     totalBytesProcessed?: string;
     /**
-     * [Output-only] Slot-milliseconds for the job.
+     * Output only. Slot-milliseconds for the job.
      */
     totalSlotMs?: string;
     /**
-     * [Output-only] [Alpha] Information of the multi-statement transaction if this job is part of one.
+     * Output only. [Alpha] Information of the multi-statement transaction if this job is part of one. This property is only expected on a child job or a job that is in a session. A script parent job is not part of the transaction started in the script.
      */
     transactionInfo?: ITransactionInfo;
   };
 
+  /**
+   * Statistics for a query job.
+   */
   type IJobStatistics2 = {
     /**
-     * BI Engine specific Statistics. [Output only] BI Engine specific Statistics.
+     * Output only. BI Engine specific Statistics.
      */
     biEngineStatistics?: IBiEngineStatistics;
     /**
-     * [Output only] Billing tier for the job.
+     * Output only. Billing tier for the job. This is a BigQuery-specific concept which is not related to the Google Cloud notion of "free tier". The value here is a measure of the query's resource consumption relative to the amount of data scanned. For on-demand queries, the limit is 100, and all queries within this limit are billed at the standard on-demand rates. On-demand queries that exceed this limit will fail with a billingTierLimitExceeded error.
      */
     billingTier?: number;
     /**
-     * [Output only] Whether the query result was fetched from the query cache.
+     * Output only. Whether the query result was fetched from the query cache.
      */
     cacheHit?: boolean;
     /**
-     * [Output only] [Preview] The number of row access policies affected by a DDL statement. Present only for DROP ALL ROW ACCESS POLICIES queries.
+     * Output only. Referenced dataset for DCL statement.
+     */
+    dclTargetDataset?: IDatasetReference;
+    /**
+     * Output only. Referenced table for DCL statement.
+     */
+    dclTargetTable?: ITableReference;
+    /**
+     * Output only. Referenced view for DCL statement.
+     */
+    dclTargetView?: ITableReference;
+    /**
+     * Output only. The number of row access policies affected by a DDL statement. Present only for DROP ALL ROW ACCESS POLICIES queries.
      */
     ddlAffectedRowAccessPolicyCount?: string;
     /**
-     * [Output only] The DDL destination table. Present only for ALTER TABLE RENAME TO queries. Note that ddl_target_table is used just for its type information.
+     * Output only. The table after rename. Present only for ALTER TABLE RENAME TO query.
      */
     ddlDestinationTable?: ITableReference;
     /**
-     * The DDL operation performed, possibly dependent on the pre-existence of the DDL target. Possible values (new values might be added in the future): "CREATE": The query created the DDL target. "SKIP": No-op. Example cases: the query is CREATE TABLE IF NOT EXISTS while the table already exists, or the query is DROP TABLE IF EXISTS while the table does not exist. "REPLACE": The query replaced the DDL target. Example case: the query is CREATE OR REPLACE TABLE, and the table already exists. "DROP": The query deleted the DDL target.
+     * Output only. The DDL operation performed, possibly dependent on the pre-existence of the DDL target.
      */
     ddlOperationPerformed?: string;
     /**
-     * [Output only] The DDL target dataset. Present only for CREATE/ALTER/DROP SCHEMA queries.
+     * Output only. The DDL target dataset. Present only for CREATE/ALTER/DROP SCHEMA(dataset) queries.
      */
     ddlTargetDataset?: IDatasetReference;
     /**
-     * The DDL target routine. Present only for CREATE/DROP FUNCTION/PROCEDURE queries.
+     * Output only. [Beta] The DDL target routine. Present only for CREATE/DROP FUNCTION/PROCEDURE queries.
      */
     ddlTargetRoutine?: IRoutineReference;
     /**
-     * [Output only] [Preview] The DDL target row access policy. Present only for CREATE/DROP ROW ACCESS POLICY queries.
+     * Output only. The DDL target row access policy. Present only for CREATE/DROP ROW ACCESS POLICY queries.
      */
     ddlTargetRowAccessPolicy?: IRowAccessPolicyReference;
     /**
-     * [Output only] The DDL target table. Present only for CREATE/DROP TABLE/VIEW and DROP ALL ROW ACCESS POLICIES queries.
+     * Output only. The DDL target table. Present only for CREATE/DROP TABLE/VIEW and DROP ALL ROW ACCESS POLICIES queries.
      */
     ddlTargetTable?: ITableReference;
     /**
-     * [Output only] Detailed statistics for DML statements Present only for DML statements INSERT, UPDATE, DELETE or TRUNCATE.
+     * Output only. Detailed statistics for DML statements INSERT, UPDATE, DELETE, MERGE or TRUNCATE.
      */
     dmlStats?: IDmlStatistics;
     /**
-     * [Output only] The original estimate of bytes processed for the job.
+     * Output only. The original estimate of bytes processed for the job.
      */
     estimatedBytesProcessed?: string;
     /**
-     * [Output only] Statistics of a BigQuery ML training job.
+     * Output only. Stats for EXPORT DATA statement.
+     */
+    exportDataStatistics?: IExportDataStatistics;
+    /**
+     * Output only. Job cost breakdown as bigquery internal cost and external service costs.
+     */
+    externalServiceCosts?: Array<IExternalServiceCost>;
+    /**
+     * Output only. Statistics for a LOAD query.
+     */
+    loadQueryStatistics?: ILoadQueryStatistics;
+    /**
+     * Output only. Statistics of materialized views of a query job.
+     */
+    materializedViewStatistics?: IMaterializedViewStatistics;
+    /**
+     * Output only. Statistics of metadata cache usage in a query for BigLake tables.
+     */
+    metadataCacheStatistics?: IMetadataCacheStatistics;
+    /**
+     * Output only. Statistics of a BigQuery ML training job.
      */
     mlStatistics?: IMlStatistics;
     /**
-     * [Output only, Beta] Information about create model query job progress.
+     * Deprecated.
      */
     modelTraining?: IBigQueryModelTraining;
     /**
-     * [Output only, Beta] Deprecated; do not use.
+     * Deprecated.
      */
     modelTrainingCurrentIteration?: number;
     /**
-     * [Output only, Beta] Deprecated; do not use.
+     * Deprecated.
      */
     modelTrainingExpectedTotalIteration?: string;
     /**
-     * [Output only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
+     * Output only. The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
      */
     numDmlAffectedRows?: string;
     /**
-     * [Output only] Describes execution plan for the query.
+     * Output only. Performance insights.
+     */
+    performanceInsights?: IPerformanceInsights;
+    /**
+     * Output only. Query optimization information for a QUERY job.
+     */
+    queryInfo?: IQueryInfo;
+    /**
+     * Output only. Describes execution plan for the query.
      */
     queryPlan?: Array<IExplainQueryStage>;
     /**
-     * [Output only] Referenced routines (persistent user-defined functions and stored procedures) for the job.
+     * Output only. Referenced routines for the job.
      */
     referencedRoutines?: Array<IRoutineReference>;
     /**
-     * [Output only] Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
+     * Output only. Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
      */
     referencedTables?: Array<ITableReference>;
     /**
-     * [Output only] Job resource usage breakdown by reservation.
+     * Output only. Job resource usage breakdown by reservation. This field reported misleading information and will no longer be populated.
      */
     reservationUsage?: Array<{
       /**
-       * [Output only] Reservation name or "unreserved" for on-demand resources usage.
+       * Reservation name or "unreserved" for on-demand resources usage.
        */
       name?: string;
       /**
-       * [Output only] Slot-milliseconds the job spent in the given reservation.
+       * Total slot milliseconds used by the reservation for a particular job.
        */
       slotMs?: string;
     }>;
     /**
-     * [Output only] The schema of the results. Present only for successful dry run of non-legacy SQL queries.
+     * Output only. The schema of the results. Present only for successful dry run of non-legacy SQL queries.
      */
     schema?: ITableSchema;
     /**
-     * [Output only] Search query specific statistics.
+     * Output only. Search query specific statistics.
      */
     searchStatistics?: ISearchStatistics;
     /**
-     * [Output only] Statistics of a Spark procedure job.
+     * Output only. Statistics of a Spark procedure job.
      */
     sparkStatistics?: ISparkStatistics;
     /**
-     * The type of query statement, if valid. Possible values (new values might be added in the future): "SELECT": SELECT query. "INSERT": INSERT query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "UPDATE": UPDATE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "DELETE": DELETE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "MERGE": MERGE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. "ALTER_TABLE": ALTER TABLE query. "ALTER_VIEW": ALTER VIEW query. "ASSERT": ASSERT condition AS 'description'. "CREATE_FUNCTION": CREATE FUNCTION query. "CREATE_MODEL": CREATE [OR REPLACE] MODEL ... AS SELECT ... . "CREATE_PROCEDURE": CREATE PROCEDURE query. "CREATE_TABLE": CREATE [OR REPLACE] TABLE without AS SELECT. "CREATE_TABLE_AS_SELECT": CREATE [OR REPLACE] TABLE ... AS SELECT ... . "CREATE_VIEW": CREATE [OR REPLACE] VIEW ... AS SELECT ... . "DROP_FUNCTION" : DROP FUNCTION query. "DROP_PROCEDURE": DROP PROCEDURE query. "DROP_TABLE": DROP TABLE query. "DROP_VIEW": DROP VIEW query.
+     * Output only. The type of query statement, if valid. Possible values: * `SELECT`: [`SELECT`](/bigquery/docs/reference/standard-sql/query-syntax#select_list) statement. * `ASSERT`: [`ASSERT`](/bigquery/docs/reference/standard-sql/debugging-statements#assert) statement. * `INSERT`: [`INSERT`](/bigquery/docs/reference/standard-sql/dml-syntax#insert_statement) statement. * `UPDATE`: [`UPDATE`](/bigquery/docs/reference/standard-sql/query-syntax#update_statement) statement. * `DELETE`: [`DELETE`](/bigquery/docs/reference/standard-sql/data-manipulation-language) statement. * `MERGE`: [`MERGE`](/bigquery/docs/reference/standard-sql/data-manipulation-language) statement. * `CREATE_TABLE`: [`CREATE TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement) statement, without `AS SELECT`. * `CREATE_TABLE_AS_SELECT`: [`CREATE TABLE AS SELECT`](/bigquery/docs/reference/standard-sql/data-definition-language#query_statement) statement. * `CREATE_VIEW`: [`CREATE VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#create_view_statement) statement. * `CREATE_MODEL`: [`CREATE MODEL`](/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-create#create_model_statement) statement. * `CREATE_MATERIALIZED_VIEW`: [`CREATE MATERIALIZED VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#create_materialized_view_statement) statement. * `CREATE_FUNCTION`: [`CREATE FUNCTION`](/bigquery/docs/reference/standard-sql/data-definition-language#create_function_statement) statement. * `CREATE_TABLE_FUNCTION`: [`CREATE TABLE FUNCTION`](/bigquery/docs/reference/standard-sql/data-definition-language#create_table_function_statement) statement. * `CREATE_PROCEDURE`: [`CREATE PROCEDURE`](/bigquery/docs/reference/standard-sql/data-definition-language#create_procedure) statement. * `CREATE_ROW_ACCESS_POLICY`: [`CREATE ROW ACCESS POLICY`](/bigquery/docs/reference/standard-sql/data-definition-language#create_row_access_policy_statement) statement. * `CREATE_SCHEMA`: [`CREATE SCHEMA`](/bigquery/docs/reference/standard-sql/data-definition-language#create_schema_statement) statement. * `CREATE_SNAPSHOT_TABLE`: [`CREATE SNAPSHOT TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#create_snapshot_table_statement) statement. * `CREATE_SEARCH_INDEX`: [`CREATE SEARCH INDEX`](/bigquery/docs/reference/standard-sql/data-definition-language#create_search_index_statement) statement. * `DROP_TABLE`: [`DROP TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_table_statement) statement. * `DROP_EXTERNAL_TABLE`: [`DROP EXTERNAL TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_external_table_statement) statement. * `DROP_VIEW`: [`DROP VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_view_statement) statement. * `DROP_MODEL`: [`DROP MODEL`](/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-drop-model) statement. * `DROP_MATERIALIZED_VIEW`: [`DROP MATERIALIZED VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_materialized_view_statement) statement. * `DROP_FUNCTION` : [`DROP FUNCTION`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_function_statement) statement. * `DROP_TABLE_FUNCTION` : [`DROP TABLE FUNCTION`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_table_function) statement. * `DROP_PROCEDURE`: [`DROP PROCEDURE`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_procedure_statement) statement. * `DROP_SEARCH_INDEX`: [`DROP SEARCH INDEX`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_search_index) statement. * `DROP_SCHEMA`: [`DROP SCHEMA`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_schema_statement) statement. * `DROP_SNAPSHOT_TABLE`: [`DROP SNAPSHOT TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_snapshot_table_statement) statement. * `DROP_ROW_ACCESS_POLICY`: [`DROP [ALL] ROW ACCESS POLICY|POLICIES`](/bigquery/docs/reference/standard-sql/data-definition-language#drop_row_access_policy_statement) statement. * `ALTER_TABLE`: [`ALTER TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_set_options_statement) statement. * `ALTER_VIEW`: [`ALTER VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#alter_view_set_options_statement) statement. * `ALTER_MATERIALIZED_VIEW`: [`ALTER MATERIALIZED VIEW`](/bigquery/docs/reference/standard-sql/data-definition-language#alter_materialized_view_set_options_statement) statement. * `ALTER_SCHEMA`: [`ALTER SCHEMA`](/bigquery/docs/reference/standard-sql/data-definition-language#aalter_schema_set_options_statement) statement. * `SCRIPT`: [`SCRIPT`](/bigquery/docs/reference/standard-sql/procedural-language). * `TRUNCATE_TABLE`: [`TRUNCATE TABLE`](/bigquery/docs/reference/standard-sql/dml-syntax#truncate_table_statement) statement. * `CREATE_EXTERNAL_TABLE`: [`CREATE EXTERNAL TABLE`](/bigquery/docs/reference/standard-sql/data-definition-language#create_external_table_statement) statement. * `EXPORT_DATA`: [`EXPORT DATA`](/bigquery/docs/reference/standard-sql/other-statements#export_data_statement) statement. * `EXPORT_MODEL`: [`EXPORT MODEL`](/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-export-model) statement. * `LOAD_DATA`: [`LOAD DATA`](/bigquery/docs/reference/standard-sql/other-statements#load_data_statement) statement. * `CALL`: [`CALL`](/bigquery/docs/reference/standard-sql/procedural-language#call) statement.
      */
     statementType?: string;
     /**
-     * [Output only] [Beta] Describes a timeline of job execution.
+     * Output only. Describes a timeline of job execution.
      */
     timeline?: Array<IQueryTimelineSample>;
     /**
-     * [Output only] Total bytes billed for the job.
+     * Output only. If the project is configured to use on-demand pricing, then this field contains the total bytes billed for the job. If the project is configured to use flat-rate pricing, then you are not billed for bytes and this field is informational only.
      */
     totalBytesBilled?: string;
     /**
-     * [Output only] Total bytes processed for the job.
+     * Output only. Total bytes processed for the job.
      */
     totalBytesProcessed?: string;
     /**
-     * [Output only] For dry-run jobs, totalBytesProcessed is an estimate and this field specifies the accuracy of the estimate. Possible values can be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is precise. LOWER_BOUND: estimate is lower bound of what the query would cost. UPPER_BOUND: estimate is upper bound of what the query would cost.
+     * Output only. For dry-run jobs, totalBytesProcessed is an estimate and this field specifies the accuracy of the estimate. Possible values can be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is precise. LOWER_BOUND: estimate is lower bound of what the query would cost. UPPER_BOUND: estimate is upper bound of what the query would cost.
      */
     totalBytesProcessedAccuracy?: string;
     /**
-     * [Output only] Total number of partitions processed from all partitioned tables referenced in the job.
+     * Output only. Total number of partitions processed from all partitioned tables referenced in the job.
      */
     totalPartitionsProcessed?: string;
     /**
-     * [Output only] Slot-milliseconds for the job.
+     * Output only. Slot-milliseconds for the job.
      */
     totalSlotMs?: string;
     /**
-     * [Output-only] Total bytes transferred for cross-cloud queries such as Cross Cloud Transfer and CREATE TABLE AS SELECT (CTAS).
+     * Output only. Total bytes transferred for cross-cloud queries such as Cross Cloud Transfer and CREATE TABLE AS SELECT (CTAS).
      */
     transferredBytes?: string;
     /**
-     * Standard SQL only: list of undeclared query parameters detected during a dry run validation.
+     * Output only. GoogleSQL only: list of undeclared query parameters detected during a dry run validation.
      */
     undeclaredQueryParameters?: Array<IQueryParameter>;
+    /**
+     * Output only. Search query specific statistics.
+     */
+    vectorSearchStatistics?: IVectorSearchStatistics;
   };
 
+  /**
+   * Statistics for a load job.
+   */
   type IJobStatistics3 = {
     /**
-     * [Output-only] The number of bad records encountered. Note that if the job has failed because of more bad records encountered than the maximum allowed in the load job configuration, then this number can be less than the total number of bad records present in the input data.
+     * Output only. The number of bad records encountered. Note that if the job has failed because of more bad records encountered than the maximum allowed in the load job configuration, then this number can be less than the total number of bad records present in the input data.
      */
     badRecords?: string;
     /**
-     * [Output-only] Number of bytes of source data in a load job.
+     * Output only. Number of bytes of source data in a load job.
      */
     inputFileBytes?: string;
     /**
-     * [Output-only] Number of source files in a load job.
+     * Output only. Number of source files in a load job.
      */
     inputFiles?: string;
     /**
-     * [Output-only] Size of the loaded data in bytes. Note that while a load job is in the running state, this value may change.
+     * Output only. Size of the loaded data in bytes. Note that while a load job is in the running state, this value may change.
      */
     outputBytes?: string;
     /**
-     * [Output-only] Number of rows imported in a load job. Note that while an import job is in the running state, this value may change.
+     * Output only. Number of rows imported in a load job. Note that while an import job is in the running state, this value may change.
      */
     outputRows?: string;
+    /**
+     * Output only. Describes a timeline of job execution.
+     */
+    timeline?: Array<IQueryTimelineSample>;
   };
 
+  /**
+   * Statistics for an extract job.
+   */
   type IJobStatistics4 = {
     /**
-     * [Output-only] Number of files per destination URI or URI pattern specified in the extract configuration. These values will be in the same order as the URIs specified in the 'destinationUris' field.
+     * Output only. Number of files per destination URI or URI pattern specified in the extract configuration. These values will be in the same order as the URIs specified in the 'destinationUris' field.
      */
     destinationUriFileCounts?: Array<string>;
     /**
-     * [Output-only] Number of user bytes extracted into the result. This is the byte count as computed by BigQuery for billing purposes.
+     * Output only. Number of user bytes extracted into the result. This is the byte count as computed by BigQuery for billing purposes and doesn't have any relationship with the number of actual result bytes extracted in the desired format.
      */
     inputBytes?: string;
+    /**
+     * Output only. Describes a timeline of job execution.
+     */
+    timeline?: Array<IQueryTimelineSample>;
   };
 
+  /**
+   * Statistics for a copy job.
+   */
   type IJobStatistics5 = {
     /**
-     * [Output-only] Number of logical bytes copied to the destination table.
+     * Output only. Number of logical bytes copied to the destination table.
      */
     copiedLogicalBytes?: string;
     /**
-     * [Output-only] Number of rows copied to the destination table.
+     * Output only. Number of rows copied to the destination table.
      */
     copiedRows?: string;
   };
 
   type IJobStatus = {
     /**
-     * [Output-only] Final error result of the job. If present, indicates that the job has completed and was unsuccessful.
+     * Output only. Final error result of the job. If present, indicates that the job has completed and was unsuccessful.
      */
     errorResult?: IErrorProto;
     /**
-     * [Output-only] The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
+     * Output only. The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has not completed or was unsuccessful.
      */
     errors?: Array<IErrorProto>;
     /**
-     * [Output-only] Running state of the job.
+     * Output only. Running state of the job. Valid states include 'PENDING', 'RUNNING', and 'DONE'.
      */
     state?: string;
   };
@@ -2551,15 +2967,31 @@ declare namespace bigquery {
    */
   type IJsonObject = {[key: string]: IJsonValue};
 
+  /**
+   * Json Options for load and make external tables.
+   */
   type IJsonOptions = {
     /**
-     * [Optional] The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8.
+     * Optional. The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8.
      */
     encoding?: string;
   };
 
   type IJsonValue = any;
 
+  /**
+   * A dataset source type which refers to another BigQuery dataset.
+   */
+  type ILinkedDatasetSource = {
+    /**
+     * The source dataset reference contains project numbers and not project ids.
+     */
+    sourceDataset?: IDatasetReference;
+  };
+
+  /**
+   * Response format for a single page when listing BigQuery ML models.
+   */
   type IListModelsResponse = {
     /**
      * Models in the requested dataset. Only the following fields are populated: model_reference, model_type, creation_time, last_modified_time and labels.
@@ -2571,6 +3003,9 @@ declare namespace bigquery {
     nextPageToken?: string;
   };
 
+  /**
+   * Describes the format of a single result page when listing routines.
+   */
   type IListRoutinesResponse = {
     /**
      * A token to request the next page of results.
@@ -2597,6 +3032,36 @@ declare namespace bigquery {
   };
 
   /**
+   * Statistics for a LOAD query.
+   */
+  type ILoadQueryStatistics = {
+    /**
+     * Output only. The number of bad records encountered while processing a LOAD query. Note that if the job has failed because of more bad records encountered than the maximum allowed in the load job configuration, then this number can be less than the total number of bad records present in the input data.
+     */
+    badRecords?: string;
+    /**
+     * Output only. This field is deprecated. The number of bytes of source data copied over the network for a `LOAD` query. `transferred_bytes` has the canonical value for physical transferred bytes, which is used for BigQuery Omni billing.
+     */
+    bytesTransferred?: string;
+    /**
+     * Output only. Number of bytes of source data in a LOAD query.
+     */
+    inputFileBytes?: string;
+    /**
+     * Output only. Number of source files in a LOAD query.
+     */
+    inputFiles?: string;
+    /**
+     * Output only. Size of the loaded data in bytes. Note that while a LOAD query is in the running state, this value may change.
+     */
+    outputBytes?: string;
+    /**
+     * Output only. Number of rows imported in a LOAD query. Note that while a LOAD query is in the running state, this value may change.
+     */
+    outputRows?: string;
+  };
+
+  /**
    * BigQuery-specific metadata about a location. This will be set on google.cloud.location.Location.metadata in Cloud Location API responses.
    */
   type ILocationMetadata = {
@@ -2606,17 +3071,54 @@ declare namespace bigquery {
     legacyLocationId?: string;
   };
 
+  /**
+   * A materialized view considered for a query job.
+   */
+  type IMaterializedView = {
+    /**
+     * Whether the materialized view is chosen for the query. A materialized view can be chosen to rewrite multiple parts of the same query. If a materialized view is chosen to rewrite any part of the query, then this field is true, even if the materialized view was not chosen to rewrite others parts.
+     */
+    chosen?: boolean;
+    /**
+     * If present, specifies a best-effort estimation of the bytes saved by using the materialized view rather than its base tables.
+     */
+    estimatedBytesSaved?: string;
+    /**
+     * If present, specifies the reason why the materialized view was not chosen for the query.
+     */
+    rejectedReason?:
+      | 'REJECTED_REASON_UNSPECIFIED'
+      | 'NO_DATA'
+      | 'COST'
+      | 'BASE_TABLE_TRUNCATED'
+      | 'BASE_TABLE_DATA_CHANGE'
+      | 'BASE_TABLE_PARTITION_EXPIRATION_CHANGE'
+      | 'BASE_TABLE_EXPIRED_PARTITION'
+      | 'BASE_TABLE_INCOMPATIBLE_METADATA_CHANGE'
+      | 'TIME_ZONE'
+      | 'OUT_OF_TIME_TRAVEL_WINDOW'
+      | 'BASE_TABLE_FINE_GRAINED_SECURITY_POLICY'
+      | 'BASE_TABLE_TOO_STALE';
+    /**
+     * The candidate materialized view.
+     */
+    tableReference?: ITableReference;
+  };
+
+  /**
+   * Definition and configuration of a materialized view.
+   */
   type IMaterializedViewDefinition = {
     /**
-     * [Optional] Allow non incremental materialized view definition. The default value is "false".
+     * Optional. This option declares authors intention to construct a materialized view that will not be refreshed incrementally.
      */
     allowNonIncrementalDefinition?: boolean;
     /**
-     * [Optional] [TrustedTester] Enable automatic refresh of the materialized view when the base table is updated. The default value is "true".
+     * Optional. Enable automatic refresh of the materialized view when the base table is updated. The default value is "true".
      */
     enableRefresh?: boolean;
     /**
-     * [Output-only] [TrustedTester] The time when this materialized view was last modified, in milliseconds since the epoch.
+     * Output only. The time when this materialized view was last refreshed, in milliseconds since the epoch.
      */
     lastRefreshTime?: string;
     /**
@@ -2624,24 +3126,100 @@ declare namespace bigquery {
      */
     maxStaleness?: string;
     /**
-     * [Required] A query whose result is persisted.
+     * Required. A query whose results are persisted.
      */
     query?: string;
     /**
-     * [Optional] [TrustedTester] The maximum frequency at which this materialized view will be refreshed. The default value is "1800000" (30 minutes).
+     * Optional. The maximum frequency at which this materialized view will be refreshed. The default value is "1800000" (30 minutes).
      */
     refreshIntervalMs?: string;
   };
 
+  /**
+   * Statistics of materialized views considered in a query job.
+   */
+  type IMaterializedViewStatistics = {
+    /**
+     * Materialized views considered for the query job. Only certain materialized views are used. For a detailed list, see the child message. If many materialized views are considered, then the list might be incomplete.
+     */
+    materializedView?: Array<IMaterializedView>;
+  };
+
+  /**
+   * Status of a materialized view. The last refresh timestamp status is omitted here, but is present in the MaterializedViewDefinition message.
+   */
+  type IMaterializedViewStatus = {
+    /**
+     * Output only. Error result of the last automatic refresh. If present, indicates that the last automatic refresh was unsuccessful.
+     */
+    lastRefreshStatus?: IErrorProto;
+    /**
+     * Output only. Refresh watermark of materialized view. The base tables' data were collected into the materialized view cache until this time.
+     */
+    refreshWatermark?: string;
+  };
+
+  /**
+   * Statistics for metadata caching in BigLake tables.
+   */
+  type IMetadataCacheStatistics = {
+    /**
+     * Set for the Metadata caching eligible tables referenced in the query.
+     */
+    tableMetadataCacheUsage?: Array<ITableMetadataCacheUsage>;
+  };
+
+  /**
+   * Job statistics specific to a BigQuery ML training job.
+   */
   type IMlStatistics = {
     /**
-     * Results for all completed iterations.
+     * Output only. Trials of a [hyperparameter tuning job](/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-hp-tuning-overview) sorted by trial_id.
+     */
+    hparamTrials?: Array<IHparamTuningTrial>;
+    /**
+     * Results for all completed iterations. Empty for [hyperparameter tuning jobs](/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-hp-tuning-overview).
      */
     iterationResults?: Array<IIterationResult>;
     /**
-     * Maximum number of iterations specified as max_iterations in the 'CREATE MODEL' query. The actual number of iterations may be less than this number due to early stop.
+     * Output only. Maximum number of iterations specified as max_iterations in the 'CREATE MODEL' query. The actual number of iterations may be less than this number due to early stop.
      */
     maxIterations?: string;
+    /**
+     * Output only. The type of the model that is being trained.
+     */
+    modelType?:
+      | 'MODEL_TYPE_UNSPECIFIED'
+      | 'LINEAR_REGRESSION'
+      | 'LOGISTIC_REGRESSION'
+      | 'KMEANS'
+      | 'MATRIX_FACTORIZATION'
+      | 'DNN_CLASSIFIER'
+      | 'TENSORFLOW'
+      | 'DNN_REGRESSOR'
+      | 'XGBOOST'
+      | 'BOOSTED_TREE_REGRESSOR'
+      | 'BOOSTED_TREE_CLASSIFIER'
+      | 'ARIMA'
+      | 'AUTOML_REGRESSOR'
+      | 'AUTOML_CLASSIFIER'
+      | 'PCA'
+      | 'DNN_LINEAR_COMBINED_CLASSIFIER'
+      | 'DNN_LINEAR_COMBINED_REGRESSOR'
+      | 'AUTOENCODER'
+      | 'ARIMA_PLUS'
+      | 'ARIMA_PLUS_XREG'
+      | 'RANDOM_FOREST_REGRESSOR'
+      | 'RANDOM_FOREST_CLASSIFIER'
+      | 'TENSORFLOW_LITE'
+      | 'ONNX';
+    /**
+     * Output only. Training type of the job.
+     */
+    trainingType?:
+      | 'TRAINING_TYPE_UNSPECIFIED'
+      | 'SINGLE_TRAINING'
+      | 'HPARAM_TUNING';
   };
 
   type IModel = {
@@ -2757,7 +3335,7 @@ declare namespace bigquery {
 
   type IModelDefinition = {
     /**
-     * [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
+     * Deprecated.
      */
     modelOptions?: {
       labels?: Array<string>;
@@ -2765,11 +3343,24 @@ declare namespace bigquery {
       modelType?: string;
     };
     /**
-     * [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
+     * Deprecated.
      */
     trainingRuns?: Array<IBqmlTrainingRun>;
   };
 
+  /**
+   * Options related to model extraction.
+   */
+  type IModelExtractOptions = {
+    /**
+     * The 1-based ID of the trial to be exported from a hyperparameter tuning model. If not specified, the trial with id = [Model](/bigquery/docs/reference/rest/v2/models#resource:-model).defaultTrialId is exported. This field is ignored for models not trained with hyperparameter tuning.
+     */
+    trialId?: string;
+  };
+
+  /**
+   * Id path of a model.
+   */
   type IModelReference = {
     /**
      * Required. The ID of the dataset containing this model.
@@ -2799,15 +3390,36 @@ declare namespace bigquery {
     confusionMatrixList?: Array<IConfusionMatrix>;
   };
 
+  /**
+   * Parquet Options for load and make external tables.
+   */
   type IParquetOptions = {
     /**
-     * [Optional] Indicates whether to use schema inference specifically for Parquet LIST logical type.
+     * Optional. Indicates whether to use schema inference specifically for Parquet LIST logical type.
      */
     enableListInference?: boolean;
     /**
-     * [Optional] Indicates whether to infer Parquet ENUM logical type as STRING instead of BYTES by default.
+     * Optional. Indicates whether to infer Parquet ENUM logical type as STRING instead of BYTES by default.
      */
     enumAsString?: boolean;
+  };
+
+  /**
+   * Performance insights for the job.
+   */
+  type IPerformanceInsights = {
+    /**
+     * Output only. Average execution ms of previous runs. Indicates the job ran slow compared to previous executions. To find previous executions, use INFORMATION_SCHEMA tables and filter jobs with same query hash.
+     */
+    avgPreviousExecutionMs?: string;
+    /**
+     * Output only. Query stage performance insights compared to previous runs, for diagnosing performance regression.
+     */
+    stagePerformanceChangeInsights?: Array<IStagePerformanceChangeInsight>;
+    /**
+     * Output only. Standalone query stage performance insights, for exploring potential improvements.
+     */
+    stagePerformanceStandaloneInsights?: Array<IStagePerformanceStandaloneInsight>;
   };
 
   /**
@@ -2854,25 +3466,38 @@ declare namespace bigquery {
     principalComponentId?: string;
   };
 
+  /**
+   * Represents privacy policy that contains the privacy requirements specified by the data owner. Currently, this is only supported on views.
+   */
+  type IPrivacyPolicy = {
+    /**
+     * Optional. Policy used for aggregation thresholds.
+     */
+    aggregationThresholdPolicy?: IAggregationThresholdPolicy;
+  };
+
+  /**
+   * Response object of ListProjects
+   */
   type IProjectList = {
     /**
-     * A hash of the page of results
+     * A hash of the page of results.
      */
     etag?: string;
     /**
-     * The type of list.
+     * The resource type of the response.
      */
     kind?: string;
     /**
-     * A token to request the next page of results.
+     * Use this token to request the next page of results.
      */
     nextPageToken?: string;
     /**
-     * Projects to which you have at least READ access.
+     * Projects to which the user has at least READ access.
      */
     projects?: Array<{
       /**
-       * A descriptive name for this project.
+       * A descriptive name for this project. A wrapper is used here because friendlyName can be set to the empty string.
        */
       friendlyName?: string;
       /**
@@ -2893,79 +3518,112 @@ declare namespace bigquery {
       projectReference?: IProjectReference;
     }>;
     /**
-     * The total number of projects in the list.
+     * The total number of projects in the page. A wrapper is used here because the field should still be in the response when the value is 0.
      */
     totalItems?: number;
   };
 
+  /**
+   * A unique reference to a project.
+   */
   type IProjectReference = {
     /**
-     * [Required] ID of the project. Can be either the numeric ID or the assigned ID of the project.
+     * Required. ID of the project. Can be either the numeric ID or the assigned ID of the project.
      */
     projectId?: string;
   };
 
+  /**
+   * Query optimization information for a QUERY job.
+   */
+  type IQueryInfo = {
+    /**
+     * Output only. Information about query optimizations.
+     */
+    optimizationDetails?: {[key: string]: any};
+  };
+
+  /**
+   * A parameter given to a query.
+   */
   type IQueryParameter = {
     /**
-     * [Optional] If unset, this is a positional parameter. Otherwise, should be unique within a query.
+     * Optional. If unset, this is a positional parameter. Otherwise, should be unique within a query.
      */
     name?: string;
     /**
-     * [Required] The type of this parameter.
+     * Required. The type of this parameter.
      */
     parameterType?: IQueryParameterType;
     /**
-     * [Required] The value of this parameter.
+     * Required. The value of this parameter.
      */
     parameterValue?: IQueryParameterValue;
   };
 
+  /**
+   * The type of a query parameter.
+   */
   type IQueryParameterType = {
     /**
-     * [Optional] The type of the array's elements, if this is an array.
+     * Optional. The type of the array's elements, if this is an array.
      */
     arrayType?: IQueryParameterType;
     /**
-     * [Optional] The types of the fields of this struct, in order, if this is a struct.
+     * Optional. The element type of the range, if this is a range.
+     */
+    rangeElementType?: IQueryParameterType;
+    /**
+     * Optional. The types of the fields of this struct, in order, if this is a struct.
      */
     structTypes?: Array<{
       /**
-       * [Optional] Human-oriented description of the field.
+       * Optional. Human-oriented description of the field.
        */
       description?: string;
       /**
-       * [Optional] The name of this field.
+       * Optional. The name of this field.
        */
       name?: string;
       /**
-       * [Required] The type of this field.
+       * Required. The type of this field.
        */
       type?: IQueryParameterType;
     }>;
     /**
-     * [Required] The top level type of this field.
+     * Required. The top level type of this field.
      */
     type?: string;
   };
 
+  /**
+   * The value of a query parameter.
+   */
   type IQueryParameterValue = {
     /**
-     * [Optional] The array values, if this is an array type.
+     * Optional. The array values, if this is an array type.
      */
     arrayValues?: Array<IQueryParameterValue>;
     /**
-     * [Optional] The struct field values, in order of the struct type's declaration.
+     * Optional. The range value, if this is a range type.
+     */
+    rangeValue?: IRangeValue;
+    /**
+     * The struct field values.
      */
     structValues?: {[key: string]: IQueryParameterValue};
     /**
-     * [Optional] The value of this value, if a simple scalar type.
+     * Optional. The value of this value, if a simple scalar type.
      */
     value?: string;
   };
 
+  /**
+   * Describes the format of the jobs.query request.
+   */
   type IQueryRequest = {
     /**
-     * Connection properties.
+     * Optional. Connection properties which can modify the query behavior.
      */
     connectionProperties?: Array<IConnectionProperty>;
     /**
@@ -2973,23 +3631,34 @@ declare namespace bigquery {
      */
     continuous?: boolean;
     /**
-     * If true, creates a new session, where session id will be a server generated random id. If false, runs query with an existing session_id passed in ConnectionProperty, otherwise runs query in non-session mode.
+     * Optional. If true, creates a new session using a randomly generated session_id. If false, runs query with an existing session_id passed in ConnectionProperty, otherwise runs query in non-session mode. The session location will be set to QueryRequest.location if it is present, otherwise it's set to the default location based on existing routing logic.
      */
     createSession?: boolean;
     /**
-     * [Optional] Specifies the default datasetId and projectId to assume for any unqualified table names in the query. If not set, all table names in the query string must be qualified in the format 'datasetId.tableId'.
+     * Optional. Specifies the default datasetId and projectId to assume for any unqualified table names in the query. If not set, all table names in the query string must be qualified in the format 'datasetId.tableId'.
      */
     defaultDataset?: IDatasetReference;
     /**
-     * [Optional] If set to true, BigQuery doesn't run the job. Instead, if the query is valid, BigQuery returns statistics about the job such as how many bytes would be processed. If the query is invalid, an error returns. The default value is false.
+     * Optional. If set to true, BigQuery doesn't run the job. Instead, if the query is valid, BigQuery returns statistics about the job such as how many bytes would be processed. If the query is invalid, an error returns. The default value is false.
      */
     dryRun?: boolean;
+    /**
+     * Optional. Output format adjustments.
+     */
+    formatOptions?: IDataFormatOptions;
+    /**
+     * Optional. If not set, jobs are always required. If set, the query request will follow the behavior described JobCreationMode. This feature is not yet available. Jobs will always be created.
+     */
+    jobCreationMode?:
+      | 'JOB_CREATION_MODE_UNSPECIFIED'
+      | 'JOB_CREATION_REQUIRED'
+      | 'JOB_CREATION_OPTIONAL';
     /**
      * The resource type of the request.
      */
     kind?: string;
     /**
-     * The labels associated with this job. You can use these to organize and group your jobs. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.
+     * Optional. The labels associated with this query. Labels can be used to organize and group query jobs. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label keys must start with a letter and each label in the list must have a different key.
      */
     labels?: {[key: string]: string};
     /**
@@ -2997,43 +3666,43 @@ declare namespace bigquery {
      */
     location?: string;
     /**
-     * [Optional] The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.
+     * Optional. The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.
      */
     maxResults?: number;
     /**
-     * [Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.
+     * Optional. Limits the bytes billed for this query. Queries with bytes billed above this limit will fail (without incurring a charge). If unspecified, the project default is used.
      */
     maximumBytesBilled?: string;
     /**
-     * Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
+     * GoogleSQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.
      */
     parameterMode?: string;
     /**
-     * [Deprecated] This property is deprecated.
+     * This property is deprecated.
      */
     preserveNulls?: boolean;
     /**
-     * [Required] A query string, following the BigQuery query syntax, of the query to execute. Example: "SELECT count(f1) FROM [myProjectId:myDatasetId.myTableId]".
+     * Required. A query string to execute, using Google Standard SQL or legacy SQL syntax. Example: "SELECT COUNT(f1) FROM myProjectId.myDatasetId.myTableId".
      */
     query?: string;
     /**
-     * Query parameters for Standard SQL queries.
+     * Query parameters for GoogleSQL queries.
      */
     queryParameters?: Array<IQueryParameter>;
     /**
-     * A unique user provided identifier to ensure idempotent behavior for queries. Note that this is different from the job_id. It has the following properties: 1. It is case-sensitive, limited to up to 36 ASCII characters. A UUID is recommended. 2. Read only queries can ignore this token since they are nullipotent by definition. 3. For the purposes of idempotency ensured by the request_id, a request is considered duplicate of another only if they have the same request_id and are actually duplicates. When determining whether a request is a duplicate of the previous request, all parameters in the request that may affect the behavior are considered. For example, query, connection_properties, query_parameters, use_legacy_sql are parameters that affect the result and are considered when determining whether a request is a duplicate, but properties like timeout_ms don't affect the result and are thus not considered. Dry run query requests are never considered duplicate of another request. 4. When a duplicate mutating query request is detected, it returns: a. the results of the mutation if it completes successfully within the timeout. b. the running operation if it is still in progress at the end of the timeout. 5. Its lifetime is limited to 15 minutes. In other words, if two requests are sent with the same request_id, but more than 15 minutes apart, idempotency is not guaranteed.
+     * Optional. A unique user provided identifier to ensure idempotent behavior for queries. Note that this is different from the job_id. It has the following properties: 1. It is case-sensitive, limited to up to 36 ASCII characters. A UUID is recommended. 2. Read only queries can ignore this token since they are nullipotent by definition. 3. For the purposes of idempotency ensured by the request_id, a request is considered duplicate of another only if they have the same request_id and are actually duplicates. When determining whether a request is a duplicate of another request, all parameters in the request that may affect the result are considered. For example, query, connection_properties, query_parameters, use_legacy_sql are parameters that affect the result and are considered when determining whether a request is a duplicate, but properties like timeout_ms don't affect the result and are thus not considered. Dry run query requests are never considered duplicate of another request. 4. When a duplicate mutating query request is detected, it returns: a. the results of the mutation if it completes successfully within the timeout. b. the running operation if it is still in progress at the end of the timeout. 5. Its lifetime is limited to 15 minutes. In other words, if two requests are sent with the same request_id, but more than 15 minutes apart, idempotency is not guaranteed.
      */
     requestId?: string;
     /**
-     * [Optional] How long to wait for the query to complete, in milliseconds, before the request times out and returns. Note that this is only a timeout for the request, not the query. If the query takes longer to run than the timeout value, the call returns without any results and with the 'jobComplete' flag set to false. You can call GetQueryResults() to wait for the query to complete and read the results. The default value is 10000 milliseconds (10 seconds).
+     * Optional. Optional: Specifies the maximum amount of time, in milliseconds, that the client is willing to wait for the query to complete. By default, this limit is 10 seconds (10,000 milliseconds). If the query is complete, the jobComplete field in the response is true. If the query has not yet completed, jobComplete is false. You can request a longer timeout period in the timeoutMs field. However, the call is not guaranteed to wait for the specified timeout; it typically returns after around 200 seconds (200,000 milliseconds), even if the query is not complete. If jobComplete is false, you can continue to wait for the query to complete by calling the getQueryResults method until the jobComplete field in the getQueryResults response is true.
      */
     timeoutMs?: number;
     /**
-     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
+     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
      */
     useLegacySql?: boolean;
     /**
-     * [Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. The default value is true.
+     * Optional. Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. The default value is true.
      */
     useQueryCache?: boolean;
   };
@@ -3044,17 +3713,21 @@ declare namespace bigquery {
      */
     cacheHit?: boolean;
     /**
-     * [Output-only] Detailed statistics for DML statements Present only for DML statements INSERT, UPDATE, DELETE or TRUNCATE.
+     * Output only. Detailed statistics for DML statements INSERT, UPDATE, DELETE, MERGE or TRUNCATE.
      */
     dmlStats?: IDmlStatistics;
     /**
-     * [Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.
+     * Output only. The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful. For more information about error messages, see [Error messages](https://cloud.google.com/bigquery/docs/error-messages).
      */
     errors?: Array<IErrorProto>;
     /**
      * Whether the query has completed or not. If rows or totalRows are present, this will always be true. If this is false, totalRows will not be available.
      */
     jobComplete?: boolean;
+    /**
+     * Optional. Only relevant when a job_reference is present in the response. If job_reference is not present it will always be unset. When job_reference is present, this field should be interpreted as follows: If set, it will provide the reason of why a Job was created. If not set, it should be treated as the default: REQUESTED. This feature is not yet available. Jobs will always be created.
+     */
+    jobCreationReason?: IJobCreationReason;
     /**
      * Reference to the Job that was created to run the query. This field will be present even if the original request timed out, in which case GetQueryResults can be used to read the results once the query has completed. Since this API only returns the first page of results, subsequent pages can be fetched via the same mechanism (GetQueryResults).
      */
@@ -3064,13 +3737,17 @@ declare namespace bigquery {
      */
     kind?: string;
     /**
-     * [Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
+     * Output only. The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.
      */
     numDmlAffectedRows?: string;
     /**
-     * A token used for paging results.
+     * A token used for paging results. A non-empty token indicates that additional results are available. To see additional results, query the [`jobs.getQueryResults`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults) method. For more information, see [Paging through table data](https://cloud.google.com/bigquery/docs/paging-results).
      */
     pageToken?: string;
+    /**
+     * Query ID for the completed query. This ID will be auto-generated. This field is not yet available and it is currently not guaranteed to be populated.
+     */
+    queryId?: string;
     /**
      * An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above.
      */
@@ -3080,7 +3757,7 @@ declare namespace bigquery {
      */
     schema?: ITableSchema;
     /**
-     * [Output-only] [Preview] Information of the session if this job is part of one.
+     * Output only. Information of the session if this job is part of one.
      */
     sessionInfo?: ISessionInfo;
     /**
@@ -3093,9 +3770,12 @@ declare namespace bigquery {
     totalRows?: string;
   };
 
+  /**
+   * Summary of the state of query execution at a given time.
+   */
   type IQueryTimelineSample = {
     /**
-     * Total number of units currently being processed by workers. This does not correspond directly to slot usage. This is the largest value observed since the last sample.
+     * Total number of active workers. This does not correspond directly to slot usage. This is the largest value observed since the last sample.
      */
     activeUnits?: string;
     /**
@@ -3107,7 +3787,7 @@ declare namespace bigquery {
      */
     elapsedMs?: string;
     /**
-     * Units of work that can be scheduled immediately. Providing additional slots for these units of work will speed up the query, provided no other query in the reservation needs additional slots.
+     * Units of work that can be scheduled immediately. Providing additional slots for these units of work will accelerate the query, if no other query in the reservation needs additional slots.
      */
     estimatedRunnableUnits?: string;
     /**
@@ -3122,26 +3802,40 @@ declare namespace bigquery {
 
   type IRangePartitioning = {
     /**
-     * [TrustedTester] [Required] The table is partitioned by this field. The field must be a top-level NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.
+     * Required. [Experimental] The table is partitioned by this field. The field must be a top-level NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.
      */
     field?: string;
     /**
-     * [TrustedTester] [Required] Defines the ranges for range partitioning.
+     * [Experimental] Defines the ranges for range partitioning.
      */
     range?: {
       /**
-       * [TrustedTester] [Required] The end of range partitioning, exclusive.
+       * [Experimental] The end of range partitioning, exclusive.
        */
       end?: string;
       /**
-       * [TrustedTester] [Required] The width of each interval.
+       * [Experimental] The width of each interval.
        */
       interval?: string;
       /**
-       * [TrustedTester] [Required] The start of range partitioning, inclusive.
+       * [Experimental] The start of range partitioning, inclusive.
        */
       start?: string;
     };
+  };
+
+  /**
+   * Represents the value of a range.
+   */
+  type IRangeValue = {
+    /**
+     * Optional. The end value of the range. A missing value represents an unbounded end.
+     */
+    end?: IQueryParameterValue;
+    /**
+     * Optional. The start value of the range. A missing value represents an unbounded start.
+     */
+    start?: IQueryParameterValue;
   };
 
   /**
@@ -3241,7 +3935,12 @@ declare namespace bigquery {
       | 'REMOTE_SERVICE_TYPE_UNSPECIFIED'
       | 'CLOUD_AI_TRANSLATE_V3'
       | 'CLOUD_AI_VISION_V1'
-      | 'CLOUD_AI_NATURAL_LANGUAGE_V1';
+      | 'CLOUD_AI_NATURAL_LANGUAGE_V1'
+      | 'CLOUD_AI_SPEECH_TO_TEXT_V2';
+    /**
+     * Output only. The name of the speech recognizer to use for speech recognition. The expected format is `projects/{project}/locations/{location}/recognizers/{recognizer}`. Customers can specify this field at model creation. If not specified, a default recognizer `projects/{model project}/locations/global/recognizers/_` will be used. See more details at [recognizers](https://cloud.google.com/speech-to-text/v2/docs/reference/rest/v2/projects.locations.recognizers)
+     */
+    speechRecognizer?: string;
   };
 
   /**
@@ -3257,7 +3956,7 @@ declare namespace bigquery {
      */
     creationTime?: string;
     /**
-     * Optional. Data governance specific option, if the value is DATA_MASKING, the function will be validated as masking functions.
+     * Optional. If set to `DATA_MASKING`, the function is validated and made available as a masking function. For more information, see [Create custom masking routines](https://cloud.google.com/bigquery/docs/user-defined-functions#custom-mask).
      */
     dataGovernanceType?: 'DATA_GOVERNANCE_TYPE_UNSPECIFIED' | 'DATA_MASKING';
     /**
@@ -3323,15 +4022,22 @@ declare namespace bigquery {
       | 'TABLE_VALUED_FUNCTION'
       | 'AGGREGATE_FUNCTION';
     /**
+     * Optional. The security mode of the routine, if defined. If not defined, the security mode is automatically determined from the routine's configuration.
+     */
+    securityMode?: 'SECURITY_MODE_UNSPECIFIED' | 'DEFINER' | 'INVOKER';
+    /**
      * Optional. Spark specific options.
      */
     sparkOptions?: ISparkOptions;
     /**
-     * Optional. Can be set for procedures only. If true (default), the definition body will be validated in the creation and the updates of the procedure. For procedures with an argument of ANY TYPE, the definition body validtion is not supported at creation/update time, and thus this field must be set to false explicitly.
+     * Optional. Use this option to catch many common errors. Error checking is not exhaustive, and successfully creating a procedure doesn't guarantee that the procedure will successfully execute at runtime. If `strictMode` is set to `TRUE`, the procedure body is further checked for errors such as non-existent tables or columns. The `CREATE PROCEDURE` statement fails if the body fails any of these checks. If `strictMode` is set to `FALSE`, the procedure body is checked only for syntax. For procedures that invoke themselves recursively, specify `strictMode=FALSE` to avoid non-existent procedure errors during validation. Default value is `TRUE`.
      */
     strictMode?: boolean;
   };
 
+  /**
+   * Id path of a routine.
+   */
   type IRoutineReference = {
     /**
      * Required. The ID of the dataset containing this routine.
@@ -3387,6 +4093,9 @@ declare namespace bigquery {
     rowAccessPolicyReference?: IRowAccessPolicyReference;
   };
 
+  /**
+   * Id path of a row access policy.
+   */
   type IRowAccessPolicyReference = {
     /**
      * Required. The ID of the dataset containing this row access policy.
@@ -3406,65 +4115,105 @@ declare namespace bigquery {
     tableId?: string;
   };
 
+  /**
+   * Statistics for row-level security.
+   */
   type IRowLevelSecurityStatistics = {
     /**
-     * [Output-only] [Preview] Whether any accessed data was protected by row access policies.
+     * Whether any accessed data was protected by row access policies.
      */
     rowLevelSecurityApplied?: boolean;
   };
 
+  /**
+   * Options related to script execution.
+   */
+  type IScriptOptions = {
+    /**
+     * Determines which statement in the script represents the "key result", used to populate the schema and query results of the script job. Default is LAST.
+     */
+    keyResultStatement?:
+      | 'KEY_RESULT_STATEMENT_KIND_UNSPECIFIED'
+      | 'LAST'
+      | 'FIRST_SELECT';
+    /**
+     * Limit on the number of bytes billed per statement. Exceeding this budget results in an error.
+     */
+    statementByteBudget?: string;
+    /**
+     * Timeout period for each statement in a script.
+     */
+    statementTimeoutMs?: string;
+  };
+
+  /**
+   * Represents the location of the statement/expression being evaluated. Line and column numbers are defined as follows: - Line and column numbers start with one. That is, line 1 column 1 denotes the start of the script. - When inside a stored procedure, all line/column numbers are relative to the procedure body, not the script in which the procedure was defined. - Start/end positions exclude leading/trailing comments and whitespace. The end position always ends with a ";", when present. - Multi-byte Unicode characters are treated as just one column. - If the original script (or procedure definition) contains TAB characters, a tab "snaps" the indentation forward to the nearest multiple of 8 characters, plus 1. For example, a TAB on column 1, 2, 3, 4, 5, 6 , or 8 will advance the next character to column 9. A TAB on column 9, 10, 11, 12, 13, 14, 15, or 16 will advance the next character to column 17.
+   */
   type IScriptStackFrame = {
     /**
-     * [Output-only] One-based end column.
+     * Output only. One-based end column.
      */
     endColumn?: number;
     /**
-     * [Output-only] One-based end line.
+     * Output only. One-based end line.
      */
     endLine?: number;
     /**
-     * [Output-only] Name of the active procedure, empty if in a top-level script.
+     * Output only. Name of the active procedure, empty if in a top-level script.
      */
     procedureId?: string;
     /**
-     * [Output-only] One-based start column.
+     * Output only. One-based start column.
      */
     startColumn?: number;
     /**
-     * [Output-only] One-based start line.
+     * Output only. One-based start line.
      */
     startLine?: number;
     /**
-     * [Output-only] Text of the current statement/expression.
+     * Output only. Text of the current statement/expression.
      */
     text?: string;
   };
 
+  /**
+   * Job statistics specific to the child job of a script.
+   */
   type IScriptStatistics = {
     /**
-     * [Output-only] Whether this child job was a statement or expression.
+     * Whether this child job was a statement or expression.
      */
-    evaluationKind?: string;
+    evaluationKind?: 'EVALUATION_KIND_UNSPECIFIED' | 'STATEMENT' | 'EXPRESSION';
     /**
      * Stack trace showing the line/column/procedure name of each frame on the stack at the point where the current evaluation happened. The leaf frame is first, the primary script is last. Never empty.
      */
     stackFrames?: Array<IScriptStackFrame>;
   };
 
+  /**
+   * Statistics for a search query. Populated as part of JobStatistics2.
+   */
   type ISearchStatistics = {
     /**
-     * When index_usage_mode is UNUSED or PARTIALLY_USED, this field explains why index was not used in all or part of the search query. If index_usage_mode is FULLLY_USED, this field is not populated.
+     * When `indexUsageMode` is `UNUSED` or `PARTIALLY_USED`, this field explains why indexes were not used in all or part of the search query. If `indexUsageMode` is `FULLY_USED`, this field is not populated.
      */
     indexUnusedReasons?: Array<IIndexUnusedReason>;
     /**
-     * Specifies index usage mode for the query.
+     * Specifies the index usage mode for the query.
      */
-    indexUsageMode?: string;
+    indexUsageMode?:
+      | 'INDEX_USAGE_MODE_UNSPECIFIED'
+      | 'UNUSED'
+      | 'PARTIALLY_USED'
+      | 'FULLY_USED';
   };
 
+  /**
+   * [Preview] Information related to sessions.
+   */
   type ISessionInfo = {
     /**
-     * [Output-only] // [Preview] Id of the session.
+     * Output only. The id of the session.
      */
     sessionId?: string;
   };
@@ -3483,26 +4232,32 @@ declare namespace bigquery {
     updateMask?: string;
   };
 
+  /**
+   * Information about base table and snapshot time of the snapshot.
+   */
   type ISnapshotDefinition = {
     /**
-     * [Required] Reference describing the ID of the table that was snapshot.
+     * Required. Reference describing the ID of the table that was snapshot.
      */
     baseTableReference?: ITableReference;
     /**
-     * [Required] The time at which the base table was snapshot. This value is reported in the JSON response using RFC3339 format.
+     * Required. The time at which the base table was snapshot. This value is reported in the JSON response using RFC3339 format.
      */
     snapshotTime?: string;
   };
 
+  /**
+   * Spark job logs can be filtered by these fields in Cloud Logging.
+   */
   type ISparkLoggingInfo = {
     /**
-     * [Output-only] Project ID used for logging
+     * Output only. Project ID where the Spark logs were written.
      */
-    project_id?: string;
+    projectId?: string;
     /**
-     * [Output-only] Resource type used for logging
+     * Output only. Resource type used for logging.
      */
-    resource_type?: string;
+    resourceType?: string;
   };
 
   /**
@@ -3551,23 +4306,74 @@ declare namespace bigquery {
     runtimeVersion?: string;
   };
 
+  /**
+   * Statistics for a BigSpark query. Populated as part of JobStatistics2
+   */
   type ISparkStatistics = {
     /**
-     * [Output-only] Endpoints generated for the Spark job.
+     * Output only. Endpoints returned from Dataproc. Key list: - history_server_endpoint: A link to Spark job UI.
      */
     endpoints?: {[key: string]: string};
     /**
-     * [Output-only] Logging info is used to generate a link to Cloud Logging.
+     * Output only. The Google Cloud Storage bucket that is used as the default filesystem by the Spark application. This fields is only filled when the Spark procedure uses the INVOKER security mode. It is inferred from the system variable @@spark_proc_properties.staging_bucket if it is provided. Otherwise, BigQuery creates a default staging bucket for the job and returns the bucket name in this field. Example: * `gs://[bucket_name]`
+     */
+    gcsStagingBucket?: string;
+    /**
+     * Output only. The Cloud KMS encryption key that is used to protect the resources created by the Spark job. If the Spark procedure uses DEFINER security mode, the Cloud KMS key is inferred from the Spark connection associated with the procedure if it is provided. Otherwise the key is inferred from the default key of the Spark connection's project if the CMEK organization policy is enforced. If the Spark procedure uses INVOKER security mode, the Cloud KMS encryption key is inferred from the system variable @@spark_proc_properties.kms_key_name if it is provided. Otherwise, the key is inferred fromt he default key of the BigQuery job's project if the CMEK organization policy is enforced. Example: * `projects/[kms_project_id]/locations/[region]/keyRings/[key_region]/cryptoKeys/[key]`
+     */
+    kmsKeyName?: string;
+    /**
+     * Output only. Logging info is used to generate a link to Cloud Logging.
      */
     loggingInfo?: ISparkLoggingInfo;
     /**
-     * [Output-only] Spark job id if a Spark job is created successfully.
+     * Output only. Spark job ID if a Spark job is created successfully.
      */
     sparkJobId?: string;
     /**
-     * [Output-only] Location where the Spark job is executed.
+     * Output only. Location where the Spark job is executed. A location is selected by BigQueury for jobs configured to run in a multi-region.
      */
     sparkJobLocation?: string;
+  };
+
+  /**
+   * Performance insights compared to the previous executions for a specific stage.
+   */
+  type IStagePerformanceChangeInsight = {
+    /**
+     * Output only. Input data change insight of the query stage.
+     */
+    inputDataChange?: IInputDataChange;
+    /**
+     * Output only. The stage id that the insight mapped to.
+     */
+    stageId?: string;
+  };
+
+  /**
+   * Standalone performance insights for a specific stage.
+   */
+  type IStagePerformanceStandaloneInsight = {
+    /**
+     * Output only. If present, the stage had the following reasons for being disqualified from BI Engine execution.
+     */
+    biEngineReasons?: Array<IBiEngineReason>;
+    /**
+     * Output only. High cardinality joins in the stage.
+     */
+    highCardinalityJoins?: Array<IHighCardinalityJoin>;
+    /**
+     * Output only. True if the stage has insufficient shuffle quota.
+     */
+    insufficientShuffleQuota?: boolean;
+    /**
+     * Output only. True if the stage has a slot contention issue.
+     */
+    slotContention?: boolean;
+    /**
+     * Output only. The stage id that the insight mapped to.
+     */
+    stageId?: string;
   };
 
   /**
@@ -3624,7 +4430,15 @@ declare namespace bigquery {
     type?: IStandardSqlDataType;
   };
 
-  type IStandardSqlStructType = {fields?: Array<IStandardSqlField>};
+  /**
+   * The representation of a SQL STRUCT type.
+   */
+  type IStandardSqlStructType = {
+    /**
+     * Fields within the struct.
+     */
+    fields?: Array<IStandardSqlField>;
+  };
 
   /**
    * A table type
@@ -3638,15 +4452,15 @@ declare namespace bigquery {
 
   type IStreamingbuffer = {
     /**
-     * [Output-only] A lower-bound estimate of the number of bytes currently in the streaming buffer.
+     * Output only. A lower-bound estimate of the number of bytes currently in the streaming buffer.
      */
     estimatedBytes?: string;
     /**
-     * [Output-only] A lower-bound estimate of the number of rows currently in the streaming buffer.
+     * Output only. A lower-bound estimate of the number of rows currently in the streaming buffer.
      */
     estimatedRows?: string;
     /**
-     * [Output-only] Contains the timestamp of the oldest entry in the streaming buffer, in milliseconds since the epoch, if the streaming buffer is available.
+     * Output only. Contains the timestamp of the oldest entry in the streaming buffer, in milliseconds since the epoch, if the streaming buffer is available.
      */
     oldestEntryTime?: string;
   };
@@ -3661,33 +4475,50 @@ declare namespace bigquery {
     candidates?: Array<string>;
   };
 
+  /**
+   * System variables given to a query.
+   */
+  type ISystemVariables = {
+    /**
+     * Output only. Data type for each system variable.
+     */
+    types?: {[key: string]: IStandardSqlDataType};
+    /**
+     * Output only. Value for each system variable.
+     */
+    values?: {[key: string]: any};
+  };
+
   type ITable = {
     /**
-     * [Optional] Specifies the configuration of a BigLake managed table.
+     * Optional. Specifies the configuration of a BigLake managed table.
      */
     biglakeConfiguration?: IBigLakeConfiguration;
     /**
-     * [Output-only] Clone definition.
+     * Output only. Contains information about the clone. This value is set via the clone operation.
      */
     cloneDefinition?: ICloneDefinition;
     /**
-     * [Beta] Clustering specification for the table. Must be specified with partitioning, data in the table will be first partitioned and subsequently clustered.
+     * Clustering specification for the table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.
      */
     clustering?: IClustering;
     /**
-     * [Output-only] The time when this table was created, in milliseconds since the epoch.
+     * Output only. The time when this table was created, in milliseconds since the epoch.
      */
     creationTime?: string;
     /**
-     * [Output-only] The default collation of the table.
+     * Optional. Defines the default collation specification of new STRING fields in the table. During table creation or update, if a STRING field is added to this table without explicit collation specified, then the table inherits the table default collation. A change to this field affects only fields added afterwards, and does not alter the existing fields. The following values are supported: * 'und:ci': undetermined locale, case insensitive. * '': empty string. Default to case-sensitive behavior.
      */
     defaultCollation?: string;
     /**
-     * [Output-only] The default rounding mode of the table.
+     * Optional. Defines the default rounding mode specification of new decimal fields (NUMERIC OR BIGNUMERIC) in the table. During table creation or update, if a decimal field is added to this table without an explicit rounding mode specified, then the field inherits the table default rounding mode. Changing this field doesn't affect existing fields.
      */
-    defaultRoundingMode?: string;
+    defaultRoundingMode?:
+      | 'ROUNDING_MODE_UNSPECIFIED'
+      | 'ROUND_HALF_AWAY_FROM_ZERO'
+      | 'ROUND_HALF_EVEN';
     /**
-     * [Optional] A user-friendly description of this table.
+     * Optional. A user-friendly description of this table.
      */
     description?: string;
     /**
@@ -3695,27 +4526,27 @@ declare namespace bigquery {
      */
     encryptionConfiguration?: IEncryptionConfiguration;
     /**
-     * [Output-only] A hash of the table metadata. Used to ensure there were no concurrent modifications to the resource when attempting an update. Not guaranteed to change when the table contents or the fields numRows, numBytes, numLongTermBytes or lastModifiedTime change.
+     * Output only. A hash of this resource.
      */
     etag?: string;
     /**
-     * [Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed. The defaultTableExpirationMs property of the encapsulating dataset can be used to set a default expirationTime on newly created tables.
+     * Optional. The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed. The defaultTableExpirationMs property of the encapsulating dataset can be used to set a default expirationTime on newly created tables.
      */
     expirationTime?: string;
     /**
-     * [Optional] Describes the data format, location, and other properties of a table stored outside of BigQuery. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.
+     * Optional. Describes the data format, location, and other properties of a table stored outside of BigQuery. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.
      */
     externalDataConfiguration?: IExternalDataConfiguration;
     /**
-     * [Optional] A descriptive name for this table.
+     * Optional. A descriptive name for this table.
      */
     friendlyName?: string;
     /**
-     * [Output-only] An opaque ID uniquely identifying the table.
+     * Output only. An opaque ID uniquely identifying the table.
      */
     id?: string;
     /**
-     * [Output-only] The type of the resource.
+     * The type of resource ID.
      */
     kind?: string;
     /**
@@ -3723,130 +4554,161 @@ declare namespace bigquery {
      */
     labels?: {[key: string]: string};
     /**
-     * [Output-only] The time when this table was last modified, in milliseconds since the epoch.
+     * Output only. The time when this table was last modified, in milliseconds since the epoch.
      */
     lastModifiedTime?: string;
     /**
-     * [Output-only] The geographic location where the table resides. This value is inherited from the dataset.
+     * Output only. The geographic location where the table resides. This value is inherited from the dataset.
      */
     location?: string;
     /**
-     * [Optional] Materialized view definition.
+     * Optional. The materialized view definition.
      */
     materializedView?: IMaterializedViewDefinition;
     /**
-     * [Optional] Max staleness of data that could be returned when table or materialized view is queried (formatted as Google SQL Interval type).
+     * Output only. The materialized view status.
+     */
+    materializedViewStatus?: IMaterializedViewStatus;
+    /**
+     * Optional. The maximum staleness of data that could be returned when the table (or stale MV) is queried. Staleness encoded as a string encoding of sql IntervalValue type.
      */
     maxStaleness?: string;
     /**
-     * [Output-only, Beta] Present iff this table represents a ML model. Describes the training information for the model, and it is required to run 'PREDICT' queries.
+     * Deprecated.
      */
     model?: IModelDefinition;
     /**
-     * [Output-only] Number of logical bytes that are less than 90 days old.
+     * Output only. Number of logical bytes that are less than 90 days old.
      */
     numActiveLogicalBytes?: string;
     /**
-     * [Output-only] Number of physical bytes less than 90 days old. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
+     * Output only. Number of physical bytes less than 90 days old. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
      */
     numActivePhysicalBytes?: string;
     /**
-     * [Output-only] The size of this table in bytes, excluding any data in the streaming buffer.
+     * Output only. The size of this table in logical bytes, excluding any data in the streaming buffer.
      */
     numBytes?: string;
     /**
-     * [Output-only] The number of bytes in the table that are considered "long-term storage".
+     * Output only. The number of logical bytes in the table that are considered "long-term storage".
      */
     numLongTermBytes?: string;
     /**
-     * [Output-only] Number of logical bytes that are more than 90 days old.
+     * Output only. Number of logical bytes that are more than 90 days old.
      */
     numLongTermLogicalBytes?: string;
     /**
-     * [Output-only] Number of physical bytes more than 90 days old. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
+     * Output only. Number of physical bytes more than 90 days old. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
      */
     numLongTermPhysicalBytes?: string;
     /**
-     * [Output-only] The number of partitions present in the table or materialized view. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
+     * Output only. The number of partitions present in the table or materialized view. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
      */
     numPartitions?: string;
     /**
-     * [Output-only] [TrustedTester] The physical size of this table in bytes, excluding any data in the streaming buffer. This includes compression and storage used for time travel.
+     * Output only. The physical size of this table in bytes. This includes storage used for time travel.
      */
     numPhysicalBytes?: string;
     /**
-     * [Output-only] The number of rows of data in this table, excluding any data in the streaming buffer.
+     * Output only. The number of rows of data in this table, excluding any data in the streaming buffer.
      */
     numRows?: string;
     /**
-     * [Output-only] Number of physical bytes used by time travel storage (deleted or changed data). This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
+     * Output only. Number of physical bytes used by time travel storage (deleted or changed data). This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
      */
     numTimeTravelPhysicalBytes?: string;
     /**
-     * [Output-only] Total number of logical bytes in the table or materialized view.
+     * Output only. Total number of logical bytes in the table or materialized view.
      */
     numTotalLogicalBytes?: string;
     /**
-     * [Output-only] The physical size of this table in bytes. This also includes storage used for time travel. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
+     * Output only. The physical size of this table in bytes. This also includes storage used for time travel. This data is not kept in real time, and might be delayed by a few seconds to a few minutes.
      */
     numTotalPhysicalBytes?: string;
     /**
-     * [TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
+     * If specified, configures range partitioning for this table.
      */
     rangePartitioning?: IRangePartitioning;
     /**
-     * [Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.
+     * Optional. Output only. Table references of all replicas currently active on the table.
+     */
+    replicas?: Array<ITableReference>;
+    /**
+     * Optional. If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.
      */
     requirePartitionFilter?: boolean;
     /**
-     * [Optional] Describes the schema of this table.
+     * [Optional] The tags associated with this table. Tag keys are globally unique. See additional information on [tags](https://cloud.google.com/iam/docs/tags-access-control#definitions). An object containing a list of "key": value pairs. The key is the namespaced friendly name of the tag key, e.g. "12345/environment" where 12345 is parent id. The value is the friendly short name of the tag value, e.g. "production".
+     */
+    resourceTags?: {[key: string]: string};
+    /**
+     * Optional. Describes the schema of this table.
      */
     schema?: ITableSchema;
     /**
-     * [Output-only] A URL that can be used to access this resource again.
+     * Output only. A URL that can be used to access this resource again.
      */
     selfLink?: string;
     /**
-     * [Output-only] Snapshot definition.
+     * Output only. Contains information about the snapshot. This value is set via snapshot creation.
      */
     snapshotDefinition?: ISnapshotDefinition;
     /**
-     * [Output-only] Contains information regarding this table's streaming buffer, if one is present. This field will be absent if the table is not being streamed to or if there is no data in the streaming buffer.
+     * Output only. Contains information regarding this table's streaming buffer, if one is present. This field will be absent if the table is not being streamed to or if there is no data in the streaming buffer.
      */
     streamingBuffer?: IStreamingbuffer;
     /**
-     * [Optional] The table constraints on the table.
+     * Optional. Tables Primary Key and Foreign Key information
      */
     tableConstraints?: ITableConstraints;
     /**
-     * [Required] Reference describing the ID of this table.
+     * Required. Reference describing the ID of this table.
      */
     tableReference?: ITableReference;
     /**
-     * Time-based partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.
+     * Optional. Table replication info for table created `AS REPLICA` DDL like: `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`
+     */
+    tableReplicationInfo?: ITableReplicationInfo;
+    /**
+     * If specified, configures time-based partitioning for this table.
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * [Output-only] Describes the table type. The following values are supported: TABLE: A normal BigQuery table. VIEW: A virtual table defined by a SQL query. SNAPSHOT: An immutable, read-only table that is a copy of another table. [TrustedTester] MATERIALIZED_VIEW: SQL query whose result is persisted. EXTERNAL: A table that references data stored in an external storage system, such as Google Cloud Storage. The default value is TABLE.
+     * Output only. Describes the table type. The following values are supported: * `TABLE`: A normal BigQuery table. * `VIEW`: A virtual table defined by a SQL query. * `EXTERNAL`: A table that references data stored in an external storage system, such as Google Cloud Storage. * `MATERIALIZED_VIEW`: A precomputed view defined by a SQL query. * `SNAPSHOT`: An immutable BigQuery table that preserves the contents of a base table at a particular time. See additional information on [table snapshots](/bigquery/docs/table-snapshots-intro). The default value is `TABLE`.
      */
     type?: string;
     /**
-     * [Optional] The view definition.
+     * Optional. The view definition.
      */
     view?: IViewDefinition;
   };
 
   type ITableCell = {v?: any};
 
+  /**
+   * The TableConstraints defines the primary key and foreign key.
+   */
   type ITableConstraints = {
     /**
-     * [Optional] The foreign keys of the tables.
+     * Optional. Present only if the table has a foreign key. The foreign key is not enforced.
      */
     foreignKeys?: Array<{
+      /**
+       * Required. The columns that compose the foreign key.
+       */
       columnReferences?: Array<{
+        /**
+         * Required. The column in the primary key that are referenced by the referencing_column.
+         */
         referencedColumn?: string;
+        /**
+         * Required. The column that composes the foreign key.
+         */
         referencingColumn?: string;
       }>;
+      /**
+       * Optional. Set only if the foreign key constraint is named.
+       */
       name?: string;
       referencedTable?: {
         datasetId?: string;
@@ -3855,46 +4717,58 @@ declare namespace bigquery {
       };
     }>;
     /**
-     * [Optional] The primary key of the table.
+     * Represents the primary key constraint on a table's columns.
      */
-    primaryKey?: {columns?: Array<string>};
+    primaryKey?: {
+      /**
+       * Required. The columns that are composed of the primary key constraint.
+       */
+      columns?: Array<string>;
+    };
   };
 
+  /**
+   * Request for sending a single streaming insert.
+   */
   type ITableDataInsertAllRequest = {
     /**
-     * [Optional] Accept rows that contain values that do not match the schema. The unknown values are ignored. Default is false, which treats unknown values as errors.
+     * Optional. Accept rows that contain values that do not match the schema. The unknown values are ignored. Default is false, which treats unknown values as errors.
      */
     ignoreUnknownValues?: boolean;
     /**
-     * The resource type of the response.
+     * Optional. The resource type of the response. The value is not checked at the backend. Historically, it has been set to "bigquery#tableDataInsertAllRequest" but you are not required to set it.
      */
     kind?: string;
-    /**
-     * The rows to insert.
-     */
     rows?: Array<{
       /**
-       * [Optional] A unique ID for each row. BigQuery uses this property to detect duplicate insertion requests on a best-effort basis.
+       * Insertion ID for best-effort deduplication. This feature is not recommended, and users seeking stronger insertion semantics are encouraged to use other mechanisms such as the BigQuery Write API.
        */
       insertId?: string;
       /**
-       * [Required] A JSON object that contains a row of data. The object's properties and values must match the destination table's schema.
+       * Data for a single row.
        */
       json?: IJsonObject;
     }>;
     /**
-     * [Optional] Insert all valid rows of a request, even if invalid rows exist. The default value is false, which causes the entire request to fail if any invalid rows exist.
+     * Optional. Insert all valid rows of a request, even if invalid rows exist. The default value is false, which causes the entire request to fail if any invalid rows exist.
      */
     skipInvalidRows?: boolean;
     /**
-     * If specified, treats the destination table as a base template, and inserts the rows into an instance table named "{destination}{templateSuffix}". BigQuery will manage creation of the instance table, using the schema of the base template table. See https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables for considerations when working with templates tables.
+     * Optional. If specified, treats the destination table as a base template, and inserts the rows into an instance table named "{destination}{templateSuffix}". BigQuery will manage creation of the instance table, using the schema of the base template table. See https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables for considerations when working with templates tables.
      */
     templateSuffix?: string;
+    /**
+     * Optional. Unique request trace id. Used for debugging purposes only. It is case-sensitive, limited to up to 36 ASCII characters. A UUID is recommended.
+     */
+    traceId?: string;
   };
 
+  /**
+   * Describes the format of a streaming insert response.
+   */
   type ITableDataInsertAllResponse = {
     /**
-     * An array of errors for rows that were not inserted.
+     * Describes specific errors encountered while processing the request.
      */
     insertErrors?: Array<{
       /**
@@ -3907,7 +4781,7 @@ declare namespace bigquery {
       index?: number;
     }>;
     /**
-     * The resource type of the response.
+     * Returns "bigquery#tableDataInsertAllResponse".
      */
     kind?: string;
   };
@@ -3930,82 +4804,94 @@ declare namespace bigquery {
      */
     rows?: Array<ITableRow>;
     /**
-     * The total number of rows in the complete table.
+     * Total rows of the entire table. In order to show default value 0 we have to present it as string.
      */
     totalRows?: string;
   };
 
+  /**
+   * A field in TableSchema
+   */
   type ITableFieldSchema = {
     /**
-     * [Optional] The categories attached to this field, used for field-level access control.
+     * Deprecated.
      */
     categories?: {
       /**
-       * A list of category resource names. For example, "projects/1/taxonomies/2/categories/3". At most 5 categories are allowed.
+       * Deprecated.
        */
       names?: Array<string>;
     };
     /**
-     * Optional. Collation specification of the field. It only can be set on string type field.
+     * Optional. Field collation can be set only when the type of field is STRING. The following values are supported: * 'und:ci': undetermined locale, case insensitive. * '': empty string. Default to case-sensitive behavior.
      */
     collation?: string;
     /**
-     * Optional. A SQL expression to specify the default value for this field. It can only be set for top level fields (columns). You can use struct or array expression to specify default value for the entire struct or array. The valid SQL expressions are: - Literals for all data types, including STRUCT and ARRAY. - Following functions: - CURRENT_TIMESTAMP - CURRENT_TIME - CURRENT_DATE - CURRENT_DATETIME - GENERATE_UUID - RAND - SESSION_USER - ST_GEOGPOINT - Struct or array composed with the above allowed functions, for example, [CURRENT_DATE(), DATE '2020-01-01']
+     * Optional. A SQL expression to specify the [default value] (https://cloud.google.com/bigquery/docs/default-values) for this field.
      */
     defaultValueExpression?: string;
     /**
-     * [Optional] The field description. The maximum length is 1,024 characters.
+     * Optional. The field description. The maximum length is 1,024 characters.
      */
     description?: string;
     /**
-     * [Optional] Describes the nested schema fields if the type property is set to RECORD.
+     * Optional. Describes the nested schema fields if the type property is set to RECORD.
      */
     fields?: Array<ITableFieldSchema>;
     /**
-     * [Optional] Maximum length of values of this field for STRINGS or BYTES. If max_length is not specified, no maximum length constraint is imposed on this field. If type = "STRING", then max_length represents the maximum UTF-8 length of strings in this field. If type = "BYTES", then max_length represents the maximum number of bytes in this field. It is invalid to set this field if type ≠ "STRING" and ≠ "BYTES".
+     * Optional. Maximum length of values of this field for STRINGS or BYTES. If max_length is not specified, no maximum length constraint is imposed on this field. If type = "STRING", then max_length represents the maximum UTF-8 length of strings in this field. If type = "BYTES", then max_length represents the maximum number of bytes in this field. It is invalid to set this field if type ≠ "STRING" and ≠ "BYTES".
      */
     maxLength?: string;
     /**
-     * [Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
+     * Optional. The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
      */
     mode?: string;
     /**
-     * [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 300 characters.
+     * Required. The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 300 characters.
      */
     name?: string;
+    /**
+     * Optional. The policy tags attached to this field, used for field-level access control. If not set, defaults to empty policy_tags.
+     */
     policyTags?: {
       /**
-       * A list of category resource names. For example, "projects/1/location/eu/taxonomies/2/policyTags/3". At most 1 policy tag is allowed.
+       * A list of policy tag resource names. For example, "projects/1/locations/eu/taxonomies/2/policyTags/3". At most 1 policy tag is currently allowed.
        */
       names?: Array<string>;
     };
     /**
-     * [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
+     * Optional. Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: * Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] * Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: * If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. * If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): * If type = "NUMERIC": 1 ≤ precision ≤ 29. * If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
      */
     precision?: string;
     /**
-     * Optional. The subtype of the RANGE, if the type of this field is RANGE. If the type is RANGE, this field is required. Possible values for the field element type of a RANGE include: - DATE - DATETIME - TIMESTAMP
+     * Represents the type of a field element.
      */
     rangeElementType?: {
       /**
-       * The field element type of a RANGE
+       * Required. The type of a field element. See TableFieldSchema.type.
        */
       type?: string;
     };
     /**
-     * Optional. Rounding Mode specification of the field. It only can be set on NUMERIC or BIGNUMERIC type fields.
+     * Optional. Specifies the rounding mode to be used when storing values of NUMERIC and BIGNUMERIC type.
      */
-    roundingMode?: string;
+    roundingMode?:
+      | 'ROUNDING_MODE_UNSPECIFIED'
+      | 'ROUND_HALF_AWAY_FROM_ZERO'
+      | 'ROUND_HALF_EVEN';
     /**
-     * [Optional] See documentation for precision.
+     * Optional. See documentation for precision.
      */
     scale?: string;
     /**
-     * [Required] The field data type. Possible values include STRING, BYTES, INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT), NUMERIC, BIGNUMERIC, BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, INTERVAL, RECORD (where RECORD indicates that the field contains a nested schema) or STRUCT (same as RECORD).
+     * Required. The field data type. Possible values include: * STRING * BYTES * INTEGER (or INT64) * FLOAT (or FLOAT64) * BOOLEAN (or BOOL) * TIMESTAMP * DATE * TIME * DATETIME * GEOGRAPHY * NUMERIC * BIGNUMERIC * JSON * RECORD (or STRUCT) Use of RECORD/STRUCT indicates that the field contains a nested schema.
      */
     type?: string;
   };
 
+  /**
+   * Partial projection of the metadata for a given table in a list response.
+   */
   type ITableList = {
     /**
      * A hash of this page of results.
@@ -4024,15 +4910,15 @@ declare namespace bigquery {
      */
     tables?: Array<{
       /**
-       * [Beta] Clustering specification for this table, if configured.
+       * Clustering specification for this table, if configured.
        */
       clustering?: IClustering;
       /**
-       * The time when this table was created, in milliseconds since the epoch.
+       * Output only. The time when this table was created, in milliseconds since the epoch.
        */
       creationTime?: string;
       /**
-       * [Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed.
+       * The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed.
        */
       expirationTime?: string;
       /**
@@ -4040,7 +4926,7 @@ declare namespace bigquery {
        */
       friendlyName?: string;
       /**
-       * An opaque ID of the table
+       * An opaque ID of the table.
        */
       id?: string;
       /**
@@ -4052,27 +4938,35 @@ declare namespace bigquery {
        */
       labels?: {[key: string]: string};
       /**
-       * The range partitioning specification for this table, if configured.
+       * The range partitioning for this table.
        */
       rangePartitioning?: IRangePartitioning;
       /**
-       * A reference uniquely identifying the table.
+       * Optional. If set to true, queries including this table must specify a partition filter. This filter is used for partition elimination.
+       */
+      requirePartitionFilter?: boolean;
+      /**
+       * A reference uniquely identifying table.
        */
       tableReference?: ITableReference;
       /**
-       * The time-based partitioning specification for this table, if configured.
+       * The time-based partitioning for this table.
        */
       timePartitioning?: ITimePartitioning;
       /**
-       * The type of table. Possible values are: TABLE, VIEW.
+       * The type of table.
        */
       type?: string;
       /**
-       * Additional details for a view.
+       * Information about a logical view.
        */
       view?: {
         /**
-         * True if view is defined in legacy SQL dialect, false if in standard SQL.
+         * Specifices the privacy policy for the view.
+         */
+        privacyPolicy?: IPrivacyPolicy;
+        /**
+         * True if view is defined in legacy SQL dialect, false if in GoogleSQL.
          */
         useLegacySql?: boolean;
       };
@@ -4083,19 +4977,76 @@ declare namespace bigquery {
     totalItems?: number;
   };
 
+  /**
+   * Table level detail on the usage of metadata caching. Only set for Metadata caching eligible tables referenced in the query.
+   */
+  type ITableMetadataCacheUsage = {
+    /**
+     * Free form human-readable reason metadata caching was unused for the job.
+     */
+    explanation?: string;
+    /**
+     * Metadata caching eligible table referenced in the query.
+     */
+    tableReference?: ITableReference;
+    /**
+     * [Table type](/bigquery/docs/reference/rest/v2/tables#Table.FIELDS.type).
+     */
+    tableType?: string;
+    /**
+     * Reason for not using metadata caching for the table.
+     */
+    unusedReason?:
+      | 'UNUSED_REASON_UNSPECIFIED'
+      | 'EXCEEDED_MAX_STALENESS'
+      | 'METADATA_CACHING_NOT_ENABLED'
+      | 'OTHER_REASON';
+  };
+
   type ITableReference = {
     /**
-     * [Required] The ID of the dataset containing this table.
+     * Required. The ID of the dataset containing this table.
      */
     datasetId?: string;
     /**
-     * [Required] The ID of the project containing this table.
+     * Required. The ID of the project containing this table.
      */
     projectId?: string;
     /**
-     * [Required] The ID of the table. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.
+     * Required. The ID of the table. The ID can contain Unicode characters in category L (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), and Zs (space). For more information, see [General Category](https://wikipedia.org/wiki/Unicode_character_property#General_Category). The maximum length is 1,024 characters. Certain operations allow suffixing of the table ID with a partition decorator, such as `sample_table$20190123`.
      */
     tableId?: string;
+  };
+
+  /**
+   * Replication info of a table created using `AS REPLICA` DDL like: `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`
+   */
+  type ITableReplicationInfo = {
+    /**
+     * Optional. Output only. If source is a materialized view, this field signifies the last refresh time of the source.
+     */
+    replicatedSourceLastRefreshTime?: string;
+    /**
+     * Optional. Output only. Replication error that will permanently stopped table replication.
+     */
+    replicationError?: IErrorProto;
+    /**
+     * Required. Specifies the interval at which the source table is polled for updates.
+     */
+    replicationIntervalMs?: string;
+    /**
+     * Optional. Output only. Replication status of configured replication.
+     */
+    replicationStatus?:
+      | 'REPLICATION_STATUS_UNSPECIFIED'
+      | 'ACTIVE'
+      | 'SOURCE_DELETED'
+      | 'PERMISSION_DENIED'
+      | 'UNSUPPORTED_CONFIGURATION';
+    /**
+     * Required. Source table reference that is replicated.
+     */
+    sourceTable?: ITableReference;
   };
 
   type ITableRow = {
@@ -4105,6 +5056,9 @@ declare namespace bigquery {
     f?: Array<ITableCell>;
   };
 
+  /**
+   * Schema of a table
+   */
   type ITableSchema = {
     /**
      * Describes the fields in a table.
@@ -4134,16 +5088,19 @@ declare namespace bigquery {
 
   type ITimePartitioning = {
     /**
-     * [Optional] Number of milliseconds for which to keep the storage for partitions in the table. The storage in a partition will have an expiration time of its partition time plus this value.
+     * Optional. Number of milliseconds for which to keep the storage for a partition. A wrapper is used here because 0 is an invalid value.
      */
     expirationMs?: string;
     /**
-     * [Beta] [Optional] If not set, the table is partitioned by pseudo column, referenced via either '_PARTITIONTIME' as TIMESTAMP type, or '_PARTITIONDATE' as DATE type. If field is specified, the table is instead partitioned by this field. The field must be a top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.
+     * Optional. If not set, the table is partitioned by pseudo column '_PARTITIONTIME'; if set, the table is partitioned by this field. The field must be a top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED. A wrapper is used here because an empty string is an invalid value.
      */
     field?: string;
+    /**
+     * If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. This field is deprecated; please set the field with the same name on the table itself instead. This field needs a wrapper because we want to output the default value, false, if the user explicitly set it.
+     */
     requirePartitionFilter?: boolean;
     /**
-     * [Required] The supported types are DAY, HOUR, MONTH, and YEAR, which will generate one partition per day, hour, month, and year, respectively. When the type is not specified, the default behavior is DAY.
+     * Required. The supported types are DAY, HOUR, MONTH, and YEAR, which will generate one partition per day, hour, month, and year, respectively.
      */
     type?: string;
   };
@@ -4741,9 +5698,12 @@ declare namespace bigquery {
     vertexAiModelVersion?: string;
   };
 
+  /**
+   * [Alpha] Information of a multi-statement transaction.
+   */
   type ITransactionInfo = {
     /**
-     * [Output-only] // [Alpha] Id of the transaction.
+     * Output only. [Alpha] Id of the transaction.
      */
     transactionId?: string;
   };
@@ -4767,7 +5727,17 @@ declare namespace bigquery {
   };
 
   /**
-   * This is used for defining User Defined Function (UDF) resources only when using legacy SQL. Users of Standard SQL should leverage either DDL (e.g. CREATE [TEMPORARY] FUNCTION ... ) or the Routines API to define UDF resources. For additional information on migrating, see: https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions
+   * Request format for undeleting a dataset.
+   */
+  type IUndeleteDatasetRequest = {
+    /**
+     * Optional. The exact time when the dataset was deleted. If not specified, it will undelete the most recently deleted version.
+     */
+    deletionTime?: string;
+  };
+
+  /**
+   *  This is used for defining User Defined Function (UDF) resources only when using legacy SQL. Users of GoogleSQL should leverage either DDL (e.g. CREATE [TEMPORARY] FUNCTION ... ) or the Routines API to define UDF resources. For additional information on migrating, see: https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions
    */
   type IUserDefinedFunctionResource = {
     /**
@@ -4780,17 +5750,42 @@ declare namespace bigquery {
     resourceUri?: string;
   };
 
+  /**
+   * Statistics for a vector search query. Populated as part of JobStatistics2.
+   */
+  type IVectorSearchStatistics = {
+    /**
+     * When `indexUsageMode` is `UNUSED` or `PARTIALLY_USED`, this field explains why indexes were not used in all or part of the vector search query. If `indexUsageMode` is `FULLY_USED`, this field is not populated.
+     */
+    indexUnusedReasons?: Array<IIndexUnusedReason>;
+    /**
+     * Specifies the index usage mode for the query.
+     */
+    indexUsageMode?:
+      | 'INDEX_USAGE_MODE_UNSPECIFIED'
+      | 'UNUSED'
+      | 'PARTIALLY_USED'
+      | 'FULLY_USED';
+  };
+
+  /**
+   * Describes the definition of a logical view.
+   */
   type IViewDefinition = {
     /**
-     * [Required] A query that BigQuery executes when the view is referenced.
+     * Optional. Specifices the privacy policy for the view.
+     */
+    privacyPolicy?: IPrivacyPolicy;
+    /**
+     * Required. A query that BigQuery executes when the view is referenced.
      */
     query?: string;
     /**
-     * True if the column names are explicitly specified. For example by using the 'CREATE VIEW v(c1, c2) AS ...' syntax. Can only be set using BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/
+     * True if the column names are explicitly specified. For example by using the 'CREATE VIEW v(c1, c2) AS ...' syntax. Can only be set for GoogleSQL views.
      */
     useExplicitColumnNames?: boolean;
     /**
-     * Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value.
+     * Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value. A wrapper is used here because the default value is True.
      */
     useLegacySql?: boolean;
     /**
@@ -4811,7 +5806,17 @@ declare namespace bigquery {
     };
 
     /**
-     * Lists all datasets in the specified project to which you have been granted the READER dataset role.
+     * Returns the dataset specified by datasetID.
+     */
+    type IGetParams = {
+      /**
+       * Optional. Specifies the view that determines which dataset information is returned. By default, metadata and ACL information are returned.
+       */
+      datasetView?: 'DATASET_VIEW_UNSPECIFIED' | 'METADATA' | 'ACL' | 'FULL';
+    };
+
+    /**
+     * Lists all datasets in the specified project to which the user has been granted the READER dataset role.
      */
     type IListParams = {
       /**
@@ -4819,11 +5824,11 @@ declare namespace bigquery {
        */
       all?: boolean;
       /**
-       * An expression for filtering the results of the request by label. The syntax is "labels.<name>[:<value>]". Multiple filters can be ANDed together by connecting with a space. Example: "labels.department:receiving labels.active". See Filtering datasets using labels for details.
+       * An expression for filtering the results of the request by label. The syntax is \"labels.<name>[:<value>]\". Multiple filters can be ANDed together by connecting with a space. Example: \"labels.department:receiving labels.active\". See [Filtering datasets using labels](/bigquery/docs/labeling-datasets#filtering_datasets_using_labels) for details.
        */
       filter?: string;
       /**
-       * The maximum number of results to return
+       * The maximum number of results to return in a single response page. Leverage the page tokens to iterate through the entire collection.
        */
       maxResults?: number;
       /**
@@ -4839,7 +5844,7 @@ declare namespace bigquery {
      */
     type ICancelParams = {
       /**
-       * The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       * The geographic location of the job. You must specify the location to run the job for the following scenarios: - If the location to run a job is not in the `us` or the `eu` multi-regional location - If the job's location is in a single region (for example, `us-central1`) For more information, see https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
        */
       location?: string;
     };
@@ -4859,33 +5864,37 @@ declare namespace bigquery {
      */
     type IGetParams = {
       /**
-       * The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       * The geographic location of the job. You must specify the location to run the job for the following scenarios: - If the location to run a job is not in the `us` or the `eu` multi-regional location - If the job's location is in a single region (for example, `us-central1`) For more information, see https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
        */
       location?: string;
     };
 
     /**
-     * Retrieves the results of a query job.
+     * RPC to get the results of a query job.
      */
     type IGetQueryResultsParams = {
       /**
-       * The geographic location where the job should run. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
+       * Optional. Output timestamp as usec int64. Default is false.
+       */
+      'formatOptions.useInt64Timestamp'?: boolean;
+      /**
+       * The geographic location of the job. You must specify the location to run the job for the following scenarios: - If the location to run a job is not in the `us` or the `eu` multi-regional location - If the job's location is in a single region (for example, `us-central1`) For more information, see https://cloud.google.com/bigquery/docs/locations#specifying_your_location.
        */
       location?: string;
       /**
-       * Maximum number of results to read
+       * Maximum number of results to read.
        */
       maxResults?: number;
       /**
-       * Page token, returned by a previous call, to request the next page of results
+       * Page token, returned by a previous call, to request the next page of results.
        */
       pageToken?: string;
       /**
-       * Zero-based index of the starting row
+       * Zero-based index of the starting row.
        */
       startIndex?: string;
       /**
-       * How long to wait for the query to complete, in milliseconds, before returning. Default is 10 seconds. If the timeout passes before the job completes, the 'jobComplete' field in the response will be false
+       * Optional: Specifies the maximum amount of time, in milliseconds, that the client is willing to wait for the query to complete. By default, this limit is 10 seconds (10,000 milliseconds). If the query is complete, the jobComplete field in the response is true. If the query has not yet completed, jobComplete is false. You can request a longer timeout period in the timeoutMs field. However, the call is not guaranteed to wait for the specified timeout; it typically returns after around 200 seconds (200,000 milliseconds), even if the query is not complete. If jobComplete is false, you can continue to wait for the query to complete by calling the getQueryResults method until the jobComplete field in the getQueryResults response is true.
        */
       timeoutMs?: number;
     };
@@ -4895,27 +5904,27 @@ declare namespace bigquery {
      */
     type IListParams = {
       /**
-       * Whether to display jobs owned by all users in the project. Default false
+       * Whether to display jobs owned by all users in the project. Default False.
        */
       allUsers?: boolean;
       /**
-       * Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned
+       * Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned.
        */
       maxCreationTime?: string;
       /**
-       * Maximum number of results to return
+       * The maximum number of results to return in a single response page. Leverage the page tokens to iterate through the entire collection.
        */
       maxResults?: number;
       /**
-       * Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned
+       * Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned.
        */
       minCreationTime?: string;
       /**
-       * Page token, returned by a previous call, to request the next page of results
+       * Page token, returned by a previous call, to request the next page of results.
        */
       pageToken?: string;
       /**
-       * If set, retrieves only jobs whose parent is this job. Otherwise, retrieves only jobs which have no parent
+       * If set, show only child jobs of the specified parent. Otherwise, show all top-level jobs.
        */
       parentJobId?: string;
       /**
@@ -4947,15 +5956,15 @@ declare namespace bigquery {
 
   namespace projects {
     /**
-     * Lists all projects to which you have been granted any project role.
+     * RPC to list projects to which the user has been granted any project role. Users of this method are encouraged to consider the [Resource Manager](https://cloud.google.com/resource-manager/docs/) API, which provides the underlying data for this method and has more capabilities.
      */
     type IListParams = {
       /**
-       * Maximum number of results to return
+       * `maxResults` unset returns all results, up to 50 per page. Additionally, the number of projects in a page may be fewer than `maxResults` because projects are retrieved and then filtered to only projects with the BigQuery API enabled.
        */
       maxResults?: number;
       /**
-       * Page token, returned by a previous call, to request the next page of results
+       * Page token, returned by a previous call, to request the next page of results. If not present, no further pages are present.
        */
       pageToken?: string;
     };
@@ -5013,23 +6022,27 @@ declare namespace bigquery {
 
   namespace tabledata {
     /**
-     * Retrieves table data from a specified set of rows. Requires the READER dataset role.
+     * List the content of a table in rows.
      */
     type IListParams = {
       /**
-       * Maximum number of results to return
+       * Optional. Output timestamp as usec int64. Default is false.
+       */
+      'formatOptions.useInt64Timestamp'?: boolean;
+      /**
+       * Row limit of the table.
        */
       maxResults?: number;
       /**
-       * Page token, returned by a previous call, identifying the result set
+       * To retrieve the next page of table data, set this field to the string provided in the pageToken field of the response body from your previous call to tabledata.list.
        */
       pageToken?: string;
       /**
-       * List of fields to return (comma-separated). If unspecified, all fields are returned
+       * Subset of fields to return, supports select into sub fields. Example: selected_fields = "a,e.d.f";
        */
       selectedFields?: string;
       /**
-       * Zero-based index of the starting row to read
+       * Start row index of the table.
        */
       startIndex?: string;
     };
@@ -5041,17 +6054,17 @@ declare namespace bigquery {
      */
     type IGetParams = {
       /**
-       * List of fields to return (comma-separated). If unspecified, all fields are returned
+       * List of table schema fields to return (comma-separated). If unspecified, all fields are returned. A fieldMask cannot be used here because the fields will automatically be converted from camelCase to snake_case and the conversion will fail if there are underscores. Since these are fields in BigQuery table schemas, underscores are allowed.
        */
       selectedFields?: string;
       /**
-       * Specifies the view that determines which table information is returned. By default, basic table information and storage statistics (STORAGE_STATS) are returned.
+       * Optional. Specifies the view that determines which table information is returned. By default, basic table information and storage statistics (STORAGE_STATS) are returned.
        */
       view?:
+        | 'TABLE_METADATA_VIEW_UNSPECIFIED'
         | 'BASIC'
-        | 'FULL'
         | 'STORAGE_STATS'
-        | 'TABLE_METADATA_VIEW_UNSPECIFIED';
+        | 'FULL';
     };
 
     /**
@@ -5059,7 +6072,7 @@ declare namespace bigquery {
      */
     type IListParams = {
       /**
-       * Maximum number of results to return
+       * The maximum number of results to return in a single response page. Leverage the page tokens to iterate through the entire collection.
        */
       maxResults?: number;
       /**
@@ -5069,21 +6082,21 @@ declare namespace bigquery {
     };
 
     /**
-     * Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports patch semantics.
+     * Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports RFC5789 patch semantics.
      */
     type IPatchParams = {
       /**
-       * When true will autodetect schema, else will keep original schema
+       * Optional.  When true will autodetect schema, else will keep original schema
        */
       autodetect_schema?: boolean;
     };
 
     /**
-     * Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource.
+     * Updates information in an existing table. The update method replaces the entire Table resource, whereas the patch method only replaces fields that are provided in the submitted Table resource.
      */
     type IUpdateParams = {
       /**
-       * When true will autodetect schema, else will keep original schema
+       * Optional.  When true will autodetect schema, else will keep original schema
        */
       autodetect_schema?: boolean;
     };


### PR DESCRIPTION
Update types generation script to handle new Discovery changes and handle a case where the `discovery-tsd` tool doen't handle fields with dots, like `formatOptions.useInt64Timestamp`. 

Also regenerate types with latest changes.
