### PR TITLE
test: add ci.yaml to owlbot.py excludes list

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -17,7 +17,13 @@
 import synthtool.languages.node as node
 from synthtool import shell
 
-node.owlbot_main(templates_excludes=['.github/bug-report.md', '.github/release-please.yml'])
+node.owlbot_main(
+    templates_excludes=[
+        '.github/bug-report.md',
+        '.github/release-please.yml',
+        '.github/workflows/ci.yaml',
+    ]
+)
 
 # Regenerate Discovery types.
 shell.run(('npm','run','types'))


### PR DESCRIPTION
`owlbot.py` needs to be updated to exclude the protected file '.github/workflows/ci.yaml' from automated **owlbot** updates.

* Github balks when attempts are made to update `.github/workflows` files without specific permissions.
* Back in `https://github.com/googleapis/nodejs-bigquery/pull/1583` the `.github/workflows/ci.yaml` file was customized and **owlbot** wants to undo those changes but **owlbot** does not have the necessary permissions to edit workflows files, causing a CI/CD test failure.

```
Starting Step #11
Step #11: Already have image (with digest): gcr.io/cloud-devrel-public-resources/owlbot-cli
Step #11: Retrieving PR info for googleapis/nodejs-bigquery
Step #11: Retrieved PR info for googleapis/nodejs-bigquery
Step #11: git add -A .
Step #11: git status . --porcelain
Step #11: git log -1 --format=%B
Step #11: git commit -m "🦉 Updates from OwlBot post-processor
Step #11: 
Step #11: See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md"
Step #11: git pull --no-verify
Step #11: git push --no-verify
Step #11: To https://github.com/yoshi-code-bot/nodejs-bigquery.git
Step #11:  ! [remote rejected] update-discovery-patch -> update-discovery-patch (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yaml` without `workflows` permission)
```

