### PR TITLE
fix: BigQueryTimestamp should keep accepting floats

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -882,6 +882,10 @@ export class BigQuery extends Service {
    * A timestamp represents an absolute point in time, independent of any time
    * zone or convention such as Daylight Savings Time.
    *
+   * The recommended input here is a `Date` or `PreciseDate` class.
+   * If passing as a `string`, it should be Timestamp literals: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#timestamp_literals.
+   * When passing a `number` input, it should be epoch seconds in float representation.
+   *
    * @method BigQuery.timestamp
    * @param {Date|string} value The time.
    *
@@ -891,12 +895,19 @@ export class BigQuery extends Service {
    * const timestamp = BigQuery.timestamp(new Date());
    * ```
    */
+  static timestamp(value: Date | PreciseDate | string | number) {
+    return new BigQueryTimestamp(value);
+  }
 
   /**
    * A timestamp represents an absolute point in time, independent of any time
    * zone or convention such as Daylight Savings Time.
    *
-   * @param {Date|string} value The time.
+   * The recommended input here is a `Date` or `PreciseDate` class.
+   * If passing as a `string`, it should be Timestamp literals: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#timestamp_literals.
+   * When passing a `number` input, it should be epoch seconds in float representation.
+   *
+   * @param {Date|string|string|number} value The time.
    *
    * @example
    * ```
@@ -905,10 +916,6 @@ export class BigQuery extends Service {
    * const timestamp = bigquery.timestamp(new Date());
    * ```
    */
-  static timestamp(value: Date | PreciseDate | string | number) {
-    return new BigQueryTimestamp(value);
-  }
-
   timestamp(value: Date | PreciseDate | string | number) {
     return BigQuery.timestamp(value);
   }
@@ -2205,6 +2212,11 @@ export class Geography {
 
 /**
  * Timestamp class for BigQuery.
+ *
+ * The recommended input here is a `Date` or `PreciseDate` class.
+ * If passing as a `string`, it should be Timestamp literals: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#timestamp_literals.
+ * When passing a `number` input, it should be epoch seconds in float representation.
+ *
  */
 export class BigQueryTimestamp {
   value: string;

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -471,7 +471,7 @@ describe('BigQuery', () => {
             f: [
               {v: '3'},
               {v: 'Milo'},
-              {v: now.valueOf() * 1000},
+              {v: now.valueOf() * 1000}, // int64 microseconds
               {v: 'false'},
               {v: 'true'},
               {v: '5.222330009847'},
@@ -523,7 +523,7 @@ describe('BigQuery', () => {
             id: 3,
             name: 'Milo',
             dob: {
-              input: now.valueOf() * 1000,
+              input: new PreciseDate(BigInt(now.valueOf()) * BigInt(1_000_000)),
               type: 'fakeTimestamp',
             },
             has_claws: false,
@@ -850,10 +850,8 @@ describe('BigQuery', () => {
   describe('timestamp', () => {
     const INPUT_STRING = '2016-12-06T12:00:00.000Z';
     const INPUT_STRING_MICROS = '2016-12-06T12:00:00.123456Z';
-    const INPUT_STRING_NEGATIVE = '1969-12-25T00:00:00.000Z';
     const INPUT_DATE = new Date(INPUT_STRING);
     const INPUT_PRECISE_DATE = new PreciseDate(INPUT_STRING_MICROS);
-    const INPUT_PRECISE_NEGATIVE_DATE = new PreciseDate(INPUT_STRING_NEGATIVE);
     const EXPECTED_VALUE = INPUT_DATE.toJSON();
     const EXPECTED_VALUE_MICROS = INPUT_PRECISE_DATE.toISOString();
 
@@ -891,31 +889,6 @@ describe('BigQuery', () => {
 
       timestamp = bq.timestamp(f.toString());
       assert.strictEqual(timestamp.value, d.toJSON());
-    });
-
-    it('should accept a number in microseconds', () => {
-      let ms = INPUT_PRECISE_DATE.valueOf(); // milliseconds
-      let us = ms * 1000 + INPUT_PRECISE_DATE.getMicroseconds(); // microseconds
-      let timestamp = bq.timestamp(us);
-      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
-
-      let usStr = `${us}`;
-      timestamp = bq.timestamp(usStr);
-      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
-
-      ms = INPUT_PRECISE_NEGATIVE_DATE.valueOf();
-      us = ms * 1000;
-      timestamp = bq.timestamp(us);
-      assert.strictEqual(timestamp.value, INPUT_STRING_NEGATIVE);
-
-      usStr = `${us}`;
-      timestamp = bq.timestamp(usStr);
-      assert.strictEqual(timestamp.value, INPUT_STRING_NEGATIVE);
-    });
-
-    it('should accept a string with microseconds', () => {
-      const timestamp = bq.timestamp(INPUT_STRING_MICROS);
-      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
     });
 
     it('should accept a Date object', () => {

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -887,10 +887,10 @@ describe('BigQuery', () => {
       const d = new Date();
       const f = d.valueOf() / 1000; // float seconds
       let timestamp = bq.timestamp(f);
-      assert.strictEqual(timestamp.value, d.toJSON());      
+      assert.strictEqual(timestamp.value, d.toJSON());
 
       timestamp = bq.timestamp(f.toString());
-      assert.strictEqual(timestamp.value, d.toJSON());      
+      assert.strictEqual(timestamp.value, d.toJSON());
     });
 
     it('should accept a number in microseconds', () => {

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -883,6 +883,16 @@ describe('BigQuery', () => {
       assert.strictEqual(timestamp.value, EXPECTED_VALUE);
     });
 
+    it('should accept a float number', () => {
+      const d = new Date();
+      const f = d.valueOf() / 1000; // float seconds
+      let timestamp = bq.timestamp(f);
+      assert.strictEqual(timestamp.value, d.toJSON());      
+
+      timestamp = bq.timestamp(f.toString());
+      assert.strictEqual(timestamp.value, d.toJSON());      
+    });
+
     it('should accept a number in microseconds', () => {
       let ms = INPUT_PRECISE_DATE.valueOf(); // milliseconds
       let us = ms * 1000 + INPUT_PRECISE_DATE.getMicroseconds(); // microseconds

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -881,6 +881,11 @@ describe('BigQuery', () => {
       assert.strictEqual(timestamp.value, EXPECTED_VALUE);
     });
 
+    it('should accept a string with microseconds', () => {
+      const timestamp = bq.timestamp(INPUT_STRING_MICROS);
+      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
+    });
+
     it('should accept a float number', () => {
       const d = new Date();
       const f = d.valueOf() / 1000; // float seconds


### PR DESCRIPTION
Add back parsing of timestamps as floats, as some users where relying on that internal format.

A example of that is passing `Date.now()/1000)`. This worked in the past because internally the library was parsing BigQuery timestamps being returned as a float representation from the service side. We moved away from it due to it being imprecise and now the `formatOptions.useInt64Timestamp` is available, which makes the timestamps to be return as a int64 in usec.
 
This PR restores the BigQueryTimestamp parsing and converts the int64 timestamp coming from the service side before passing to the BigQueryTimestamp constructor, so the class don't need to handle microsecond parsing for now and we keep it backward compatible.

Fixes #1338  🦕

BEGIN_COMMIT_OVERRIDE
fix: BigQueryTimestamp should keep accepting floats #1339

fix: restores BigQueryTimestamp behavior to accept a numeric value in the constructor representing epoch-seconds. The affected 7.5.0 version would parse a numeric value as epoch-microseconds.

fix: add better documentation around usage of BigQueryTimestamp class and .timestamp method.
END_COMMIT_OVERRIDE