### PR TITLE
feat: support per-job reservation assignment

### DIFF
--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -76,6 +76,7 @@ export type JobRequest<J> = J & {
   jobPrefix?: string;
   location?: string;
   projectId?: string;
+  reservation?: string;
 };
 
 export type PagedRequest<P> = P & {
@@ -114,6 +115,7 @@ export type Query = JobRequest<bigquery.IJobConfigurationQuery> & {
   job?: Job;
   maxResults?: number;
   jobTimeoutMs?: number;
+  reservation?: string;
   pageToken?: string;
   wrapIntegers?: boolean | IntegerTypeCastOptions;
   parseJSON?: boolean;
@@ -1731,9 +1733,14 @@ export class BigQuery extends Service {
       location: this.location,
     };
 
-    if (options.location) {
-      reqOpts.jobReference.location = options.location;
+    if (reqOpts.location) {
+      reqOpts.jobReference.location = reqOpts.location;
       delete reqOpts.location;
+    }
+
+    if (reqOpts.configuration && reqOpts.reservation) {
+      reqOpts.configuration.reservation = reqOpts.reservation;
+      delete reqOpts.reservation;
     }
 
     const job = this.job(jobId!, {
@@ -2327,6 +2334,7 @@ export class BigQuery extends Service {
       useLegacySql: false,
       requestId: randomUUID(),
       jobCreationMode: 'JOB_CREATION_OPTIONAL',
+      reservation: queryObj.reservation,
     };
     if (!this._enableQueryPreview) {
       delete req.jobCreationMode;

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -2340,6 +2340,12 @@ export class BigQuery extends Service {
       requestId: randomUUID(),
       jobCreationMode: 'JOB_CREATION_OPTIONAL',
       reservation: queryObj.reservation,
+      continuous: queryObj.continuous,
+      destinationEncryptionConfiguration:
+        queryObj.destinationEncryptionConfiguration,
+      writeIncrementalResults: queryObj.writeIncrementalResults,
+      connectionProperties: queryObj.connectionProperties,
+      preserveNulls: queryObj.preserveNulls,
     };
     if (!this._enableQueryPreview) {
       delete req.jobCreationMode;

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -1564,6 +1564,11 @@ export class BigQuery extends Service {
       delete query.jobId;
     }
 
+    if (query.reservation) {
+      reqOpts.configuration.reservation = query.reservation;
+      delete query.reservation;
+    }
+
     this.createJob(reqOpts, callback!);
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -26,7 +26,7 @@ import {
   RequestCallback,
   JobRequest,
 } from '.';
-import {JobMetadata} from './job';
+import {JobMetadata, JobOptions} from './job';
 import bigquery from './types';
 
 // This is supposed to be a @google-cloud/storage `File` type. The storage npm
@@ -424,8 +424,7 @@ class Model extends ServiceObject {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const body: any = {
+    const body: JobOptions = {
       configuration: {
         extract: extend(true, options, {
           sourceModel: {
@@ -445,6 +444,11 @@ class Model extends ServiceObject {
     if (options.jobId) {
       body.jobId = options.jobId;
       delete options.jobId;
+    }
+
+    if (body.configuration && options.reservation) {
+      body.configuration.reservation = options.reservation;
+      delete options.reservation;
     }
 
     this.bigQuery.createJob(body, callback!);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20250313
+ * Discovery Revision: 20250511
  */
 
 /**
@@ -417,7 +417,7 @@ declare namespace bigquery {
   };
 
   /**
-   * Configuration for BigLake managed tables.
+   * Configuration for BigQuery tables for Apache Iceberg (formerly BigLake managed tables.)
    */
   type IBigLakeConfiguration = {
     /**
@@ -1093,6 +1093,10 @@ declare namespace bigquery {
        * The dataset reference. Use this property to access specific parts of the dataset's ID, such as project ID or dataset ID.
        */
       datasetReference?: IDatasetReference;
+      /**
+       * Output only. Reference to a read-only external dataset defined in data catalogs outside of BigQuery. Filled out when the dataset type is EXTERNAL.
+       */
+      externalDatasetReference?: IExternalDatasetReference;
       /**
        * An alternate name for the dataset. The friendly name is purely decorative in nature.
        */
@@ -2549,7 +2553,7 @@ declare namespace bigquery {
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * Optional. [Experimental] Default time zone that will apply when parsing timestamp values that have no specific time zone.
+     * Optional. Default time zone that will apply when parsing timestamp values that have no specific time zone.
      */
     timeZone?: string;
     /**
@@ -2561,7 +2565,7 @@ declare namespace bigquery {
      */
     useAvroLogicalTypes?: boolean;
     /**
-     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints and uses the schema from the load job. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints and uses the schema from the load job. * WRITE_TRUNCATE_DATA: If the table already exists, BigQuery overwrites the data, but keeps the constraints and schema of the existing table. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
   };
@@ -2675,7 +2679,7 @@ declare namespace bigquery {
      */
     userDefinedFunctionResources?: Array<IUserDefinedFunctionResource>;
     /**
-     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints, and uses the schema from the query result. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
+     * Optional. Specifies the action that occurs if the destination table already exists. The following values are supported: * WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the data, removes the constraints, and uses the schema from the query result. * WRITE_TRUNCATE_DATA: If the table already exists, BigQuery overwrites the data, but keeps the constraints and schema of the existing table. * WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. * WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.
      */
     writeDisposition?: string;
     /**
@@ -3055,7 +3059,7 @@ declare namespace bigquery {
      */
     referencedRoutines?: Array<IRoutineReference>;
     /**
-     * Output only. Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
+     * Output only. Referenced tables for the job.
      */
     referencedTables?: Array<ITableReference>;
     /**
@@ -4150,6 +4154,10 @@ declare namespace bigquery {
      */
     pendingUnits?: string;
     /**
+     * Total shuffle usage ratio in shuffle RAM per reservation of this query. This will be provided for reservation customers only.
+     */
+    shuffleRamUsageRatio?: number;
+    /**
      * Cumulative slot-ms consumed by the query.
      */
     totalSlotMs?: string;
@@ -4954,7 +4962,7 @@ declare namespace bigquery {
 
   type ITable = {
     /**
-     * Optional. Specifies the configuration of a BigLake managed table.
+     * Optional. Specifies the configuration of a BigQuery table for Apache Iceberg.
      */
     biglakeConfiguration?: IBigLakeConfiguration;
     /**
@@ -6390,6 +6398,14 @@ declare namespace bigquery {
        * Optional. The version of the provided access policy schema. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. This version refers to the schema version of the access policy and not the version of access policy. This field's value can be equal or more than the access policy schema provided in the request. For example, * Operations updating conditional access policy binding in datasets must specify version 3. Some of the operations are : - Adding a new access policy entry with condition. - Removing an access policy entry with condition. - Updating an access policy entry with condition. * But dataset with no conditional role bindings in access policy may specify any valid value or leave the field unset. If unset or if 0 or 1 value is used for dataset with conditional bindings, request will be rejected. This field will be mapped to IAM Policy version (https://cloud.google.com/iam/docs/policies#versions) and will be used to set policy in IAM.
        */
       accessPolicyVersion?: number;
+      /**
+       * Optional. Specifies the fields of dataset that update/patch operation is targeting By default, both metadata and ACL fields are updated.
+       */
+      updateMode?:
+        | 'UPDATE_MODE_UNSPECIFIED'
+        | 'UPDATE_METADATA'
+        | 'UPDATE_ACL'
+        | 'UPDATE_FULL';
     };
 
     /**
@@ -6400,6 +6416,14 @@ declare namespace bigquery {
        * Optional. The version of the provided access policy schema. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. This version refers to the schema version of the access policy and not the version of access policy. This field's value can be equal or more than the access policy schema provided in the request. For example, * Operations updating conditional access policy binding in datasets must specify version 3. Some of the operations are : - Adding a new access policy entry with condition. - Removing an access policy entry with condition. - Updating an access policy entry with condition. * But dataset with no conditional role bindings in access policy may specify any valid value or leave the field unset. If unset or if 0 or 1 value is used for dataset with conditional bindings, request will be rejected. This field will be mapped to IAM Policy version (https://cloud.google.com/iam/docs/policies#versions) and will be used to set policy in IAM.
        */
       accessPolicyVersion?: number;
+      /**
+       * Optional. Specifies the fields of dataset that update/patch operation is targeting By default, both metadata and ACL fields are updated.
+       */
+      updateMode?:
+        | 'UPDATE_MODE_UNSPECIFIED'
+        | 'UPDATE_METADATA'
+        | 'UPDATE_ACL'
+        | 'UPDATE_FULL';
     };
   }
 

--- a/test/bigquery.ts
+++ b/test/bigquery.ts
@@ -2644,6 +2644,20 @@ describe('BigQuery', () => {
       bq.createQueryJob(options, assert.ifError);
     });
 
+    it('should accept a reservation id', done => {
+      const options = {
+        query: QUERY_STRING,
+        reservation: 'reservation/1',
+      };
+
+      bq.createJob = (reqOpts: JobOptions) => {
+        assert.strictEqual(reqOpts.configuration?.reservation, 'reservation/1');
+        done();
+      };
+
+      bq.createQueryJob(options, assert.ifError);
+    });
+
     it('should accept a location', done => {
       const options = {
         query: QUERY_STRING,
@@ -3299,6 +3313,29 @@ describe('BigQuery', () => {
       };
 
       bq.query(QUERY_STRING, fakeOptions, assert.ifError);
+    });
+
+    it('should accept a reservation id', done => {
+      const query: Query = {
+        query: QUERY_STRING,
+        reservation: 'reservation/1',
+      };
+      const fakeJob = {
+        getQueryResults: (options: {}) => {
+          done();
+        },
+      };
+
+      bq.createJob = (reqOpts: JobOptions, callback: Function) => {
+        assert(reqOpts.configuration?.reservation, 'reservation/1');
+        callback(null, fakeJob, FAKE_RESPONSE);
+      };
+
+      bq.buildQueryRequest_ = (query: {}, opts: {}) => {
+        return undefined;
+      };
+
+      bq.query(query, assert.ifError);
     });
   });
 

--- a/test/model.ts
+++ b/test/model.ts
@@ -257,6 +257,25 @@ describe('BigQuery/Model', () => {
         model.createExtractJob(URI, options, done);
       });
 
+      it('should accept a reservation id', done => {
+        const options = {
+          reservation: 'reservation/1',
+        };
+
+        model.bigQuery.createJob = (
+          reqOpts: JobOptions,
+          callback: Function,
+        ) => {
+          assert.strictEqual(
+            reqOpts.configuration?.reservation,
+            'reservation/1',
+          );
+          callback(); // the done fn
+        };
+
+        model.createExtractJob(URI, options, done);
+      });
+
       it('should accept a job id', done => {
         const jobId = 'job-id';
         const options = {jobId};

--- a/test/table.ts
+++ b/test/table.ts
@@ -767,6 +767,19 @@ describe('BigQuery/Table', () => {
       table.createCopyJob(DEST_TABLE, options, done);
     });
 
+    it('should accept a reservation id', done => {
+      const options = {
+        reservation: 'reservation/1',
+      };
+
+      table.bigQuery.createJob = (reqOpts: JobOptions, callback: Function) => {
+        assert.strictEqual(reqOpts.configuration?.reservation, 'reservation/1');
+        callback(); // the done fn
+      };
+
+      table.createCopyJob(DEST_TABLE, options, done);
+    });
+
     it('should use the default location', done => {
       table.bigQuery.createJob = (reqOpts: JobOptions, callback: Function) => {
         assert.strictEqual(reqOpts.location, LOCATION);
@@ -905,6 +918,19 @@ describe('BigQuery/Table', () => {
           (reqOpts.configuration!.copy as any).jobPrefix,
           undefined,
         );
+        callback(); // the done fn
+      };
+
+      table.createCopyFromJob(SOURCE_TABLE, options, done);
+    });
+
+    it('should accept a reservation id', done => {
+      const options = {
+        reservation: 'reservation/1',
+      };
+
+      table.bigQuery.createJob = (reqOpts: JobOptions, callback: Function) => {
+        assert.strictEqual(reqOpts.configuration?.reservation, 'reservation/1');
         callback(); // the done fn
       };
 
@@ -1195,6 +1221,19 @@ describe('BigQuery/Table', () => {
       table.createExtractJob(FILE, options, done);
     });
 
+    it('should accept a reservation id', done => {
+      const options = {
+        reservation: 'reservation/1',
+      };
+
+      table.bigQuery.createJob = (reqOpts: JobOptions, callback: Function) => {
+        assert.strictEqual(reqOpts.configuration?.reservation, 'reservation/1');
+        callback(); // the done fn
+      };
+
+      table.createExtractJob(FILE, options, done);
+    });
+
     it('should use the default location', done => {
       const table = new Table(DATASET, TABLE_ID, {location: LOCATION});
 
@@ -1420,6 +1459,19 @@ describe('BigQuery/Table', () => {
             load: {
               jobPrefix: undefined,
             },
+          },
+        }),
+      );
+    });
+
+    it('should set the job reservation', async () => {
+      const reservation = 'reservation/1';
+      await table.createLoadJob(FILE, {reservation});
+      assert(bqCreateJobStub.calledOnce);
+      assert(
+        bqCreateJobStub.calledWithMatch({
+          configuration: {
+            reservation,
           },
         }),
       );


### PR DESCRIPTION
This PR adds support for explicitly selecting a reservation to use when executing a job. It also includes support for optimized query execution (running via jobs.query vs jobs.insert).

Fixes internal b/414633338
