### PR TITLE
fix: PreciseDate constructor when value is timestamp `1970-01-01 00:00:00 UTC`

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2433,7 +2433,10 @@ export class BigQueryTimestamp {
     } else if (value instanceof Date) {
       pd = new PreciseDate(value);
     } else if (typeof value === 'string') {
-      if (/^\d{4}-\d{1,2}-\d{1,2}/.test(value)) {
+      if (value === '0') {
+        pd = new PreciseDate(0);
+      }
+      else if (/^\d{4}-\d{1,2}-\d{1,2}/.test(value)) {
         pd = new PreciseDate(value);
       } else {
         const floatValue = Number.parseFloat(value);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1353 🦕
