### PR TITLE
feat: Support createTable with TIMESTAMP fields that have Picosecond precision

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,16 +60,15 @@ jobs:
           node-version: 18
       - run: npm install
       - run: npm run lint
-  # TODO(https://github.com/googleapis/nodejs-bigquery/issues/1582) 
-  # docs:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 18
-  #     - run: npm install
-  #     - run: npm run docs
-  #     - uses: JustinBeckwith/linkinator-action@v1
-  #       with:
-  #         paths: docs/
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run docs
+      - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: docs/

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20251130
+ * Discovery Revision: 20260118
  */
 
 /**
@@ -2158,15 +2158,18 @@ declare namespace bigquery {
    */
   type IIncrementalResultStats = {
     /**
-     * Reason why incremental query results are/were not written by the query.
+     * Output only. Reason why incremental query results are/were not written by the query.
      */
-    disabledReason?: 'DISABLED_REASON_UNSPECIFIED' | 'OTHER';
+    disabledReason?:
+      | 'DISABLED_REASON_UNSPECIFIED'
+      | 'OTHER'
+      | 'UNSUPPORTED_OPERATOR';
     /**
-     * The time at which the result table's contents were modified. May be absent if no results have been written or the query has completed.
+     * Output only. The time at which the result table's contents were modified. May be absent if no results have been written or the query has completed.
      */
     resultSetLastModifyTime?: string;
     /**
-     * The time at which the result table's contents were completely replaced. May be absent if no results have been written or the query has completed.
+     * Output only. The time at which the result table's contents were completely replaced. May be absent if no results have been written or the query has completed.
      */
     resultSetLastReplaceTime?: string;
   };
