### PR TITLE
fix: mergeSchemaWithRows can be called with empty schema if result set is empty

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -580,7 +580,7 @@ export class BigQuery extends Service {
    * @returns Fields using their matching names from the table's schema.
    */
   static mergeSchemaWithRows_(
-    schema: TableSchema | TableField,
+    schema: TableSchema | TableField | undefined,
     rows: TableRow[],
     options: {
       wrapIntegers: boolean | IntegerTypeCastOptions;
@@ -589,7 +589,7 @@ export class BigQuery extends Service {
     }
   ) {
     // deep copy schema fields to avoid mutation
-    let schemaFields: TableField[] = extend(true, [], schema.fields);
+    let schemaFields: TableField[] = extend(true, [], schema?.fields);
     let selectedFields: string[] = extend(true, [], options.selectedFields);
     if (options.selectedFields && options.selectedFields!.length > 0) {
       const selectedFieldsArray = options.selectedFields!.map(c => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20250216
+ * Discovery Revision: 20250313
  */
 
 /**
@@ -816,6 +816,10 @@ declare namespace bigquery {
      */
     nullMarker?: string;
     /**
+     * Optional. A list of strings represented as SQL NULL value in a CSV file. null_marker and null_markers can't be set at the same time. If null_marker is set, null_markers has to be not set. If null_markers is set, null_marker has to be not set. If both null_marker and null_markers are set at the same time, a user error would be thrown. Any strings listed in null_markers, including empty string would be interpreted as SQL NULL. This applies to all column types.
+     */
+    nullMarkers?: Array<string>;
+    /**
      * Optional. Indicates if the embedded ASCII control characters (the first 32 characters in the ASCII-table, from '\x00' to '\x1F') are preserved.
      */
     preserveAsciiControlCharacters?: boolean;
@@ -827,6 +831,10 @@ declare namespace bigquery {
      * Optional. The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: string;
+    /**
+     * Optional. Controls the strategy used to match loaded columns to the schema. If not set, a sensible default is chosen based on how the schema is provided. If autodetect is used, then columns are matched by name. Otherwise, columns are matched by position. This is done to keep the behavior backward-compatible. Acceptable values are: POSITION - matches by position. This assumes that the columns are ordered the same way as the schema. NAME - matches by name. This reads the header row as column names and reorders columns to match the field names in the schema.
+     */
+    sourceColumnMatch?: string;
   };
 
   /**
@@ -2316,6 +2324,10 @@ declare namespace bigquery {
      * [Pick one] Configures a query job.
      */
     query?: IJobConfigurationQuery;
+    /**
+     * Optional. The reservation that job would use. User can specify a reservation to execute the job. If reservation is not set, reservation is determined based on the rules defined by the reservation assignments. The expected format is `projects/{project}/locations/{location}/reservations/{reservation}`.
+     */
+    reservation?: string;
   };
 
   /**
@@ -2469,6 +2481,10 @@ declare namespace bigquery {
      */
     nullMarker?: string;
     /**
+     * Optional. A list of strings represented as SQL NULL value in a CSV file. null_marker and null_markers can't be set at the same time. If null_marker is set, null_markers has to be not set. If null_markers is set, null_marker has to be not set. If both null_marker and null_markers are set at the same time, a user error would be thrown. Any strings listed in null_markers, including empty string would be interpreted as SQL NULL. This applies to all column types.
+     */
+    nullMarkers?: Array<string>;
+    /**
      * Optional. Additional properties to set if sourceFormat is set to PARQUET.
      */
     parquetOptions?: IParquetOptions;
@@ -2512,6 +2528,10 @@ declare namespace bigquery {
      * Optional. The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.
      */
     skipLeadingRows?: number;
+    /**
+     * Optional. Controls the strategy used to match loaded columns to the schema. If not set, a sensible default is chosen based on how the schema is provided. If autodetect is used, then columns are matched by name. Otherwise, columns are matched by position. This is done to keep the behavior backward-compatible.
+     */
+    sourceColumnMatch?: 'SOURCE_COLUMN_MATCH_UNSPECIFIED' | 'POSITION' | 'NAME';
     /**
      * Optional. The format of the data files. For CSV files, specify "CSV". For datastore backups, specify "DATASTORE_BACKUP". For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro, specify "AVRO". For parquet, specify "PARQUET". For orc, specify "ORC". The default value is CSV.
      */
@@ -3996,6 +4016,10 @@ declare namespace bigquery {
      * Optional. A unique user provided identifier to ensure idempotent behavior for queries. Note that this is different from the job_id. It has the following properties: 1. It is case-sensitive, limited to up to 36 ASCII characters. A UUID is recommended. 2. Read only queries can ignore this token since they are nullipotent by definition. 3. For the purposes of idempotency ensured by the request_id, a request is considered duplicate of another only if they have the same request_id and are actually duplicates. When determining whether a request is a duplicate of another request, all parameters in the request that may affect the result are considered. For example, query, connection_properties, query_parameters, use_legacy_sql are parameters that affect the result and are considered when determining whether a request is a duplicate, but properties like timeout_ms don't affect the result and are thus not considered. Dry run query requests are never considered duplicate of another request. 4. When a duplicate mutating query request is detected, it returns: a. the results of the mutation if it completes successfully within the timeout. b. the running operation if it is still in progress at the end of the timeout. 5. Its lifetime is limited to 15 minutes. In other words, if two requests are sent with the same request_id, but more than 15 minutes apart, idempotency is not guaranteed.
      */
     requestId?: string;
+    /**
+     * Optional. The reservation that jobs.query request would use. User can specify a reservation to execute the job.query. The expected format is `projects/{project}/locations/{location}/reservations/{reservation}`.
+     */
+    reservation?: string;
     /**
      * Optional. Optional: Specifies the maximum amount of time, in milliseconds, that the client is willing to wait for the query to complete. By default, this limit is 10 seconds (10,000 milliseconds). If the query is complete, the jobComplete field in the response is true. If the query has not yet completed, jobComplete is false. You can request a longer timeout period in the timeoutMs field. However, the call is not guaranteed to wait for the specified timeout; it typically returns after around 200 seconds (200,000 milliseconds), even if the query is not complete. If jobComplete is false, you can continue to wait for the query to complete by calling the getQueryResults method until the jobComplete field in the getQueryResults response is true.
      */

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -902,7 +902,7 @@ describe('BigQuery', () => {
       await dataset.createTable(emptyTableId, {
         schema: [{name: 'id', type: 'STRING'}],
       });
-      const emptyTable = await dataset.table(emptyTableId);
+      const emptyTable = dataset.table(emptyTableId);
       const [rows] = await emptyTable.getRows();
       assert(Array.isArray(rows));
       assert.equal(rows.length, 0);

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -905,7 +905,7 @@ describe('BigQuery', () => {
       const emptyTable = await dataset.table(emptyTableId);
       const [rows] = await emptyTable.getRows();
       assert(Array.isArray(rows));
-      assert.equal(rows.length, 0);      
+      assert.equal(rows.length, 0);
     });
 
     it('should get the rows in a table via stream', done => {

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -896,6 +896,18 @@ describe('BigQuery', () => {
       });
     });
 
+    // Empty results sets will not fetch table schema
+    it('should get the rows from an empty table', async () => {
+      const emptyTableId = generateName('empty-table');
+      await dataset.createTable(emptyTableId, {
+        schema: [{name: 'id', type: 'STRING'}],
+      });
+      const emptyTable = await dataset.table(emptyTableId);
+      const [rows] = await emptyTable.getRows();
+      assert(Array.isArray(rows));
+      assert.equal(rows.length, 0);      
+    });
+
     it('should get the rows in a table via stream', done => {
       table
         .createReadStream()


### PR DESCRIPTION
Fixes #1452 🦕
