### PR TITLE
fix: remove `is` package as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "big.js": "^6.2.2",
     "duplexify": "^4.1.3",
     "extend": "^3.0.2",
-    "is": "^3.3.0",
     "stream-events": "^1.0.5"
   },
   "overrides": {

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -25,7 +25,15 @@ import * as common from '@google-cloud/common';
 import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import {PreciseDate} from '@google-cloud/precise-date';
-import {toArray, isArray, isObject, isDate, isBoolean, isNumber} from './util';
+import {
+  toArray,
+  isArray,
+  isString,
+  isObject,
+  isDate,
+  isBoolean,
+  isNumber,
+} from './util';
 import * as Big from 'big.js';
 import * as extend from 'extend';
 import {randomUUID} from 'crypto';
@@ -1171,7 +1179,7 @@ export class BigQuery extends Service {
           };
         }),
       };
-    } else if (is.string(value)) {
+    } else if (isString(value)) {
       typeName = 'STRING';
     }
 
@@ -2465,7 +2473,7 @@ function convertSchemaFieldValue(
     parseJSON?: boolean;
   },
 ) {
-  if (is.null(value)) {
+  if (value === null) {
     return value;
   }
 
@@ -2782,7 +2790,7 @@ export class BigQueryTime {
       const h = value.hours;
       const m = value.minutes || 0;
       const s = value.seconds || 0;
-      const f = is.defined(value.fractional) ? '.' + value.fractional : '';
+      const f = value.fractional !== undefined ? '.' + value.fractional : '';
       value = `${h}:${m}:${s}${f}`;
     }
     this.value = value as string;

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -25,10 +25,9 @@ import * as common from '@google-cloud/common';
 import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import {PreciseDate} from '@google-cloud/precise-date';
-import {toArray} from './util';
+import {toArray, isArray, isObject, isDate, isBoolean, isNumber} from './util';
 import * as Big from 'big.js';
 import * as extend from 'extend';
-import * as is from 'is';
 import {randomUUID} from 'crypto';
 
 import {Dataset, DatasetOptions} from './dataset';
@@ -1071,13 +1070,13 @@ export class BigQuery extends Service {
       'RANGE',
     ];
 
-    if (is.array(providedType)) {
+    if (isArray(providedType)) {
       providedType = providedType as Array<ProvidedTypeStruct | string | []>;
       return {
         type: 'ARRAY',
         arrayType: BigQuery.getTypeDescriptorFromProvidedType_(providedType[0]),
       };
-    } else if (is.object(providedType)) {
+    } else if (isObject(providedType)) {
       return {
         type: 'STRUCT',
         structTypes: Object.keys(providedType).map(prop => {
@@ -1147,7 +1146,7 @@ export class BigQuery extends Service {
           type: value.elementType,
         },
       };
-    } else if (Array.isArray(value)) {
+    } else if (isArray(value)) {
       if (value.length === 0) {
         throw new Error(
           "Parameter types must be provided for empty arrays via the 'types' field in query options.",
@@ -1157,11 +1156,11 @@ export class BigQuery extends Service {
         type: 'ARRAY',
         arrayType: BigQuery.getTypeDescriptorFromValue_(value[0]),
       };
-    } else if (is.boolean(value)) {
+    } else if (isBoolean(value)) {
       typeName = 'BOOL';
-    } else if (is.number(value)) {
+    } else if (isNumber(value)) {
       typeName = (value as number) % 1 === 0 ? 'INT64' : 'FLOAT64';
-    } else if (is.object(value)) {
+    } else if (isObject(value)) {
       return {
         type: 'STRUCT',
         structTypes: Object.keys(value as object).map(prop => {
@@ -1207,7 +1206,7 @@ export class BigQuery extends Service {
     value: any,
     providedType?: string | ProvidedTypeStruct | ProvidedTypeArray,
   ) {
-    if (is.date(value)) {
+    if (isDate(value)) {
       value = BigQuery.timestamp(value as Date);
     }
     let parameterType: bigquery.IQueryParameterType;
@@ -1223,8 +1222,8 @@ export class BigQuery extends Service {
       queryParameter.parameterValue!.arrayValues = (value as Array<{}>).map(
         itemValue => {
           const value = BigQuery._getValue(itemValue, parameterType.arrayType!);
-          if (is.object(value) || is.array(value)) {
-            if (is.array(providedType)) {
+          if (isObject(value) || isArray(value)) {
+            if (isArray(providedType)) {
               providedType = providedType as [];
               return BigQuery.valueToQueryParameter_(value, providedType[0])
                 .parameterValue!;
@@ -1271,7 +1270,7 @@ export class BigQuery extends Service {
           value: rangeValue.value.end,
         },
       };
-    } else if (typeName === 'JSON' && is.object(value)) {
+    } else if (typeName === 'JSON' && isObject(value)) {
       queryParameter.parameterValue!.value = JSON.stringify(value);
     } else {
       queryParameter.parameterValue!.value = BigQuery._getValue(
@@ -1586,7 +1585,7 @@ export class BigQuery extends Service {
         params: undefined,
       };
     }
-    const parameterMode = is.array(params) ? 'positional' : 'named';
+    const parameterMode = isArray(params) ? 'positional' : 'named';
     const queryParameters: bigquery.IQueryParameter[] = [];
     if (parameterMode === 'named') {
       const namedParams = params as {[param: string]: any};
@@ -1595,7 +1594,7 @@ export class BigQuery extends Service {
         let queryParameter;
 
         if (types) {
-          if (!is.object(types)) {
+          if (!isObject(types)) {
             throw new Error(
               'Provided types must match the value type passed to `params`',
             );
@@ -1620,7 +1619,7 @@ export class BigQuery extends Service {
       }
     } else {
       if (types) {
-        if (!is.array(types)) {
+        if (!isArray(types)) {
           throw new Error(
             'Provided types must match the value type passed to `params`',
           );

--- a/src/table.ts
+++ b/src/table.ts
@@ -25,12 +25,11 @@ import {
 } from '@google-cloud/common';
 import {paginator, ResourceStream} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
-import {toArray} from './util';
+import {isArray, isString, isDate, toArray} from './util';
 import * as Big from 'big.js';
 import * as extend from 'extend';
 import {once} from 'events';
 import * as fs from 'fs';
-import * as is from 'is';
 import * as path from 'path';
 import * as streamEvents from 'stream-events';
 import {randomUUID} from 'crypto';
@@ -592,11 +591,11 @@ class Table extends ServiceObject {
       return (value as {value: {}}).value;
     }
 
-    if (is.date(value)) {
+    if (isDate(value)) {
       return (value as Date).toJSON();
     }
 
-    if (is.array(value)) {
+    if (isArray(value)) {
       return (value as []).map(Table.encodeValue_);
     }
 
@@ -625,11 +624,11 @@ class Table extends ServiceObject {
       delete (body as TableMetadata).name;
     }
 
-    if (is.string(options.schema)) {
+    if (isString(options.schema)) {
       body.schema = Table.createSchemaFromString_(options.schema as string);
     }
 
-    if (is.array(options.schema)) {
+    if (isArray(options.schema)) {
       body.schema = {
         fields: options.schema as [],
       };

--- a/src/table.ts
+++ b/src/table.ts
@@ -643,14 +643,14 @@ class Table extends ServiceObject {
       });
     }
 
-    if (is.string(options.partitioning)) {
+    if (isString(options.partitioning)) {
       body.timePartitioning = {
         type: options.partitioning!.toUpperCase(),
       };
       delete (body as TableMetadata).partitioning;
     }
 
-    if (is.string(options.view)) {
+    if (isString(options.view)) {
       body.view = {
         query: options.view! as string,
         useLegacySql: false,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20250706
+ * Discovery Revision: 20250615
  */
 
 /**
@@ -1741,10 +1741,6 @@ declare namespace bigquery {
    */
   type IExternalServiceCost = {
     /**
-     * The billing method used for the external job. This field is only used when billed on the services sku, set to "SERVICES_SKU". Otherwise, it is unspecified for backward compatibility.
-     */
-    billingMethod?: string;
-    /**
      * External service cost in terms of bigquery bytes billed.
      */
     bytesBilled?: string;
@@ -3142,10 +3138,6 @@ declare namespace bigquery {
      * Output only. Total number of partitions processed from all partitioned tables referenced in the job.
      */
     totalPartitionsProcessed?: string;
-    /**
-     * Output only. Total slot-milliseconds for the job that run on external services and billed on the service SKU. This field is only populated for jobs that have external service costs, and is the total of the usage for costs whose billing method is "SERVICES_SKU".
-     */
-    totalServicesSkuSlotMs?: string;
     /**
      * Output only. Slot-milliseconds for the job.
      */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20250615
+ * Discovery Revision: 20250706
  */
 
 /**
@@ -1741,6 +1741,10 @@ declare namespace bigquery {
    */
   type IExternalServiceCost = {
     /**
+     * The billing method used for the external job. This field is only used when billed on the services sku, set to "SERVICES_SKU". Otherwise, it is unspecified for backward compatibility.
+     */
+    billingMethod?: string;
+    /**
      * External service cost in terms of bigquery bytes billed.
      */
     bytesBilled?: string;
@@ -3138,6 +3142,10 @@ declare namespace bigquery {
      * Output only. Total number of partitions processed from all partitioned tables referenced in the job.
      */
     totalPartitionsProcessed?: string;
+    /**
+     * Output only. Total slot-milliseconds for the job that run on external services and billed on the service SKU. This field is only populated for jobs that have external service costs, and is the total of the usage for costs whose billing method is "SERVICES_SKU".
+     */
+    totalServicesSkuSlotMs?: string;
     /**
      * Output only. Slot-milliseconds for the job.
      */

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,3 +35,51 @@ export function toArray(value: any) {
 
   return [value];
 }
+
+/**
+ * Check if value is an object.
+ * @internal
+ */
+export function isObject(value: any) {
+  return value && [undefined, Object].includes(value.constructor);
+}
+
+/**
+ * Check if value is an object.
+ * @internal
+ */
+export function isString(value: any) {
+  return Object.prototype.toString.call(value) === '[object String]';
+}
+
+/**
+ * Check if value is an array.
+ * @internal
+ */
+export function isArray(value: any) {
+  return Array.isArray(value);
+}
+
+/**
+ * Check if value is an instance of Date.
+ * @internal
+ */
+export function isDate(value: any) {
+  return value instanceof Date;
+}
+
+/**
+ * Check if value is a boolean.
+ * @internal
+ */
+export function isBoolean(value: any) {
+  return Object.prototype.toString.call(value) === '[object Boolean]';
+}
+
+/**
+ * Check if value is a number.
+ * @internal
+ */
+export function isNumber(value: any) {
+  return Object.prototype.toString.call(value) === '[object Number]';
+}


### PR DESCRIPTION
Version 3.3.1 of the `is` package was compromised and published, containing some malware. The version was nucked from npm and an new v3.3.2 was published. Still we decided to remove it from the dependency chain, as it's easily replaceable. 

Fixes #1498 