@@ -2784,7 +2787,7 @@ declare namespace bigquery {
      */
     timePartitioning?: ITimePartitioning;
     /**
-     * Optional. Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
+     * Optional. Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query uses BigQuery's [GoogleSQL](https://docs.cloud.google.com/bigquery/docs/introduction-sql). When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
      */
     useLegacySql?: boolean;
     /**
@@ -4198,7 +4201,7 @@ declare namespace bigquery {
      */
     timeoutMs?: number;
     /**
-     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
+     * Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query uses BigQuery's [GoogleSQL](https://docs.cloud.google.com/bigquery/docs/introduction-sql). When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.
      */
     useLegacySql?: boolean;
     /**
@@ -6553,7 +6556,7 @@ declare namespace bigquery {
      */
     useExplicitColumnNames?: boolean;
     /**
-     * Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's GoogleSQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value. A wrapper is used here because the default value is True.
+     * Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view uses BigQuery's [GoogleSQL](https://docs.cloud.google.com/bigquery/docs/introduction-sql). Queries and views that reference this view must use the same flag value. A wrapper is used here because the default value is True.
      */
     useLegacySql?: boolean;
     /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * Discovery Revision: 20250912
+ * Discovery Revision: 20251130
  */
 
 /**
@@ -458,7 +458,7 @@ declare namespace bigquery {
    */
   type IBigtableColumn = {
     /**
-     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
+     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. PROTO_BINARY - indicates values are encoded using serialized proto messages. This can only be used in combination with JSON type. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
      */
     encoding?: string;
     /**
@@ -469,6 +469,10 @@ declare namespace bigquery {
      * Optional. If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.
      */
     onlyReadLatest?: boolean;
+    /**
+     * Optional. Protobuf-specific configurations, only takes effect when the encoding is PROTO_BINARY.
+     */
+    protoConfig?: IBigtableProtoConfig;
     /**
      * [Required] Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as `.` field. If the qualifier is valid UTF-8 string, it can be specified in the qualifier_string field. Otherwise, a base-64 encoded value must be set to qualifier_encoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match a-zA-Z*, a valid identifier must be provided as field_name.
      */
@@ -492,7 +496,7 @@ declare namespace bigquery {
      */
     columns?: Array<IBigtableColumn>;
     /**
-     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
+     * Optional. The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. PROTO_BINARY - indicates values are encoded using serialized proto messages. This can only be used in combination with JSON type. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
      */
     encoding?: string;
     /**
@@ -503,6 +507,10 @@ declare namespace bigquery {
      * Optional. If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.
      */
     onlyReadLatest?: boolean;
+    /**
+     * Optional. Protobuf-specific configurations, only takes effect when the encoding is PROTO_BINARY.
+     */
+    protoConfig?: IBigtableProtoConfig;
     /**
      * Optional. The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): * BYTES * STRING * INTEGER * FLOAT * BOOLEAN * JSON Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.
      */
@@ -529,6 +537,20 @@ declare namespace bigquery {
      * Optional. If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.
      */
     readRowkeyAsString?: boolean;
+  };
+
+  /**
+   * Information related to a Bigtable protobuf column.
+   */
+  type IBigtableProtoConfig = {
+    /**
+     * Optional. The fully qualified proto message name of the protobuf. In the format of "foo.bar.Message".
+     */
+    protoMessageName?: string;
+    /**
+     * Optional. The ID of the Bigtable SchemaBundle resource associated with this protobuf. The ID should be referred to within the parent table, e.g., `foo` rather than `projects/{project}/instances/{instance}/tables/{table}/schemaBundles/foo`. See [more details on Bigtable SchemaBundles](https://docs.cloud.google.com/bigtable/docs/create-manage-protobuf-schemas).
+     */
+    schemaBundleId?: string;
   };
 
   /**
@@ -1706,6 +1728,10 @@ declare namespace bigquery {
      * Optional. Format used to parse TIMESTAMP values. Supports C-style and SQL-style values.
      */
     timestampFormat?: string;
+    /**
+     * Precisions (maximum number of total digits in base 10) for seconds of TIMESTAMP types that are allowed to the destination table for autodetection mode. Available for the formats: CSV. For the CSV Format, Possible values include: Not Specified, [], or [6]: timestamp(6) for all auto detected TIMESTAMP columns [6, 12]: timestamp(6) for all auto detected TIMESTAMP columns that have less than 6 digits of subseconds. timestamp(12) for all auto detected TIMESTAMP columns that have more than 6 digits of subseconds. [12]: timestamp(12) for all auto detected TIMESTAMP columns. The order of the elements in this array is ignored. Inputs that have higher precision than the highest target precision in this array will be truncated.
+     */
+    timestampTargetPrecision?: Array<number>;
   };
 
   /**
@@ -2154,6 +2180,10 @@ declare namespace bigquery {
      */
     baseTable?: ITableReference;
     /**
+     * The index id.
+     */
+    indexId?: string;
+    /**
      * The number of parallel inputs after index pruning.
      */
     postIndexPruningParallelInputCount?: string;
@@ -2404,7 +2434,7 @@ declare namespace bigquery {
      */
     load?: IJobConfigurationLoad;
     /**
-     * Optional. INTERNAL: DO NOT USE. The maximum rate of slot consumption to allow for this job. If set, the number of slots used to execute the job will be throttled to try and keep its slot consumption below the requested rate.
+     * Optional. A target limit on the rate of slot consumption by this job. If set to a value > 0, BigQuery will attempt to limit the rate of slot consumption by this job to keep it below the configured limit, even if the job is eligible for more slots based on fair scheduling. The unused slots will be available for other jobs and queries to use. Note: This feature is not yet generally available.
      */
     maxSlots?: number;
     /**
@@ -2643,6 +2673,10 @@ declare namespace bigquery {
      * Optional. Date format used for parsing TIMESTAMP values.
      */
     timestampFormat?: string;
+    /**
+     * Precisions (maximum number of total digits in base 10) for seconds of TIMESTAMP types that are allowed to the destination table for autodetection mode. Available for the formats: CSV. For the CSV Format, Possible values include: Not Specified, [], or [6]: timestamp(6) for all auto detected TIMESTAMP columns [6, 12]: timestamp(6) for all auto detected TIMESTAMP columns that have less than 6 digits of subseconds. timestamp(12) for all auto detected TIMESTAMP columns that have more than 6 digits of subseconds. [12]: timestamp(12) for all auto detected TIMESTAMP columns. The order of the elements in this array is ignored. Inputs that have higher precision than the highest target precision in this array will be truncated.
+     */
+    timestampTargetPrecision?: Array<number>;
     /**
      * Optional. If sourceFormat is set to "AVRO", indicates whether to interpret logical types as the corresponding BigQuery data type (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
      */
@@ -2974,6 +3008,10 @@ declare namespace bigquery {
      * Output only. Quotas which delayed this job's start time.
      */
     quotaDeferments?: Array<string>;
+    /**
+     * Output only. The reservation group path of the reservation assigned to this job. This field has a limit of 10 nested reservation groups. This is to maintain consistency between reservatins info schema and jobs info schema. The first reservation group is the root reservation group and the last is the leaf or lowest level reservation group.
+     */
+    reservationGroupPath?: Array<string>;
     /**
      * Output only. Job resource usage breakdown by reservation. This field reported misleading information and will no longer be populated.
      */
@@ -4124,7 +4162,7 @@ declare namespace bigquery {
      */
     maxResults?: number;
     /**
-     * Optional. INTERNAL: DO NOT USE. The maximum rate of slot consumption to allow for this job. If set, the number of slots used to execute the job will be throttled to try and keep its slot consumption below the requested rate. This limit is best effort.
+     * Optional. A target limit on the rate of slot consumption by this query. If set to a value > 0, BigQuery will attempt to limit the rate of slot consumption by this query to keep it below the configured limit, even if the query is eligible for more slots based on fair scheduling. The unused slots will be available for other jobs and queries to use. Note: This feature is not yet generally available.
      */
     maxSlots?: number;
     /**
@@ -5525,6 +5563,10 @@ declare namespace bigquery {
      * Optional. See documentation for precision.
      */
     scale?: string;
+    /**
+     * Optional. Precision (maximum number of total digits in base 10) for seconds of TIMESTAMP type. Possible values include: * 6 (Default, for TIMESTAMP type with microsecond precision) * 12 (For TIMESTAMP type with picosecond precision)
+     */
+    timestampPrecision?: string;
     /**
      * Required. The field data type. Possible values include: * STRING * BYTES * INTEGER (or INT64) * FLOAT (or FLOAT64) * BOOLEAN (or BOOL) * TIMESTAMP * DATE * TIME * DATETIME * GEOGRAPHY * NUMERIC * BIGNUMERIC * JSON * RECORD (or STRUCT) * RANGE Use of RECORD/STRUCT indicates that the field contains a nested schema.
      */

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -575,9 +575,8 @@ describe('BigQuery', () => {
       const QUERY = `SELECT * FROM \`${table.id}\``;
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const SCHEMA = require('../../system-test/data/schema.json');
-      const TEST_DATA_FILE = require.resolve(
-        '../../system-test/data/location-test-data.json',
-      );
+      const TEST_DATA_FILE =
+        require.resolve('../../system-test/data/location-test-data.json');
 
       before(async () => {
         // create a dataset in a certain location will cascade the location
@@ -880,9 +879,8 @@ describe('BigQuery', () => {
   });
 
   describe('BigQuery/Table', () => {
-    const TEST_DATA_JSON_PATH = require.resolve(
-      '../../system-test/data/kitten-test-data.json',
-    );
+    const TEST_DATA_JSON_PATH =
+      require.resolve('../../system-test/data/kitten-test-data.json');
 
     it('should have created the correct schema', () => {
       assert.deepStrictEqual(table.metadata.schema.fields, SCHEMA);
@@ -1020,7 +1018,7 @@ describe('BigQuery', () => {
       }
     });
 
-    it.only('should create a table with timestampPrecision', async () => {
+    it('should create a table with timestampPrecision', async () => {
       const table = dataset.table(generateName('timestamp-precision-table'));
       const schema = {
         fields: [
@@ -1036,7 +1034,7 @@ describe('BigQuery', () => {
         const [metadata] = await table.getMetadata();
         assert.deepStrictEqual(
           metadata.schema.fields[0].timestampPrecision,
-          '12'
+          '12',
         );
       } catch (e) {
         assert.ifError(e);

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -1020,6 +1020,29 @@ describe('BigQuery', () => {
       }
     });
 
+    it.only('should create a table with timestampPrecision', async () => {
+      const table = dataset.table(generateName('timestamp-precision-table'));
+      const schema = {
+        fields: [
+          {
+            name: 'ts_field',
+            type: 'TIMESTAMP',
+            timestampPrecision: 12,
+          },
+        ],
+      };
+      try {
+        await table.create({schema});
+        const [metadata] = await table.getMetadata();
+        assert.deepStrictEqual(
+          metadata.schema.fields[0].timestampPrecision,
+          '12'
+        );
+      } catch (e) {
+        assert.ifError(e);
+      }
+    });
+
     describe('copying', () => {
       interface TableItem {
         data?: {tableId?: number};

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -998,14 +998,14 @@ describe('BigQuery', () => {
       assert.strictEqual(basicMetadata.metadata.lastModifiedTime, undefined);
     });
 
-    it('should create a table with numeric precision', async () => {
+    it('should create a table with a numeric field having picosecond precision', async () => {
       const table = dataset.table(generateName('numeric-precision-table'));
       const schema = {
         fields: [
           {
             name: 'numeric_field',
             type: 'NUMERIC',
-            precision: 12,
+            precision: 12, // 12 indicates picosecond precision
             scale: 2,
           },
         ],

--- a/system-test/bigquery.ts
+++ b/system-test/bigquery.ts
@@ -998,6 +998,28 @@ describe('BigQuery', () => {
       assert.strictEqual(basicMetadata.metadata.lastModifiedTime, undefined);
     });
 
+    it('should create a table with numeric precision', async () => {
+      const table = dataset.table(generateName('numeric-precision-table'));
+      const schema = {
+        fields: [
+          {
+            name: 'numeric_field',
+            type: 'NUMERIC',
+            precision: 12,
+            scale: 2,
+          },
+        ],
+      };
+      try {
+        await table.create({schema});
+        const [metadata] = await table.getMetadata();
+        assert.deepStrictEqual(metadata.schema.fields[0].precision, '12');
+        assert.deepStrictEqual(metadata.schema.fields[0].scale, '2');
+      } catch (e) {
+        assert.ifError(e);
+      }
+    });
+
     describe('copying', () => {
       interface TableItem {
         data?: {tableId?: number};


### PR DESCRIPTION
## Description

For TIMESTAMP type fields in the table schema we can now specify timestampPrecision property so that the TIMESTAMP field can have Picosecond precision.

To support this we ran `npm run types` to generate all changes in this PR to `types.d.ts`. This automatically makes changes upstream to the `createTable` method adding the `timestampPrecision` property for fields. Then we write a system test that
makes use of the new property to verify it works as intended.

## Impact

Allows users to create tables with TIMESTAMP fields that have picosecond precision.

## Testing

- Adds a test showing how precision is specified for fields of non-TIMESTAMP type.
- Adds a test showing how precision (timestampPrecision) is specified for TIMESTAMP type.

## Additional Information

An alternative considered is that we would just allow the user to specify a `precision` value in their table schema instead of timestampPrecision and the `timestampPrecision` property would be invisible to the user. However, this is not how it is done in other languages like https://github.com/googleapis/java-bigquery/pull/4014 and supporting `timestampPrecision` this way would complicate the codebase because we would need to exclude `timestampPrecision` from `TableField` and `TableSchema` interfaces which would introduce a lot of changes and complexity.

The new timestampPrecision field affects ITableFieldSchema which affects ITableSchema which affects TableSchema and TableMetadata. This means the following methods now support the new timestampPrecision property too:
- table.setMetadata
- bigquery.mergeSchemaWithRows
- table.createSchemaFromString
- all methods using the ITable, IQueryResponse, IJobStatistics2, IJobConfigurationLoad, IGetQueryResultsResponse, IExternalDataConfiguration interfaces

## Next Steps

- Add support for a SQL high precision data type, query parameterization, reading rows language value types, write API support and insert all support