### PR TITLE
fix: change startIndex option type from string to number

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5900,7 +5900,7 @@ declare namespace bigquery {
       /**
        * Zero-based index of the starting row.
        */
-      startIndex?: string;
+      startIndex?: number;
       /**
        * Optional: Specifies the maximum amount of time, in milliseconds, that the client is willing to wait for the query to complete. By default, this limit is 10 seconds (10,000 milliseconds). If the query is complete, the jobComplete field in the response is true. If the query has not yet completed, jobComplete is false. You can request a longer timeout period in the timeoutMs field. However, the call is not guaranteed to wait for the specified timeout; it typically returns after around 200 seconds (200,000 milliseconds), even if the query is not complete. If jobComplete is false, you can continue to wait for the query to complete by calling the getQueryResults method until the jobComplete field in the getQueryResults response is true.
        */
@@ -6052,7 +6052,7 @@ declare namespace bigquery {
       /**
        * Start row index of the table.
        */
-      startIndex?: string;
+      startIndex?: number;
     };
   }
 


### PR DESCRIPTION
startIndex should be an 0-indexed integer. But as it is was expecting a string which is incorrect and caused a lot of confusion, preventing compilation and requiring odd workarounds.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-node#7230 🙏
