### PR TITLE
chore: add discovery revision to types.d.ts

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20240418
+ * Discovery Revision: 20240526
  */
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 /**
+ * Discovery Revision: 20240418
+ */
+
+/**
  * BigQuery API
  */
 declare namespace bigquery {


### PR DESCRIPTION
To keep track of which revision of the Discovery doc is being used to generated the `types.d.ts` file and avoid accepting changes that rollback to a previous revision. 
