### PR TITLE
feat: use Storage Read API for faster data fetching

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ResourceStream} from '@google-cloud/paginator';
+import {Transform} from 'stream';
+import {BigQuery, QueryRowsResponse, RowMetadata} from '.';
+import bigquery from './types';
+
+// Minimal interface for a BigQuery Storage Read API client 
+// that can read data from tables.
+export interface StorageReadClient {
+  createTableReader(req: {
+    table: bigquery.ITableReference;
+  }): Promise<TableReader>;
+}
+
+// Interface for fetching data from a BigQuery table using 
+// the BigQuery Storage Read API.
+export interface TableReader {
+  getRows(): Promise<QueryRowsResponse>;
+  getRowsAsStream(): Promise<ResourceStream<RowMetadata>>;
+}
+
+export class MergeSchemaTransform extends Transform {
+  constructor(schema: bigquery.ITableSchema) {
+    super({
+      objectMode: true,
+      transform(row, _, callback) {
+        const rows = BigQuery.mergeSchemaWithRows_(schema, [row], {
+          wrapIntegers: false,
+          parseJSON: false,
+        });
+        if (rows.length == 0) {
+          callback(new Error('failed to convert row'), null);
+          return;
+        }
+        callback(null, rows[0]);
+      },
+    });
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/googleapis/nodejs-bigquery-storage/pull/431

Some early results:

1. ```SELECT repository_url as url, repository_owner as owner, repository_forks as forks FROM `bigquery-public-data.samples.github_timeline` where repository_url is not null LIMIT 300000```
* fetchGetQueryResultsI:  `31.135s` 🔴 
* fetchStorageAPI:  `20.033s` ⬆️  36% speedup

2. ```SELECT repository_url as url, repository_owner as owner, repository_forks as forks FROM `bigquery-public-data.samples.github_timeline` where repository_url is not null LIMIT 1000000```
* fetchGetQueryResultsI: `1:32.622` (m:ss.mmm) 🔴
* fetchStorageAPI:  `1:07.363` (m:ss.mmm) ⬆️  27% faster

3. ```SELECT name, number, state from `bigquery-public-data.usa_names.usa_1910_current ```
* fetchGetQueryResults:  `5:00.514` (m:ss.mmm) 🔴
* fetchStorageAPI: `3:20.987` (m:ss.mmm) ⬆️ 33% faster
