### PR TITLE
fix: revert switch to timestamp representation to int64 usec

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2217,13 +2217,15 @@ export class BigQueryTimestamp {
       if (/^\d{4}-\d{1,2}-\d{1,2}/.test(value)) {
         pd = new PreciseDate(value);
       } else {
-        pd = new PreciseDate(BigInt(value) * BigInt(1000));
+        const floatValue = Number.parseFloat(value);
+        if (!Number.isNaN(floatValue)) {
+          pd = this.fromFloatValue_(floatValue);
+        } else {
+          pd = new PreciseDate(value);
+        }
       }
-    } else if (value) {
-      pd = new PreciseDate(BigInt(value) * BigInt(1000));
     } else {
-      // Nan or 0 - invalid dates
-      pd = new PreciseDate(value);
+      pd = this.fromFloatValue_(value);
     }
     // to keep backward compatibility, only converts with microsecond
     // precision if needed.
@@ -2232,6 +2234,15 @@ export class BigQueryTimestamp {
     } else {
       this.value = new Date(pd.getTime()).toJSON();
     }
+  }
+
+  fromFloatValue_(value: number): PreciseDate {
+    const secs = Math.trunc(value);
+    // Timestamps in BigQuery have microsecond precision, so we must
+    // return a round number of microseconds.
+    const micros = Math.trunc((value - secs) * 1e6 + 0.5);
+    const pd = new PreciseDate([secs, micros * 1000]);
+    return pd;
   }
 }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -529,10 +529,10 @@ class Job extends Operation {
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
+
     const qs = extend(
       {
         location: this.location,
-        'formatOptions.useInt64Timestamp': true,
       },
       options
     );

--- a/src/table.ts
+++ b/src/table.ts
@@ -1848,17 +1848,10 @@ class Table extends ServiceObject {
       callback!(null, rows, nextQuery, resp);
     };
 
-    const qs = extend(
-      {
-        'formatOptions.useInt64Timestamp': true,
-      },
-      options
-    );
-
     this.request(
       {
         uri: '/data',
-        qs,
+        qs: options,
       },
       (err, resp) => {
         if (err) {
@@ -1867,7 +1860,7 @@ class Table extends ServiceObject {
         }
         let nextQuery: GetRowsOptions | null = null;
         if (resp.pageToken) {
-          nextQuery = Object.assign({}, qs, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.pageToken,
           });
         }

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -850,10 +850,8 @@ describe('BigQuery', () => {
   describe('timestamp', () => {
     const INPUT_STRING = '2016-12-06T12:00:00.000Z';
     const INPUT_STRING_MICROS = '2016-12-06T12:00:00.123456Z';
-    const INPUT_STRING_NEGATIVE = '1969-12-25T00:00:00.000Z';
     const INPUT_DATE = new Date(INPUT_STRING);
     const INPUT_PRECISE_DATE = new PreciseDate(INPUT_STRING_MICROS);
-    const INPUT_PRECISE_NEGATIVE_DATE = new PreciseDate(INPUT_STRING_NEGATIVE);
     const EXPECTED_VALUE = INPUT_DATE.toJSON();
     const EXPECTED_VALUE_MICROS = INPUT_PRECISE_DATE.toISOString();
 
@@ -881,26 +879,6 @@ describe('BigQuery', () => {
     it('should accept a string', () => {
       const timestamp = bq.timestamp(INPUT_STRING);
       assert.strictEqual(timestamp.value, EXPECTED_VALUE);
-    });
-
-    it('should accept a number in microseconds', () => {
-      let ms = INPUT_PRECISE_DATE.valueOf(); // milliseconds
-      let us = ms * 1000 + INPUT_PRECISE_DATE.getMicroseconds(); // microseconds
-      let timestamp = bq.timestamp(us);
-      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
-
-      let usStr = `${us}`;
-      timestamp = bq.timestamp(usStr);
-      assert.strictEqual(timestamp.value, EXPECTED_VALUE_MICROS);
-
-      ms = INPUT_PRECISE_NEGATIVE_DATE.valueOf();
-      us = ms * 1000;
-      timestamp = bq.timestamp(us);
-      assert.strictEqual(timestamp.value, INPUT_STRING_NEGATIVE);
-
-      usStr = `${us}`;
-      timestamp = bq.timestamp(usStr);
-      assert.strictEqual(timestamp.value, INPUT_STRING_NEGATIVE);
     });
 
     it('should accept a string with microseconds', () => {

--- a/test/job.ts
+++ b/test/job.ts
@@ -238,10 +238,7 @@ describe('BigQuery/Job', () => {
 
     it('should optionally accept options', done => {
       const options = {a: 'b'};
-      const expectedOptions = Object.assign(
-        {location: undefined, 'formatOptions.useInt64Timestamp': true},
-        options
-      );
+      const expectedOptions = Object.assign({location: undefined}, options);
 
       BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
         assert.deepStrictEqual(reqOpts.qs, expectedOptions);
@@ -255,10 +252,7 @@ describe('BigQuery/Job', () => {
       const job = new Job(BIGQUERY, JOB_ID, {location: LOCATION});
 
       BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
-        assert.deepStrictEqual(reqOpts.qs, {
-          location: LOCATION,
-          'formatOptions.useInt64Timestamp': true,
-        });
+        assert.deepStrictEqual(reqOpts.qs, {location: LOCATION});
         done();
       };
 
@@ -267,11 +261,7 @@ describe('BigQuery/Job', () => {
 
     it('should delete any cached jobs', done => {
       const options = {job: {}, a: 'b'};
-      const expectedOptions = {
-        location: undefined,
-        a: 'b',
-        'formatOptions.useInt64Timestamp': true,
-      };
+      const expectedOptions = {location: undefined, a: 'b'};
 
       BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
         assert.deepStrictEqual(reqOpts.qs, expectedOptions);
@@ -350,10 +340,7 @@ describe('BigQuery/Job', () => {
       const mergedRows: Array<{}> = [];
 
       const options = {wrapIntegers: true};
-      const expectedOptions = Object.assign({
-        location: undefined,
-        'formatOptions.useInt64Timestamp': true,
-      });
+      const expectedOptions = Object.assign({location: undefined});
 
       BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
         assert.deepStrictEqual(reqOpts.qs, expectedOptions);
@@ -381,10 +368,7 @@ describe('BigQuery/Job', () => {
       const mergedRows: Array<{}> = [];
 
       const options = {parseJSON: true};
-      const expectedOptions = Object.assign({
-        location: undefined,
-        'formatOptions.useInt64Timestamp': true,
-      });
+      const expectedOptions = Object.assign({location: undefined});
 
       BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
         assert.deepStrictEqual(reqOpts.qs, expectedOptions);

--- a/test/table.ts
+++ b/test/table.ts
@@ -1979,10 +1979,7 @@ describe('BigQuery/Table', () => {
 
       table.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
         assert.strictEqual(reqOpts.uri, '/data');
-        assert.deepStrictEqual(reqOpts.qs, {
-          ...options,
-          'formatOptions.useInt64Timestamp': true,
-        });
+        assert.strictEqual(reqOpts.qs, options);
         callback(null, {});
       };
 
@@ -2132,10 +2129,7 @@ describe('BigQuery/Table', () => {
       table.metadata = {schema: {}};
 
       table.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
-        callback(null, {
-          'formatOptions.useInt64Timestamp': true,
-          pageToken,
-        });
+        callback(null, {pageToken});
       };
 
       table.getRows(options, (err: Error, rows: {}, nextQuery: {}) => {
@@ -2143,7 +2137,6 @@ describe('BigQuery/Table', () => {
         assert.deepStrictEqual(nextQuery, {
           a: 'b',
           c: 'd',
-          'formatOptions.useInt64Timestamp': true,
           pageToken,
         });
         // Original object isn't affected.
@@ -2264,9 +2257,7 @@ describe('BigQuery/Table', () => {
       const merged = [{name: 'stephen'}];
 
       table.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
-        assert.deepStrictEqual(reqOpts.qs, {
-          'formatOptions.useInt64Timestamp': true,
-        });
+        assert.deepStrictEqual(reqOpts.qs, {});
         callback(null, {});
       };
 
@@ -2288,9 +2279,7 @@ describe('BigQuery/Table', () => {
       const merged = [{name: 'stephen'}];
 
       table.request = (reqOpts: DecorateRequestOptions, callback: Function) => {
-        assert.deepStrictEqual(reqOpts.qs, {
-          'formatOptions.useInt64Timestamp': true,
-        });
+        assert.deepStrictEqual(reqOpts.qs, {});
         callback(null, {});
       };
 


### PR DESCRIPTION
Reverts googleapis/nodejs-bigquery#1332 due to breaking change being introduced.