### PR TITLE
fix: set projectId in jobs emitted by load streams

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1554,6 +1554,7 @@ class Table extends ServiceObject {
         (data: any) => {
           const job = this.bigQuery.job(data.jobReference.jobId, {
             location: data.jobReference.location,
+            projectId: data.jobReference.projectId,
           });
           job.metadata = data;
           dup.emit('job', job);

--- a/test/table.ts
+++ b/test/table.ts
@@ -1783,6 +1783,7 @@ describe('BigQuery/Table', () => {
           jobReference: {
             jobId: 'job-id',
             location: 'location',
+            projectId: 'project-id',
           },
           a: 'b',
           c: 'd',
@@ -1792,6 +1793,7 @@ describe('BigQuery/Table', () => {
           assert.strictEqual(id, metadata.jobReference!.jobId);
           assert.deepStrictEqual(options, {
             location: metadata.jobReference!.location,
+            projectId: metadata.jobReference!.projectId,
           });
           return fakeJob;
         };


### PR DESCRIPTION
This explicitly sets the project ID in jobs returned by loading operations that are stream-based (e.g. `Table.load(filePath)` or `Table.createWriteStream()`), which fixes support for project IDs specified at the dataset level.

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #1345 🦕
