### PR TITLE
fix: parsing zero value timestamp

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -665,7 +665,8 @@ export class BigQuery extends Service {
           break;
         }
         case 'TIMESTAMP': {
-          const pd = new PreciseDate(BigInt(value) * BigInt(1000));
+          const pd = new PreciseDate();
+          pd.setFullTime(PreciseDate.parseFull(BigInt(value) * BigInt(1000)));
           value = BigQuery.timestamp(pd);
           break;
         }

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -661,7 +661,7 @@ describe('BigQuery', () => {
         ],
       };
 
-      let mergedRows = BigQuery.mergeSchemaWithRows_(
+      const mergedRows = BigQuery.mergeSchemaWithRows_(
         SCHEMA_OBJECT,
         rows.raw,
         {}


### PR DESCRIPTION
`PreciseDate` class fails when instantiated with zero value ( number `0` or `BigInt(0)`). Using `PreciseDate.parseFull` + `preciseDateInstance.setFulltime` manually with `BigInt` skips the code paths that doesn't check for zero.

Reference:
* https://github.com/googleapis/nodejs-precise-date/blob/04b3784b0a9948687cbd98a2be376246589c372c/src/index.ts#L122
* https://github.com/googleapis/nodejs-precise-date/issues/250

Fixes #1353  🦕
Supersedes #1354 
