### PR TITLE
feat: integrate jobs.query and stateless query for faster queries

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2118,7 +2118,7 @@ export class BigQuery extends Service {
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
 
     this.trace('[query]', query, options);
-    const queryReq = this.buildQueryRequest(query, options);
+    const queryReq = this.buildQueryRequest_(query, options);
     if (!queryReq) {
       this.createQueryJob(query, (err, job, resp) => {
         if (err) {
@@ -2181,11 +2181,11 @@ export class BigQuery extends Service {
    * @param options QueryOptions
    * @returns bigquery.IQueryRequest | undefined
    */
-  private buildQueryRequest(
+  private buildQueryRequest_(
     query: string | Query,
     options: QueryOptions
   ): bigquery.IQueryRequest | undefined {
-    this.trace('[probeFastPath_]', query, options);
+    this.trace('[buildQueryRequest]', query, options);
     if (process.env.FAST_QUERY_PATH === 'DISABLED') {
       return undefined;
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -51,8 +51,12 @@ export type QueryResultsOptions = {
   job?: Job;
   wrapIntegers?: boolean | IntegerTypeCastOptions;
   parseJSON?: boolean;
-  cachedRows?: any[];
-} & PagedRequest<bigquery.jobs.IGetQueryResultsParams>;
+} & PagedRequest<bigquery.jobs.IGetQueryResultsParams> & {
+    /**
+     * internal properties
+     */
+    _cachedRows?: any[];
+  };
 
 /**
  * @callback QueryResultsCallback
@@ -560,15 +564,15 @@ class Job extends Operation {
     const timeoutOverride =
       typeof qs.timeoutMs === 'number' ? qs.timeoutMs : false;
 
-    if (options.cachedRows) {
+    if (options._cachedRows) {
       let nextQuery: QueryResultsOptions | null = null;
       if (options.pageToken) {
         nextQuery = Object.assign({}, options, {
           pageToken: options.pageToken,
         });
-        delete nextQuery.cachedRows;
+        delete nextQuery._cachedRows;
       }
-      callback!(null, options.cachedRows, nextQuery);
+      callback!(null, options._cachedRows, nextQuery);
       return;
     }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -382,7 +382,7 @@ class Job extends Operation {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private trace(msg: string, ...otherArgs: any[]) {
+  private trace_(msg: string, ...otherArgs: any[]) {
     logger(`[job][${this.id}]`, msg, ...otherArgs);
   }
 
@@ -543,7 +543,7 @@ class Job extends Operation {
       },
       options
     );
-    this.trace(
+    this.trace_(
       '[getQueryResults]',
       this.id,
       options.pageToken,
@@ -607,7 +607,7 @@ class Job extends Operation {
             return;
           }
         } else if (resp.pageToken) {
-          this.trace('[getQueryResults] has more pages', resp.pageToken);
+          this.trace_('[getQueryResults] has more pages', resp.pageToken);
           // More results exist.
           nextQuery = Object.assign({}, options, {
             pageToken: resp.pageToken,

--- a/src/job.ts
+++ b/src/job.ts
@@ -561,10 +561,13 @@ class Job extends Operation {
       typeof qs.timeoutMs === 'number' ? qs.timeoutMs : false;
 
     if (options.cachedRows) {
-      const nextQuery = Object.assign({}, options, {
-        pageToken: options.pageToken,
-      });
-      delete nextQuery.cachedRows;
+      let nextQuery: QueryResultsOptions | null = null;
+      if (options.pageToken) {
+        nextQuery = Object.assign({}, options, {
+          pageToken: options.pageToken,
+        });
+        delete nextQuery.cachedRows;
+      }
       callback!(null, options.cachedRows, nextQuery);
       return;
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -37,7 +37,7 @@ export function logger(source: string, msg: string, ...otherArgs: any[]) {
 }
 
 /**
- * Sets or disables the log function for all active Firestore instances.
+ * Sets or disables the log function for all active BigQuery instances.
  *
  * @param logger A log function that takes a message (such as `console.log`) or
  * `null` to turn off logging.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,47 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as util from 'util';
+
+/*! The external function used to emit logs. */
+let logFunction: ((msg: string) => void) | null = null;
+
+/**
+ * Log function to use for debug output. By default, we don't perform any
+ * logging.
+ *
+ * @private
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function logger(source: string, msg: string, ...otherArgs: any[]) {
+  if (logFunction) {
+    const time = new Date().toISOString();
+    const formattedMsg = util.format(
+      `D ${time} | ${source} | ${msg} |`,
+      ...otherArgs
+    );
+    logFunction(formattedMsg);
+  }
+}
+
+/**
+ * Sets or disables the log function for all active Firestore instances.
+ *
+ * @param logger A log function that takes a message (such as `console.log`) or
+ * `null` to turn off logging.
+ */
+export function setLogFunction(logger: ((msg: string) => void) | null): void {
+  logFunction = logger;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -931,7 +931,7 @@ declare namespace bigquery {
      */
     etag?: string;
     /**
-     * Optional. Information about the external metadata storage where the dataset is defined. Filled out when the dataset type is EXTERNAL.
+     * Optional. Reference to a read-only external dataset defined in data catalogs outside of BigQuery. Filled out when the dataset type is EXTERNAL.
      */
     externalDatasetReference?: IExternalDatasetReference;
     /**
@@ -970,6 +970,10 @@ declare namespace bigquery {
      * Optional. Defines the time travel window in hours. The value can be from 48 to 168 hours (2 to 7 days). The default value is 168 hours if this is not set.
      */
     maxTimeTravelHours?: string;
+    /**
+     * Output only. Reserved for future use.
+     */
+    satisfiesPzi?: boolean;
     /**
      * Output only. Reserved for future use.
      */
@@ -1927,8 +1931,8 @@ declare namespace bigquery {
       | 'ESTIMATED_PERFORMANCE_GAIN_TOO_LOW'
       | 'NOT_SUPPORTED_IN_STANDARD_EDITION'
       | 'INDEX_SUPPRESSED_BY_FUNCTION_OPTION'
-      | 'INTERNAL_ERROR'
       | 'QUERY_CACHE_HIT'
+      | 'INTERNAL_ERROR'
       | 'OTHER_REASON';
     /**
      * Specifies the name of the unused search index, if available.
@@ -2212,6 +2216,10 @@ declare namespace bigquery {
      * Optional. Connection properties which can modify the load job behavior. Currently, only the 'session_id' connection property is supported, and is used to resolve _SESSION appearing as the dataset id.
      */
     connectionProperties?: Array<IConnectionProperty>;
+    /**
+     * Optional. [Experimental] Configures the load job to only copy files to the destination BigLake managed table with an external storage_uri, without reading file content and writing them to new files. Copying files only is supported when: * source_uris are in the same external storage system as the destination table but they do not overlap with storage_uri of the destination table. * source_format is the same file format as the destination table. * destination_table is an existing BigLake managed table. Its schema does not have default value expression. It schema does not have type parameters other than precision and scale. * No options other than the above are specified.
+     */
+    copyFilesOnly?: boolean;
     /**
      * Optional. Specifies whether the job is allowed to create new tables. The following values are supported: * CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. * CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
@@ -2880,7 +2888,7 @@ declare namespace bigquery {
      */
     undeclaredQueryParameters?: Array<IQueryParameter>;
     /**
-     * Output only. Search query specific statistics.
+     * Output only. Vector Search query specific statistics.
      */
     vectorSearchStatistics?: IVectorSearchStatistics;
   };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2985,6 +2985,13 @@ declare namespace bigquery {
      */
     dryRun?: boolean;
     /**
+     * Optional. If not set, jobs are always required. If set, the query request will follow the behavior described JobCreationMode. This feature is not yet available. Jobs will always be created.
+     */
+    jobCreationMode?:
+      | 'JOB_CREATION_MODE_UNSPECIFIED'
+      | 'JOB_CREATION_REQUIRED'
+      | 'JOB_CREATION_OPTIONAL';
+    /**
      * The resource type of the request.
      */
     kind?: string;

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -189,6 +189,7 @@ describe('BigQuery', () => {
     Object.assign(fakeUtil, originalFakeUtil);
     BigQuery = Object.assign(BigQuery, BigQueryCached);
     bq = new BigQuery({projectId: PROJECT_ID});
+    bq._enableQueryPreview = true;
   });
 
   after(() => {

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -2812,6 +2812,10 @@ describe('BigQuery', () => {
         callback(error, null, FAKE_RESPONSE);
       };
 
+      bq.buildQueryRequest_ = (query: {}, options: {}) => {
+        return undefined;
+      };
+
       bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
         assert.strictEqual(err, error);
         assert.strictEqual(rows, null);
@@ -2848,6 +2852,10 @@ describe('BigQuery', () => {
 
       bq.createQueryJob = (query: {}, callback: Function) => {
         callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      bq.buildQueryRequest_ = (query: {}, options: {}) => {
+        return undefined;
       };
 
       bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
@@ -2901,6 +2909,10 @@ describe('BigQuery', () => {
         callback(null, fakeJob, FAKE_RESPONSE);
       };
 
+      bq.buildQueryRequest_ = (query: {}, opts: {}) => {
+        return undefined;
+      };
+
       bq.query(QUERY_STRING, assert.ifError);
     });
 
@@ -2916,6 +2928,10 @@ describe('BigQuery', () => {
 
       bq.createQueryJob = (query: {}, callback: Function) => {
         callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      bq.buildQueryRequest_ = (query: {}, opts: {}) => {
+        return undefined;
       };
 
       bq.query(QUERY_STRING, fakeOptions, assert.ifError);

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -2880,7 +2880,7 @@ describe('BigQuery', () => {
     it('should call job#getQueryResults with cached rows from jobs.query', done => {
       const fakeJob = {
         getQueryResults: (options: QueryResultsOptions, callback: Function) => {
-          callback(null, options.cachedRows, FAKE_RESPONSE);
+          callback(null, options._cachedRows, FAKE_RESPONSE);
         },
       };
 
@@ -3041,7 +3041,7 @@ describe('BigQuery', () => {
         labels: {
           key: 'value',
         },
-        jobCreationMode: 'JOB_CREATION_REQUIRED', // due to maxResults set
+        jobCreationMode: 'JOB_CREATION_OPTIONAL',
         formatOptions: {
           useInt64Timestamp: true,
         },

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -40,6 +40,8 @@ import {
   Table,
   JobOptions,
   TableField,
+  Query,
+  QueryResultsOptions,
 } from '../src';
 import {SinonStub} from 'sinon';
 import {PreciseDate} from '@google-cloud/precise-date';
@@ -2117,10 +2119,10 @@ describe('BigQuery', () => {
         it('should set the correct query parameters', done => {
           const queryParameter = {};
 
-          BigQuery.valueToQueryParameter_ = (value: {}) => {
+          sandbox.replace(BigQuery, 'valueToQueryParameter_', (value: {}) => {
             assert.strictEqual(value, NAMED_PARAMS.key);
             return queryParameter;
-          };
+          });
 
           bq.createJob = (reqOpts: JobOptions) => {
             const query = reqOpts.configuration!.query!;
@@ -2141,14 +2143,14 @@ describe('BigQuery', () => {
         it('should allow for optional parameter types', () => {
           const queryParameter = {};
 
-          BigQuery.valueToQueryParameter_ = (
+          sandbox.replace(BigQuery, 'valueToQueryParameter_', (
             value: {},
             providedType: string
           ) => {
             assert.strictEqual(value, NAMED_PARAMS.key);
             assert.strictEqual(providedType, NAMED_TYPES.key);
             return queryParameter;
-          };
+          });
           bq.createJob = (reqOpts: JobOptions) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             assert.strictEqual((reqOpts as any).params, undefined);
@@ -2167,10 +2169,10 @@ describe('BigQuery', () => {
         it('should allow for providing only some parameter types', () => {
           const queryParameter = {};
 
-          BigQuery.valueToQueryParameter_ = (value: {}) => {
+          sandbox.replace(BigQuery, 'valueToQueryParameter_', (value: {}) => {
             assert.strictEqual(value, NAMED_PARAMS.key);
             return queryParameter;
-          };
+          });
 
           bq.createJob = (reqOpts: JobOptions) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2202,9 +2204,9 @@ describe('BigQuery', () => {
         it('should set the correct parameter mode', done => {
           const queryParameter = {};
 
-          BigQuery.valueToQueryParameter_ = () => {
+          sandbox.replace(BigQuery, 'valueToQueryParameter_', (value: {}) => {
             return queryParameter;
-          };
+          });
 
           bq.createJob = (reqOpts: JobOptions) => {
             const query = reqOpts.configuration!.query!;
@@ -2224,10 +2226,10 @@ describe('BigQuery', () => {
         it('should set the correct query parameters', done => {
           const queryParameter = {};
 
-          BigQuery.valueToQueryParameter_ = (value: {}) => {
+          sandbox.replace(BigQuery, 'valueToQueryParameter_', (value: {}) => {
             assert.strictEqual(value, POSITIONAL_PARAMS[0]);
             return queryParameter;
-          };
+          });
 
           bq.createJob = (reqOpts: JobOptions) => {
             const query = reqOpts.configuration!.query!;
@@ -2417,7 +2419,7 @@ describe('BigQuery', () => {
         );
         assert.strictEqual(
           reqOpts.configuration!.jobTimeoutMs,
-          options.jobTimeoutMs
+          `${options.jobTimeoutMs}`
         );
         done();
       };
@@ -2824,6 +2826,21 @@ describe('BigQuery', () => {
       });
     });
 
+    it('should return any errors from jobs.query', done => {
+      const error = new Error('err');
+
+      bq.runJobsQuery = (query: {}, callback: Function) => {
+        callback(error, null, FAKE_RESPONSE);
+      };
+
+      bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
+        assert.strictEqual(err, error);
+        assert.strictEqual(rows, null);
+        assert.strictEqual(resp, FAKE_RESPONSE);
+        done();
+      });
+    });
+
     it('should exit early if dryRun is set', done => {
       const options = {
         query: QUERY_STRING,
@@ -2833,6 +2850,10 @@ describe('BigQuery', () => {
       bq.createQueryJob = (query: {}, callback: Function) => {
         assert.strictEqual(query, options);
         callback(null, null, FAKE_RESPONSE);
+      };
+
+      bq.buildQueryRequest_ = (query: {}, options: {}) => {
+        return undefined;
       };
 
       bq.query(options, (err: Error, rows: {}, resp: {}) => {
@@ -2866,6 +2887,43 @@ describe('BigQuery', () => {
       });
     });
 
+    it('should call job#getQueryResults with cached rows from jobs.query', done => {
+      const fakeJob = {
+        getQueryResults: (options: QueryResultsOptions, callback: Function) => {
+          callback(null, options.cachedRows, FAKE_RESPONSE);
+        },
+      };
+
+      bq.runJobsQuery = (query: {}, callback: Function) => {
+        callback(null, fakeJob, {
+          jobComplete: true,
+          schema: {
+            fields: [
+              {name: 'value', type: 'INT64'}
+            ]
+          },
+          rows: [
+            {f: [{v: 1}]},
+            {f: [{v: 2}]},
+            {f: [{v: 3}]},
+          ],
+        });
+      };
+
+      bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(rows, [{
+          value: 1,
+        },{
+          value: 2
+        },{
+          value: 3
+        }]);
+        assert.strictEqual(resp, FAKE_RESPONSE);
+        done();
+      });
+    });
+
     it('should call job#getQueryResults with query options', done => {
       let queryResultsOpts = {};
       const fakeJob = {
@@ -2877,6 +2935,10 @@ describe('BigQuery', () => {
 
       bq.createQueryJob = (query: {}, callback: Function) => {
         callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      bq.buildQueryRequest_ = (query: {}, options: {}) => {
+        return undefined;
       };
 
       const query = {
@@ -2935,6 +2997,143 @@ describe('BigQuery', () => {
       };
 
       bq.query(QUERY_STRING, fakeOptions, assert.ifError);
+    });
+  });
+
+  describe('buildQueryRequest_', () => {
+    const DATASET_ID = 'dataset-id';
+    const TABLE_ID = 'table-id';
+    const QUERY_STRING = 'SELECT * FROM [dataset.table]';
+
+    it('should create a QueryRequest from a Query interface', () => {
+      const q: Query = {
+        query: QUERY_STRING,
+        maxResults: 10,
+        defaultDataset: {
+          projectId: PROJECT_ID,
+          datasetId: DATASET_ID,
+        },
+        priority: 'INTERACTIVE',
+        params: {
+          key: 'value',
+        },
+        maximumBytesBilled: '1024',
+        labels: {
+          key: 'value',
+        },
+      };
+      const req = bq.buildQueryRequest_(q, {});
+      for (let key in req) {
+        if (req[key] === undefined) {
+          delete req[key];
+        }
+      }
+      const expectedReq = {
+        query: QUERY_STRING,
+        useLegacySql: false,
+        requestId: req.requestId,
+        maxResults: 10,
+        defaultDataset: {
+          projectId: PROJECT_ID,
+          datasetId: DATASET_ID,
+        },
+        parameterMode: 'named',
+        queryParameters: [
+          {
+            name: 'key',
+            parameterType: {
+              type: 'STRING',
+            },
+            parameterValue: {
+              value: 'value',
+            },
+          },
+        ],
+        maximumBytesBilled: '1024',
+        labels: {
+          key: 'value',
+        },
+        jobCreationMode: 'JOB_CREATION_REQUIRED', // due to maxResults set
+        formatOptions: {
+          useInt64Timestamp: true,
+        },
+      };
+      assert.deepStrictEqual(req, expectedReq);
+    });
+
+    it('should create a QueryRequest from a SQL string', () => {
+      const req = bq.buildQueryRequest_(QUERY_STRING, {});
+      for (let key in req) {
+        if (req[key] === undefined) {
+          delete req[key];
+        }
+      }
+      const expectedReq = {
+        query: QUERY_STRING,
+        useLegacySql: false,
+        requestId: req.requestId,
+        jobCreationMode: 'JOB_CREATION_OPTIONAL',
+        formatOptions: {
+          useInt64Timestamp: true,
+        },
+      };
+      assert.deepStrictEqual(req, expectedReq);
+    });
+
+    it('should not create a QueryRequest when config is not accepted by jobs.query', () => {
+      const dataset: any = {
+        bigQuery: bq,
+        id: 'dataset-id',
+        createTable: util.noop,
+      };
+      const table = new FakeTable(dataset, TABLE_ID);
+      const testCases: Query[] = [
+        {
+          query: QUERY_STRING,
+          dryRun: true,
+        },
+        {
+          query: QUERY_STRING,
+          destination: table,
+        },
+        {
+          query: QUERY_STRING,
+          clustering: {
+            fields: ['date'],
+          },
+        },
+        {
+          query: QUERY_STRING,
+          clustering: {},
+        },
+        {
+          query: QUERY_STRING,
+          timePartitioning: {},
+        },
+        {
+          query: QUERY_STRING,
+          rangePartitioning: {},
+        },
+        {
+          query: QUERY_STRING,
+          jobId: 'fixed-job-id'
+        },
+        {
+          query: QUERY_STRING,
+          createDisposition: 'CREATED_IF_NEEDED',
+          writeDisposition: 'WRITE_APPEND',
+        },
+        {
+          query: QUERY_STRING,
+          schemaUpdateOptions: ['update']
+        }
+      ];
+
+      for (let index in testCases) {
+        const testCase = testCases[index];
+        const req = bq.buildQueryRequest_(testCase, {});
+        assert.equal(req, undefined);
+      }
     });
   });
 

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -2143,14 +2143,15 @@ describe('BigQuery', () => {
         it('should allow for optional parameter types', () => {
           const queryParameter = {};
 
-          sandbox.replace(BigQuery, 'valueToQueryParameter_', (
-            value: {},
-            providedType: string
-          ) => {
-            assert.strictEqual(value, NAMED_PARAMS.key);
-            assert.strictEqual(providedType, NAMED_TYPES.key);
-            return queryParameter;
-          });
+          sandbox.replace(
+            BigQuery,
+            'valueToQueryParameter_',
+            (value: {}, providedType: string) => {
+              assert.strictEqual(value, NAMED_PARAMS.key);
+              assert.strictEqual(providedType, NAMED_TYPES.key);
+              return queryParameter;
+            }
+          );
           bq.createJob = (reqOpts: JobOptions) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             assert.strictEqual((reqOpts as any).params, undefined);
@@ -2898,27 +2899,25 @@ describe('BigQuery', () => {
         callback(null, fakeJob, {
           jobComplete: true,
           schema: {
-            fields: [
-              {name: 'value', type: 'INT64'}
-            ]
+            fields: [{name: 'value', type: 'INT64'}],
           },
-          rows: [
-            {f: [{v: 1}]},
-            {f: [{v: 2}]},
-            {f: [{v: 3}]},
-          ],
+          rows: [{f: [{v: 1}]}, {f: [{v: 2}]}, {f: [{v: 3}]}],
         });
       };
 
       bq.query(QUERY_STRING, (err: Error, rows: {}, resp: {}) => {
         assert.ifError(err);
-        assert.deepStrictEqual(rows, [{
-          value: 1,
-        },{
-          value: 2
-        },{
-          value: 3
-        }]);
+        assert.deepStrictEqual(rows, [
+          {
+            value: 1,
+          },
+          {
+            value: 2,
+          },
+          {
+            value: 3,
+          },
+        ]);
         assert.strictEqual(resp, FAKE_RESPONSE);
         done();
       });
@@ -3023,7 +3022,7 @@ describe('BigQuery', () => {
         },
       };
       const req = bq.buildQueryRequest_(q, {});
-      for (let key in req) {
+      for (const key in req) {
         if (req[key] === undefined) {
           delete req[key];
         }
@@ -3063,7 +3062,7 @@ describe('BigQuery', () => {
 
     it('should create a QueryRequest from a SQL string', () => {
       const req = bq.buildQueryRequest_(QUERY_STRING, {});
-      for (let key in req) {
+      for (const key in req) {
         if (req[key] === undefined) {
           delete req[key];
         }
@@ -3116,7 +3115,7 @@ describe('BigQuery', () => {
         },
         {
           query: QUERY_STRING,
-          jobId: 'fixed-job-id'
+          jobId: 'fixed-job-id',
         },
         {
           query: QUERY_STRING,
@@ -3125,11 +3124,11 @@ describe('BigQuery', () => {
         },
         {
           query: QUERY_STRING,
-          schemaUpdateOptions: ['update']
-        }
+          schemaUpdateOptions: ['update'],
+        },
       ];
 
-      for (let index in testCases) {
+      for (const index in testCases) {
         const testCase = testCases[index];
         const req = bq.buildQueryRequest_(testCase, {});
         assert.equal(req, undefined);


### PR DESCRIPTION
Integrate with `jobs.query` endpoint for faster small queries. Keep using `jobs.getQueryResults` when pagination is needed.  Fallback to current method of creating a job + `jobs.getQueryResults` when not possible to use `jobs.query`.
