### PR TITLE
feat: allow to skip wrapping data into custom types

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -50,6 +50,7 @@ export type CancelResponse = [bigquery.IJobCancelResponse];
 export type QueryResultsOptions = {
   job?: Job;
   wrapIntegers?: boolean | IntegerTypeCastOptions;
+  skipWrapCustomTypes?: boolean;
   parseJSON?: boolean;
 } & PagedRequest<bigquery.jobs.IGetQueryResultsParams> & {
     /**
@@ -556,6 +557,10 @@ class Job extends Operation {
 
     const wrapIntegers = qs.wrapIntegers ? qs.wrapIntegers : false;
     delete qs.wrapIntegers;
+    const skipWrapCustomTypes = qs.skipWrapCustomTypes
+      ? qs.skipWrapCustomTypes
+      : false;
+    delete qs.skipWrapCustomTypes;
     const parseJSON = qs.parseJSON ? qs.parseJSON : false;
     delete qs.parseJSON;
 
@@ -597,6 +602,7 @@ class Job extends Operation {
         if (resp.schema && resp.rows) {
           rows = BigQuery.mergeSchemaWithRows_(resp.schema, resp.rows, {
             wrapIntegers,
+            skipWrapCustomTypes,
             parseJSON,
           });
         }

--- a/src/table.ts
+++ b/src/table.ts
@@ -113,6 +113,7 @@ export type TableRowValue = string | TableRow;
 
 export type GetRowsOptions = PagedRequest<bigquery.tabledata.IListParams> & {
   wrapIntegers?: boolean | IntegerTypeCastOptions;
+  skipWrapCustomTypes?: boolean;
   parseJSON?: boolean;
 };
 
@@ -1851,6 +1852,10 @@ class Table extends ServiceObject {
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
     const wrapIntegers = options.wrapIntegers ? options.wrapIntegers : false;
     delete options.wrapIntegers;
+    const skipWrapCustomTypes = options.skipWrapCustomTypes
+      ? options.skipWrapCustomTypes
+      : false;
+    delete options.skipWrapCustomTypes;
     const parseJSON = options.parseJSON ? options.parseJSON : false;
     delete options.parseJSON;
     const selectedFields = options.selectedFields
@@ -1868,6 +1873,7 @@ class Table extends ServiceObject {
       }
       rows = BigQuery.mergeSchemaWithRows_(this.metadata.schema, rows || [], {
         wrapIntegers,
+        skipWrapCustomTypes,
         selectedFields,
         parseJSON,
       });

--- a/test/job.ts
+++ b/test/job.ts
@@ -327,10 +327,11 @@ describe('BigQuery/Job', () => {
 
       sandbox
         .stub(BigQuery, 'mergeSchemaWithRows_')
-        .callsFake((schema, rows, {wrapIntegers}) => {
+        .callsFake((schema, rows, {wrapIntegers, skipWrapCustomTypes}) => {
           assert.strictEqual(schema, response.schema);
           assert.strictEqual(rows, response.rows);
           assert.strictEqual(wrapIntegers, false);
+          assert.strictEqual(skipWrapCustomTypes, false);
           return mergedRows;
         });
 
@@ -366,6 +367,37 @@ describe('BigQuery/Job', () => {
           assert.strictEqual(schema, response.schema);
           assert.strictEqual(rows, response.rows);
           assert.strictEqual(wrapIntegers, true);
+          return mergedRows;
+        });
+
+      job.getQueryResults(options, assert.ifError);
+    });
+
+    it('it should skip wrapping with custom types', done => {
+      const response = {
+        schema: {},
+        rows: [],
+      };
+
+      const mergedRows: Array<{}> = [];
+
+      const options = {skipWrapCustomTypes: true};
+      const expectedOptions = Object.assign({
+        location: undefined,
+        'formatOptions.useInt64Timestamp': true,
+      });
+
+      BIGQUERY.request = (reqOpts: DecorateRequestOptions) => {
+        assert.deepStrictEqual(reqOpts.qs, expectedOptions);
+        done();
+      };
+
+      sandbox
+        .stub(BigQuery, 'mergeSchemaWithRows_')
+        .callsFake((schema, rows, {skipWrapCustomTypes}) => {
+          assert.strictEqual(schema, response.schema);
+          assert.strictEqual(rows, response.rows);
+          assert.strictEqual(skipWrapCustomTypes, true);
           return mergedRows;
         });
 


### PR DESCRIPTION
Draft PR on an idea to avoid the issue reported on googleapis/google-cloud-node#7229, where for some customers, having the custom types actually makes it harder to manipulate data. Naming is hard, not sure what is the best option name here.

Fixes googleapis/google-cloud-node#7229 
Fixes googleapis/google-cloud-node#7227 
